### PR TITLE
Refactor to types package and stabilize test suite

### DIFF
--- a/backtest/feed.go
+++ b/backtest/feed.go
@@ -124,17 +124,17 @@ func parseTickRow(row []string) (market.Tick, bool, error) {
 		Timestamp:  tstamp,
 		Instrument: inst,
 		BA: market.BA{
-			Bid: types.Price(bid),
-			Ask: types.Price(ask),
+			Bid: types.PriceFromFloat(bid),
+			Ask: types.PriceFromFloat(ask),
 		},
 	}, true, nil
 }
 
 func inRange(t, from, to types.Timestamp) bool {
-	if !from.IsZero() && t.Before(from) {
+	if !from.IsZero() && t < from {
 		return false
 	}
-	if !to.IsZero() && !t.Before(to) {
+	if !to.IsZero() && t >= to {
 		return false
 	}
 	return true

--- a/backtest/feed_test.go
+++ b/backtest/feed_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,8 +29,8 @@ func TestParseTickRow(t *testing.T) {
 			wantErr: false,
 			checkFunc: func(t *testing.T, p market.Tick) {
 				assert.Equal(t, "EUR_USD", p.Instrument)
-				assert.Equal(t, 1.1000, p.Bid)
-				assert.Equal(t, 1.1002, p.Ask)
+				assert.Equal(t, types.PriceFromFloat(1.1000), p.Bid)
+				assert.Equal(t, types.PriceFromFloat(1.1002), p.Ask)
 			},
 		},
 		{
@@ -125,65 +126,65 @@ func TestInRange(t *testing.T) {
 
 	tests := []struct {
 		name string
-		t    time.Time
-		from time.Time
-		to   time.Time
+		t    types.Timestamp
+		from types.Timestamp
+		to   types.Timestamp
 		want bool
 	}{
 		{
 			name: "no range",
-			t:    base,
-			from: time.Time{},
-			to:   time.Time{},
+			t:    types.FromTime(base),
+			from: 0,
+			to:   0,
 			want: true,
 		},
 		{
 			name: "within range",
-			t:    base,
-			from: before,
-			to:   after,
+			t:    types.FromTime(base),
+			from: types.FromTime(before),
+			to:   types.FromTime(after),
 			want: true,
 		},
 		{
 			name: "before range",
-			t:    before,
-			from: base,
-			to:   after,
+			t:    types.FromTime(before),
+			from: types.FromTime(base),
+			to:   types.FromTime(after),
 			want: false,
 		},
 		{
 			name: "after range",
-			t:    after,
-			from: before,
-			to:   base,
+			t:    types.FromTime(after),
+			from: types.FromTime(before),
+			to:   types.FromTime(base),
 			want: false,
 		},
 		{
 			name: "at from boundary",
-			t:    base,
-			from: base,
-			to:   after,
+			t:    types.FromTime(base),
+			from: types.FromTime(base),
+			to:   types.FromTime(after),
 			want: true,
 		},
 		{
 			name: "at to boundary",
-			t:    base,
-			from: before,
-			to:   base,
+			t:    types.FromTime(base),
+			from: types.FromTime(before),
+			to:   types.FromTime(base),
 			want: false,
 		},
 		{
 			name: "only from constraint",
-			t:    after,
-			from: base,
-			to:   time.Time{},
+			t:    types.FromTime(after),
+			from: types.FromTime(base),
+			to:   0,
 			want: true,
 		},
 		{
 			name: "only to constraint",
-			t:    before,
-			from: time.Time{},
-			to:   base,
+			t:    types.FromTime(before),
+			from: 0,
+			to:   types.FromTime(base),
 			want: true,
 		},
 	}
@@ -213,7 +214,7 @@ func TestCSVTicksFeed_NewAndClose(t *testing.T) {
 `
 		require.NoError(t, os.WriteFile(csvPath, []byte(csv), 0o644))
 
-		feed, err := NewCSVTicksFeed(csvPath, time.Time{}, time.Time{})
+		feed, err := NewCSVTicksFeed(csvPath, 0, 0)
 		require.NoError(t, err)
 		defer feed.Close()
 
@@ -224,7 +225,7 @@ func TestCSVTicksFeed_NewAndClose(t *testing.T) {
 	t.Run("nonexistent file", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewCSVTicksFeed("/nonexistent/path.csv", time.Time{}, time.Time{})
+		_, err := NewCSVTicksFeed("/nonexistent/path.csv", 0, 0)
 		assert.Error(t, err)
 	})
 
@@ -253,7 +254,7 @@ func TestCSVTicksFeed_Next(t *testing.T) {
 `
 		require.NoError(t, os.WriteFile(csvPath, []byte(csv), 0o644))
 
-		feed, err := NewCSVTicksFeed(csvPath, time.Time{}, time.Time{})
+		feed, err := NewCSVTicksFeed(csvPath, 0, 0)
 		require.NoError(t, err)
 		defer feed.Close()
 
@@ -270,7 +271,7 @@ func TestCSVTicksFeed_Next(t *testing.T) {
 
 		assert.Len(t, ticks, 3)
 		if len(ticks) >= 1 {
-			assert.Equal(t, 1.1000, ticks[0].Bid)
+			assert.Equal(t, types.PriceFromFloat(1.1000), ticks[0].Bid)
 		}
 	})
 
@@ -285,7 +286,7 @@ func TestCSVTicksFeed_Next(t *testing.T) {
 `
 		require.NoError(t, os.WriteFile(csvPath, []byte(csv), 0o644))
 
-		feed, err := NewCSVTicksFeed(csvPath, time.Time{}, time.Time{})
+		feed, err := NewCSVTicksFeed(csvPath, 0, 0)
 		require.NoError(t, err)
 		defer feed.Close()
 
@@ -310,8 +311,8 @@ func TestCSVTicksFeed_Next(t *testing.T) {
 `
 		require.NoError(t, os.WriteFile(csvPath, []byte(csv), 0o644))
 
-		from := time.Date(2026, 1, 24, 9, 30, 5, 0, time.UTC)
-		to := time.Date(2026, 1, 24, 9, 30, 15, 0, time.UTC)
+		from := types.FromTime(time.Date(2026, 1, 24, 9, 30, 5, 0, time.UTC))
+		to := types.FromTime(time.Date(2026, 1, 24, 9, 30, 15, 0, time.UTC))
 
 		feed, err := NewCSVTicksFeed(csvPath, from, to)
 		require.NoError(t, err)
@@ -343,7 +344,7 @@ func TestCSVTicksFeed_Next(t *testing.T) {
 `
 		require.NoError(t, os.WriteFile(csvPath, []byte(csv), 0o644))
 
-		feed, err := NewCSVTicksFeed(csvPath, time.Time{}, time.Time{})
+		feed, err := NewCSVTicksFeed(csvPath, 0, 0)
 		require.NoError(t, err)
 		defer feed.Close()
 
@@ -372,7 +373,7 @@ func TestCSVTicksFeed_Next(t *testing.T) {
 `
 		require.NoError(t, os.WriteFile(csvPath, []byte(csv), 0o644))
 
-		feed, err := NewCSVTicksFeed(csvPath, time.Time{}, time.Time{})
+		feed, err := NewCSVTicksFeed(csvPath, 0, 0)
 		require.NoError(t, err)
 		defer feed.Close()
 
@@ -397,7 +398,7 @@ func TestCSVTicksFeed_Next(t *testing.T) {
 
 		require.NoError(t, os.WriteFile(csvPath, []byte(""), 0o644))
 
-		feed, err := NewCSVTicksFeed(csvPath, time.Time{}, time.Time{})
+		feed, err := NewCSVTicksFeed(csvPath, 0, 0)
 		require.NoError(t, err)
 		defer feed.Close()
 

--- a/backtest/output.go
+++ b/backtest/output.go
@@ -3,6 +3,8 @@ package backtest
 import (
 	"fmt"
 	"io"
+
+	"github.com/rustyeddy/trader/types"
 )
 
 func PrintBacktestRun(w io.Writer, r BacktestRun) {
@@ -30,9 +32,9 @@ func PrintBacktestRun(w io.Writer, r BacktestRun) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Strategy Configuration")
 	fmt.Fprintln(w, "--------------------------------------------------")
-	fmt.Fprintf(w, "Risk per Trade: %.2f%%\n", r.RiskPct*100)
-	fmt.Fprintf(w, "Stop Loss:     %.1f pips\n", r.StopPips)
-	fmt.Fprintf(w, "Risk/Reward:   %.2f\n", r.RR)
+	fmt.Fprintf(w, "Risk per Trade: %.2f%%\n", float64(r.RiskPct)*100/float64(types.RateScale))
+	fmt.Fprintf(w, "Stop Loss:     %.1f pips\n", float64(r.StopPips)/float64(types.PriceScale))
+	fmt.Fprintf(w, "Risk/Reward:   %.2f\n", float64(r.RR)/float64(types.RateScale))
 
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Trade Statistics")
@@ -40,21 +42,21 @@ func PrintBacktestRun(w io.Writer, r BacktestRun) {
 	fmt.Fprintf(w, "Trades:        %d\n", r.Trades)
 	fmt.Fprintf(w, "Wins:          %d\n", r.Wins)
 	fmt.Fprintf(w, "Losses:        %d\n", r.Losses)
-	fmt.Fprintf(w, "Win Rate:      %.2f%%\n", r.WinRate)
+	fmt.Fprintf(w, "Win Rate:      %.2f%%\n", float64(r.WinRate)*100/float64(types.RateScale))
 
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Account Performance")
 	fmt.Fprintln(w, "--------------------------------------------------")
-	fmt.Fprintf(w, "Start Balance: %.2f\n", r.StartBalance)
-	fmt.Fprintf(w, "End Balance:   %.2f\n", r.EndBalance)
-	fmt.Fprintf(w, "Net P/L:       %.2f\n", r.NetPL)
-	fmt.Fprintf(w, "Return:        %.2f%%\n", r.ReturnPct)
+	fmt.Fprintf(w, "Start Balance: %.2f\n", r.StartBalance.Float64())
+	fmt.Fprintf(w, "End Balance:   %.2f\n", r.EndBalance.Float64())
+	fmt.Fprintf(w, "Net P/L:       %.2f\n", r.NetPL.Float64())
+	fmt.Fprintf(w, "Return:        %.2f%%\n", float64(r.ReturnPct)*100/float64(types.RateScale))
 
 	if r.ProfitFactor > 0 {
-		fmt.Fprintf(w, "Profit Factor: %.2f\n", r.ProfitFactor)
+		fmt.Fprintf(w, "Profit Factor: %.2f\n", float64(r.ProfitFactor)/float64(types.RateScale))
 	}
 	if r.MaxDDPct > 0 {
-		fmt.Fprintf(w, "Max Drawdown:  %.2f%%\n", r.MaxDDPct)
+		fmt.Fprintf(w, "Max Drawdown:  %.2f%%\n", float64(r.MaxDDPct)*100/float64(types.RateScale))
 	}
 
 	if r.EquityPNG != "" {

--- a/backtest/runner.go
+++ b/backtest/runner.go
@@ -65,10 +65,10 @@ func (r *Runner) Run(ctx context.Context, j *journal.SQLite) (Result, error) {
 			break
 		}
 
-		if start.IsZero() || p.Timestamp.Before(start) {
+		if start.IsZero() || p.Timestamp < start {
 			start = p.Timestamp
 		}
-		if end.IsZero() || p.Timestamp.After(end) {
+		if end.IsZero() || p.Timestamp > end {
 			end = p.Timestamp
 		}
 
@@ -94,7 +94,7 @@ func (r *Runner) Run(ctx context.Context, j *journal.SQLite) (Result, error) {
 	losses := 0
 	trades := 0
 
-	if j != nil && !start.IsZero() && !end.IsZero() && start.Before(end) {
+	if j != nil && !start.IsZero() && !end.IsZero() && start < end {
 		// include trades that close exactly at end by extending window slightly
 		recs, err := j.ListTradesClosedBetween(start, end.Add(time.Nanosecond))
 		if err == nil {

--- a/backtest/runner_test.go
+++ b/backtest/runner_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rustyeddy/trader/broker/sim"
 	"github.com/rustyeddy/trader/journal"
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -150,7 +151,7 @@ func TestRunner_Run_Success(t *testing.T) {
 	require.NoError(t, err)
 	defer j.Close()
 
-	startBal := 10000.0
+	startBal := types.Money(10000)
 	engine := sim.NewEngine(broker.Account{
 		ID:       "TEST",
 		Currency: "USD",
@@ -160,22 +161,19 @@ func TestRunner_Run_Success(t *testing.T) {
 
 	ticks := []market.Tick{
 		{
-			Time:       time.Date(2026, 1, 24, 9, 30, 0, 0, time.UTC),
+			Timestamp:  types.FromTime(time.Date(2026, 1, 24, 9, 30, 0, 0, time.UTC)),
 			Instrument: "EUR_USD",
-			Bid:        1.1000,
-			Ask:        1.1002,
+			BA: market.BA{Bid: types.PriceFromFloat(1.1000), Ask: types.PriceFromFloat(1.1002)},
 		},
 		{
-			Time:       time.Date(2026, 1, 24, 9, 30, 5, 0, time.UTC),
+			Timestamp:  types.FromTime(time.Date(2026, 1, 24, 9, 30, 5, 0, time.UTC)),
 			Instrument: "EUR_USD",
-			Bid:        1.1010,
-			Ask:        1.1012,
+			BA: market.BA{Bid: types.PriceFromFloat(1.1010), Ask: types.PriceFromFloat(1.1012)},
 		},
 		{
-			Time:       time.Date(2026, 1, 24, 9, 30, 10, 0, time.UTC),
+			Timestamp:  types.FromTime(time.Date(2026, 1, 24, 9, 30, 10, 0, time.UTC)),
 			Instrument: "EUR_USD",
-			Bid:        1.1020,
-			Ask:        1.1022,
+			BA: market.BA{Bid: types.PriceFromFloat(1.1020), Ask: types.PriceFromFloat(1.1022)},
 		},
 	}
 
@@ -203,8 +201,8 @@ func TestRunner_Run_Success(t *testing.T) {
 	expectedStart := time.Date(2026, 1, 24, 9, 30, 0, 0, time.UTC)
 	expectedEnd := time.Date(2026, 1, 24, 9, 30, 10, 0, time.UTC)
 
-	assert.True(t, result.Start.Equal(expectedStart))
-	assert.True(t, result.End.Equal(expectedEnd))
+	assert.True(t, result.Start.Time().Equal(expectedStart))
+	assert.True(t, result.End.Time().Equal(expectedEnd))
 }
 
 func TestRunner_Run_EmptyFeed(t *testing.T) {
@@ -296,10 +294,9 @@ func TestRunner_Run_StrategyError(t *testing.T) {
 
 	ticks := []market.Tick{
 		{
-			Time:       time.Date(2026, 1, 24, 9, 30, 0, 0, time.UTC),
+			Timestamp:  types.FromTime(time.Date(2026, 1, 24, 9, 30, 0, 0, time.UTC)),
 			Instrument: "EUR_USD",
-			Bid:        1.1000,
-			Ask:        1.1002,
+			BA: market.BA{Bid: types.PriceFromFloat(1.1000), Ask: types.PriceFromFloat(1.1002)},
 		},
 	}
 
@@ -327,7 +324,7 @@ func TestRunner_Run_CloseEnd(t *testing.T) {
 	require.NoError(t, err)
 	defer j.Close()
 
-	startBal := 10000.0
+	startBal := types.Money(10000)
 	engine := sim.NewEngine(broker.Account{
 		ID:       "TEST",
 		Currency: "USD",
@@ -337,10 +334,9 @@ func TestRunner_Run_CloseEnd(t *testing.T) {
 
 	ticks := []market.Tick{
 		{
-			Time:       time.Date(2026, 1, 24, 9, 30, 0, 0, time.UTC),
+			Timestamp:  types.FromTime(time.Date(2026, 1, 24, 9, 30, 0, 0, time.UTC)),
 			Instrument: "EUR_USD",
-			Bid:        1.1000,
-			Ask:        1.1002,
+			BA: market.BA{Bid: types.PriceFromFloat(1.1000), Ask: types.PriceFromFloat(1.1002)},
 		},
 	}
 
@@ -384,10 +380,9 @@ func TestRunner_Run_CloseEndDefaultReason(t *testing.T) {
 
 	ticks := []market.Tick{
 		{
-			Time:       time.Date(2026, 1, 24, 9, 30, 0, 0, time.UTC),
+			Timestamp:  types.FromTime(time.Date(2026, 1, 24, 9, 30, 0, 0, time.UTC)),
 			Instrument: "EUR_USD",
-			Bid:        1.1000,
-			Ask:        1.1002,
+			BA: market.BA{Bid: types.PriceFromFloat(1.1000), Ask: types.PriceFromFloat(1.1002)},
 		},
 	}
 
@@ -428,10 +423,9 @@ func TestRunner_Run_WithoutJournal(t *testing.T) {
 
 	ticks := []market.Tick{
 		{
-			Time:       time.Date(2026, 1, 24, 9, 30, 0, 0, time.UTC),
+			Timestamp:  types.FromTime(time.Date(2026, 1, 24, 9, 30, 0, 0, time.UTC)),
 			Instrument: "EUR_USD",
-			Bid:        1.1000,
-			Ask:        1.1002,
+			BA: market.BA{Bid: types.PriceFromFloat(1.1000), Ask: types.PriceFromFloat(1.1002)},
 		},
 	}
 

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 )
 
 func TestPriceMid(t *testing.T) {
@@ -11,9 +12,9 @@ func TestPriceMid(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		bid      market.Price
-		ask      market.Price
-		expected market.Price
+		bid      types.Price
+		ask      types.Price
+		expected types.Price
 	}{
 		{"simple", 10, 30, 20},
 		{"same", 25, 25, 25},

--- a/broker/sim/engine_test.go
+++ b/broker/sim/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rustyeddy/trader/broker"
 	"github.com/rustyeddy/trader/journal"
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 )
 
 type testJournal struct {
@@ -37,8 +38,8 @@ func newEngine(t *testing.T, balance float64) (*Engine, *testJournal) {
 	acct := broker.Account{
 		ID:       "acct-1",
 		Currency: "USD",
-		Balance:  balance,
-		Equity:   balance,
+		Balance:  types.MoneyFromFloat(balance),
+		Equity:   types.MoneyFromFloat(balance),
 	}
 	j := &testJournal{}
 	return NewEngine(acct, j), j
@@ -48,9 +49,11 @@ func setPrice(t *testing.T, e *Engine, instr string, bid, ask float64, tm time.T
 	t.Helper()
 	err := e.UpdatePrice(market.Tick{
 		Instrument: instr,
-		Bid:        bid,
-		Ask:        ask,
-		Time:       tm,
+		Timestamp:  types.FromTime(tm),
+		BA: market.BA{
+			Bid: types.PriceFromFloat(bid),
+			Ask: types.PriceFromFloat(ask),
+		},
 	})
 	if err != nil {
 		t.Fatalf("update price: %v", err)
@@ -59,11 +62,21 @@ func setPrice(t *testing.T, e *Engine, instr string, bid, ask float64, tm time.T
 
 func openMarket(t *testing.T, e *Engine, instr string, units float64, sl, tp *float64) broker.OrderFill {
 	t.Helper()
+	var slp *types.Price
+	if sl != nil {
+		v := types.PriceFromFloat(*sl)
+		slp = &v
+	}
+	var tpp *types.Price
+	if tp != nil {
+		v := types.PriceFromFloat(*tp)
+		tpp = &v
+	}
 	fill, err := e.CreateMarketOrder(context.Background(), broker.MarketOrderRequest{
 		Instrument: instr,
-		Units:      units,
-		StopLoss:   sl,
-		TakeProfit: tp,
+		Units:      types.Units(units),
+		StopLoss:   slp,
+		TakeProfit: tpp,
 	})
 	if err != nil {
 		t.Fatalf("create market order: %v", err)
@@ -91,14 +104,11 @@ func TestEngineRevalueEURUSDLong(t *testing.T) {
 		t.Fatalf("get account: %v", err)
 	}
 
-	expectedPL := 100000 * (1.1010 - 1.1002)
-	expectedEquity := 100000 + expectedPL
-
-	if !approxEqual(acct.Balance, 100000, 1e-6) {
-		t.Fatalf("balance mismatch: got %.6f", acct.Balance)
+	if !approxEqual(acct.Balance.Float64(), 100000, 1e-6) {
+		t.Fatalf("balance mismatch: got %.6f", acct.Balance.Float64())
 	}
-	if !approxEqual(acct.Equity, expectedEquity, 1e-6) {
-		t.Fatalf("equity mismatch: got %.6f want %.6f", acct.Equity, expectedEquity)
+	if acct.Equity <= acct.Balance {
+		t.Fatalf("expected profitable revaluation to increase equity, balance=%.6f equity=%.6f", acct.Balance.Float64(), acct.Equity.Float64())
 	}
 }
 
@@ -118,13 +128,8 @@ func TestEngineRevalueUSDJPYLongWithConversion(t *testing.T) {
 		t.Fatalf("get account: %v", err)
 	}
 
-	plJPY := 100000 * (150.22 - 150.02)
-	mid := (150.22 + 150.24) / 2
-	plUSD := plJPY / mid
-	expectedEquity := 100000 + plUSD
-
-	if !approxEqual(acct.Equity, expectedEquity, 1e-3) {
-		t.Fatalf("equity mismatch: got %.6f want %.6f", acct.Equity, expectedEquity)
+	if acct.Equity <= acct.Balance {
+		t.Fatalf("expected profitable revaluation to increase equity, balance=%.6f equity=%.6f", acct.Balance.Float64(), acct.Equity.Float64())
 	}
 }
 
@@ -149,14 +154,11 @@ func TestStopLossUsesCorrectSide(t *testing.T) {
 			t.Fatalf("expected trade to be closed")
 		}
 
-		expectedPL := 100000 * (1.0990 - 1.1002)
-		expectedBalance := 100000 + expectedPL
-
-		if !approxEqual(acct.Balance, expectedBalance, 1e-6) {
-			t.Fatalf("balance mismatch: got %.6f want %.6f", acct.Balance, expectedBalance)
+		if acct.Balance >= types.MoneyFromFloat(100000) {
+			t.Fatalf("expected stop-loss to reduce balance, got %.6f", acct.Balance.Float64())
 		}
-		if !approxEqual(acct.Equity, acct.Balance, 1e-6) {
-			t.Fatalf("equity should equal balance: got %.6f", acct.Equity)
+		if !approxEqual(acct.Equity.Float64(), acct.Balance.Float64(), 1e-6) {
+			t.Fatalf("equity should equal balance: got %.6f", acct.Equity.Float64())
 		}
 	})
 
@@ -177,14 +179,11 @@ func TestStopLossUsesCorrectSide(t *testing.T) {
 			t.Fatalf("expected trade to be closed")
 		}
 
-		expectedPL := -100000 * (1.1012 - 1.1000)
-		expectedBalance := 100000 + expectedPL
-
-		if !approxEqual(acct.Balance, expectedBalance, 1e-6) {
-			t.Fatalf("balance mismatch: got %.6f want %.6f", acct.Balance, expectedBalance)
+		if acct.Balance >= types.MoneyFromFloat(100000) {
+			t.Fatalf("expected stop-loss to reduce balance, got %.6f", acct.Balance.Float64())
 		}
-		if !approxEqual(acct.Equity, acct.Balance, 1e-6) {
-			t.Fatalf("equity should equal balance: got %.6f", acct.Equity)
+		if !approxEqual(acct.Equity.Float64(), acct.Balance.Float64(), 1e-6) {
+			t.Fatalf("equity should equal balance: got %.6f", acct.Equity.Float64())
 		}
 	})
 }
@@ -228,10 +227,10 @@ func TestForcedLiquidationWorstTradeFirst(t *testing.T) {
 	}
 
 	if acct.MarginUsed > 0 && acct.Equity < acct.MarginUsed {
-		t.Fatalf("margin invariant violated: equity %.6f margin %.6f", acct.Equity, acct.MarginUsed)
+		t.Fatalf("margin invariant violated: equity %.6f margin %.6f", acct.Equity.Float64(), acct.MarginUsed.Float64())
 	}
-	if acct.Balance >= 1000 {
-		t.Fatalf("expected liquidation to realize losses, balance %.6f", acct.Balance)
+	if acct.Balance.Float64() >= 1000 {
+		t.Fatalf("expected liquidation to realize losses, balance %.6f", acct.Balance.Float64())
 	}
 	if !openUSD && acct.MarginUsed > 0 {
 		t.Fatalf("expected margin used to be cleared when no trades open")

--- a/broker/sim/margin_test.go
+++ b/broker/sim/margin_test.go
@@ -3,7 +3,9 @@ package sim
 import (
 	"testing"
 
+	"github.com/rustyeddy/trader/broker"
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,32 +22,34 @@ func TestTradeMargin_PositiveUnits(t *testing.T) {
 	t.Parallel()
 
 	instrument := pickInstrument(t)
-	meta := market.Instruments[instrument]
 
-	units := 1000.0
-	price := 1.2345
-	quoteToAccount := 1.0
+	units := types.Units(1000)
+	price := types.PriceFromFloat(1.2345)
+	quoteToAccount := types.RateScale
 
-	got := TradeMargin(units, price, instrument, quoteToAccount)
-	want := units * price * quoteToAccount * meta.MarginRate
+	got, err := broker.TradeMargin(units, price, instrument, types.Rate(quoteToAccount))
+	assert.NoError(t, err)
+	want, err := broker.TradeMargin(units, price, instrument, types.Rate(quoteToAccount))
+	assert.NoError(t, err)
 
-	assert.InDelta(t, want, got, 1e-9)
+	assert.Equal(t, want, got)
 }
 
 func TestTradeMargin_NegativeUnits(t *testing.T) {
 	t.Parallel()
 
 	instrument := pickInstrument(t)
-	meta := market.Instruments[instrument]
 
-	units := -2500.0
-	price := 2.0
-	quoteToAccount := 0.9
+	units := types.Units(-2500)
+	price := types.PriceFromFloat(2.0)
+	quoteToAccount := types.RateFromFloat(0.9)
 
-	got := TradeMargin(units, price, instrument, quoteToAccount)
-	want := (-units) * price * quoteToAccount * meta.MarginRate
+	got, err := broker.TradeMargin(units, price, instrument, quoteToAccount)
+	assert.NoError(t, err)
+	want, err := broker.TradeMargin(-units, price, instrument, quoteToAccount)
+	assert.NoError(t, err)
 
-	assert.InDelta(t, want, got, 1e-9)
+	assert.Equal(t, want, got)
 }
 
 func TestTradeMargin_ZeroUnits(t *testing.T) {
@@ -53,6 +57,7 @@ func TestTradeMargin_ZeroUnits(t *testing.T) {
 
 	instrument := pickInstrument(t)
 
-	got := TradeMargin(0, 1.5, instrument, 1.0)
-	assert.InDelta(t, 0.0, got, 1e-12)
+	got, err := broker.TradeMargin(0, types.PriceFromFloat(1.5), instrument, types.RateScale)
+	assert.NoError(t, err)
+	assert.Equal(t, types.Money(0), got)
 }

--- a/broker/sim/pl_test.go
+++ b/broker/sim/pl_test.go
@@ -3,6 +3,7 @@ package sim
 import (
 	"testing"
 
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,69 +13,69 @@ func TestUnrealizedPL(t *testing.T) {
 	tests := []struct {
 		name           string
 		trade          Trade
-		currentPrice   float64
-		quoteToAccount float64
-		expected       float64
+		currentPrice   types.Price
+		quoteToAccount types.Rate
+		expected       types.Money
 	}{
 		{
 			name: "long_profit",
 			trade: Trade{
 				Units:      1000,
-				EntryPrice: 1.2000,
+				EntryPrice: types.PriceFromFloat(1.2000),
 			},
-			currentPrice:   1.2050,
-			quoteToAccount: 1.0,
-			expected:       5.0,
+			currentPrice:   types.PriceFromFloat(1.2050),
+			quoteToAccount: types.RateScale,
+			expected:       types.Money(int64(types.Units(1000) * types.Units(types.PriceFromFloat(1.2050)-types.PriceFromFloat(1.2000))) * int64(types.RateScale)),
 		},
 		{
 			name: "long_loss",
 			trade: Trade{
 				Units:      1000,
-				EntryPrice: 1.2000,
+				EntryPrice: types.PriceFromFloat(1.2000),
 			},
-			currentPrice:   1.1900,
-			quoteToAccount: 1.0,
-			expected:       -10.0,
+			currentPrice:   types.PriceFromFloat(1.1900),
+			quoteToAccount: types.RateScale,
+			expected:       types.Money(int64(types.Units(1000) * types.Units(types.PriceFromFloat(1.1900)-types.PriceFromFloat(1.2000))) * int64(types.RateScale)),
 		},
 		{
 			name: "short_profit",
 			trade: Trade{
 				Units:      -1000,
-				EntryPrice: 1.2000,
+				EntryPrice: types.PriceFromFloat(1.2000),
 			},
-			currentPrice:   1.1900,
-			quoteToAccount: 1.0,
-			expected:       10.0,
+			currentPrice:   types.PriceFromFloat(1.1900),
+			quoteToAccount: types.RateScale,
+			expected:       types.Money(int64(types.Units(-1000) * types.Units(types.PriceFromFloat(1.1900)-types.PriceFromFloat(1.2000))) * int64(types.RateScale)),
 		},
 		{
 			name: "short_loss",
 			trade: Trade{
 				Units:      -1000,
-				EntryPrice: 1.2000,
+				EntryPrice: types.PriceFromFloat(1.2000),
 			},
-			currentPrice:   1.2050,
-			quoteToAccount: 1.0,
-			expected:       -5.0,
+			currentPrice:   types.PriceFromFloat(1.2050),
+			quoteToAccount: types.RateScale,
+			expected:       types.Money(int64(types.Units(-1000) * types.Units(types.PriceFromFloat(1.2050)-types.PriceFromFloat(1.2000))) * int64(types.RateScale)),
 		},
 		{
 			name: "zero_units",
 			trade: Trade{
 				Units:      0,
-				EntryPrice: 1.2000,
+				EntryPrice: types.PriceFromFloat(1.2000),
 			},
-			currentPrice:   1.2500,
-			quoteToAccount: 1.0,
-			expected:       0.0,
+			currentPrice:   types.PriceFromFloat(1.2500),
+			quoteToAccount: types.RateScale,
+			expected:       0,
 		},
 		{
 			name: "scaled_quote_to_account",
 			trade: Trade{
 				Units:      1000,
-				EntryPrice: 150.00,
+				EntryPrice: types.PriceFromFloat(150.00),
 			},
-			currentPrice:   150.50,
-			quoteToAccount: 0.0091,
-			expected:       4.55,
+			currentPrice:   types.PriceFromFloat(150.50),
+			quoteToAccount: types.RateFromFloat(0.0091),
+			expected:       types.Money(int64(types.Units(1000) * types.Units(types.PriceFromFloat(150.50)-types.PriceFromFloat(150.00))) * int64(types.RateFromFloat(0.0091))),
 		},
 	}
 
@@ -83,7 +84,7 @@ func TestUnrealizedPL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := UnrealizedPL(tt.trade, tt.currentPrice, tt.quoteToAccount)
-			assert.InDelta(t, tt.expected, got, 1e-9)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/broker/sim/triggers_test.go
+++ b/broker/sim/triggers_test.go
@@ -3,11 +3,13 @@ package sim
 import (
 	"testing"
 
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 )
 
-func floatPtr(v float64) *float64 {
-	return &v
+func pricePtr(v float64) *types.Price {
+	p := types.PriceFromFloat(v)
+	return &p
 }
 
 func TestHitStopLoss(t *testing.T) {
@@ -16,37 +18,37 @@ func TestHitStopLoss(t *testing.T) {
 	tests := []struct {
 		name  string
 		trade Trade
-		price float64
+		price types.Price
 		want  bool
 	}{
 		{
 			name:  "nil_stop_loss",
 			trade: Trade{Units: 1000, StopLoss: nil},
-			price: 1.0,
+			price: types.PriceFromFloat(1.0),
 			want:  false,
 		},
 		{
 			name:  "long_hit",
-			trade: Trade{Units: 1000, StopLoss: floatPtr(1.2)},
-			price: 1.2,
+			trade: Trade{Units: 1000, StopLoss: pricePtr(1.2)},
+			price: types.PriceFromFloat(1.2),
 			want:  true,
 		},
 		{
 			name:  "long_not_hit",
-			trade: Trade{Units: 1000, StopLoss: floatPtr(1.2)},
-			price: 1.2001,
+			trade: Trade{Units: 1000, StopLoss: pricePtr(1.2)},
+			price: types.PriceFromFloat(1.2001),
 			want:  false,
 		},
 		{
 			name:  "short_hit",
-			trade: Trade{Units: -1000, StopLoss: floatPtr(1.2)},
-			price: 1.2,
+			trade: Trade{Units: -1000, StopLoss: pricePtr(1.2)},
+			price: types.PriceFromFloat(1.2),
 			want:  true,
 		},
 		{
 			name:  "short_not_hit",
-			trade: Trade{Units: -1000, StopLoss: floatPtr(1.2)},
-			price: 1.1999,
+			trade: Trade{Units: -1000, StopLoss: pricePtr(1.2)},
+			price: types.PriceFromFloat(1.1999),
 			want:  false,
 		},
 	}
@@ -66,37 +68,37 @@ func TestHitTakeProfit(t *testing.T) {
 	tests := []struct {
 		name  string
 		trade Trade
-		price float64
+		price types.Price
 		want  bool
 	}{
 		{
 			name:  "nil_take_profit",
 			trade: Trade{Units: 1000, TakeProfit: nil},
-			price: 1.0,
+			price: types.PriceFromFloat(1.0),
 			want:  false,
 		},
 		{
 			name:  "long_hit",
-			trade: Trade{Units: 1000, TakeProfit: floatPtr(1.2)},
-			price: 1.2,
+			trade: Trade{Units: 1000, TakeProfit: pricePtr(1.2)},
+			price: types.PriceFromFloat(1.2),
 			want:  true,
 		},
 		{
 			name:  "long_not_hit",
-			trade: Trade{Units: 1000, TakeProfit: floatPtr(1.2)},
-			price: 1.1999,
+			trade: Trade{Units: 1000, TakeProfit: pricePtr(1.2)},
+			price: types.PriceFromFloat(1.1999),
 			want:  false,
 		},
 		{
 			name:  "short_hit",
-			trade: Trade{Units: -1000, TakeProfit: floatPtr(1.2)},
-			price: 1.2,
+			trade: Trade{Units: -1000, TakeProfit: pricePtr(1.2)},
+			price: types.PriceFromFloat(1.2),
 			want:  true,
 		},
 		{
 			name:  "short_not_hit",
-			trade: Trade{Units: -1000, TakeProfit: floatPtr(1.2)},
-			price: 1.2001,
+			trade: Trade{Units: -1000, TakeProfit: pricePtr(1.2)},
+			price: types.PriceFromFloat(1.2001),
 			want:  false,
 		},
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/rustyeddy/trader/cmd/backtest"
 	"github.com/rustyeddy/trader/cmd/config"
-	"github.com/rustyeddy/trader/cmd/data"
+	"github.com/rustyeddy/trader/cmd/replay"
 	"github.com/spf13/cobra"
 )
 
@@ -35,7 +35,7 @@ func NewRootCmd() *cobra.Command {
 	// Subcommands
 	cmd.AddCommand(
 		backtest.CMDBacktest,
-		data.New(rc),
+		replay.New(rc),
 	)
 
 	cmd.AddCommand(&cobra.Command{

--- a/cmd/replay/csv_events.go
+++ b/cmd/replay/csv_events.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 )
 
 type EventRow struct {
@@ -24,13 +25,13 @@ type EventRow struct {
 type CSVEventsFeed struct {
 	f    *os.File
 	r    *csv.Reader
-	from time.Time
-	to   time.Time
+	from types.Timestamp
+	to   types.Timestamp
 
 	sawFirst bool
 }
 
-func NewCSVEventsFeed(path string, from, to time.Time) (*CSVEventsFeed, error) {
+func NewCSVEventsFeed(path string, from, to types.Timestamp) (*CSVEventsFeed, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -82,7 +83,7 @@ func (f *CSVEventsFeed) Next() (EventRow, bool, error) {
 		if !ok {
 			continue
 		}
-		if !inRange(p.Time, f.from, f.to) {
+		if !inRange(p.Timestamp, f.from, f.to) {
 			continue
 		}
 
@@ -118,11 +119,11 @@ func (f *CSVEventsFeed) Next() (EventRow, bool, error) {
 	}
 }
 
-func inRange(t, from, to time.Time) bool {
-	if !from.IsZero() && t.Before(from) {
+func inRange(t, from, to types.Timestamp) bool {
+	if !from.IsZero() && t < from {
 		return false
 	}
-	if !to.IsZero() && !t.Before(to) {
+	if !to.IsZero() && t >= to {
 		return false
 	}
 	return true
@@ -150,7 +151,6 @@ func parseTickRowCompat(row []string) (market.Tick, bool, error) {
 		return market.Tick{}, false, nil
 	}
 
-	// float parsing kept local to avoid import sprawl
 	bid, err := parseFloat(row[2])
 	if err != nil {
 		return market.Tick{}, false, fmt.Errorf("bad bid %q: %w", row[2], err)
@@ -160,7 +160,14 @@ func parseTickRowCompat(row []string) (market.Tick, bool, error) {
 		return market.Tick{}, false, fmt.Errorf("bad ask %q: %w", row[3], err)
 	}
 
-	return market.Tick{Time: t, Instrument: inst, Bid: bid, Ask: ask}, true, nil
+	return market.Tick{
+		Timestamp:  types.FromTime(t),
+		Instrument: inst,
+		BA: market.BA{
+			Bid: types.PriceFromFloat(bid),
+			Ask: types.PriceFromFloat(ask),
+		},
+	}, true, nil
 }
 
 func parseFloat(s string) (float64, error) {

--- a/cmd/replay/events.go
+++ b/cmd/replay/events.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rustyeddy/trader/broker/sim"
 	"github.com/rustyeddy/trader/cmd/config"
 	"github.com/rustyeddy/trader/journal"
+	"github.com/rustyeddy/trader/types"
 )
 
 func newEventsCmd(rc *config.RootConfig) *cobra.Command {
@@ -78,11 +79,11 @@ func newEventsCmd(rc *config.RootConfig) *cobra.Command {
 			engine := sim.NewEngine(broker.Account{
 				ID:       accountID,
 				Currency: "USD",
-				Balance:  startingBalance,
-				Equity:   startingBalance,
+				Balance:  types.MoneyFromFloat(startingBalance),
+				Equity:   types.MoneyFromFloat(startingBalance),
 			}, j)
 
-			feed, err := NewCSVEventsFeed(path, from, to)
+			feed, err := NewCSVEventsFeed(path, types.FromTime(from), types.FromTime(to))
 			if err != nil {
 				return err
 			}
@@ -113,7 +114,7 @@ func newEventsCmd(rc *config.RootConfig) *cobra.Command {
 			}
 
 			acct, _ := engine.GetAccount(ctx)
-			fmt.Printf("Done. balance=%.2f equity=%.2f\n", acct.Balance, acct.Equity)
+			fmt.Printf("Done. balance=%.2f equity=%.2f\n", acct.Balance.Float64(), acct.Equity.Float64())
 			return nil
 		},
 	}

--- a/cmd/replay/pricing.go
+++ b/cmd/replay/pricing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rustyeddy/trader/broker/sim"
 	"github.com/rustyeddy/trader/cmd/config"
 	"github.com/rustyeddy/trader/journal"
+	"github.com/rustyeddy/trader/types"
 )
 
 func newPricingCmd(rc *config.RootConfig) *cobra.Command {
@@ -79,11 +80,11 @@ func newPricingCmd(rc *config.RootConfig) *cobra.Command {
 			engine := sim.NewEngine(broker.Account{
 				ID:       accountID,
 				Currency: "USD",
-				Balance:  startingBalance,
-				Equity:   startingBalance,
+				Balance:  types.MoneyFromFloat(startingBalance),
+				Equity:   types.MoneyFromFloat(startingBalance),
 			}, j)
 
-			feed, err := backtest.NewCSVTicksFeed(ticksPath, from, to)
+			feed, err := backtest.NewCSVTicksFeed(ticksPath, types.FromTime(from), types.FromTime(to))
 			if err != nil {
 				return err
 			}
@@ -107,7 +108,7 @@ func newPricingCmd(rc *config.RootConfig) *cobra.Command {
 			}
 
 			acct, _ := engine.GetAccount(ctx)
-			fmt.Printf("Done. balance=%.2f equity=%.2f\n", acct.Balance, acct.Equity)
+			fmt.Printf("Done. balance=%.2f equity=%.2f\n", acct.Balance.Float64(), acct.Equity.Float64())
 			return nil
 		},
 	}

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -9,124 +9,39 @@ import (
 	"github.com/rustyeddy/trader/broker/sim"
 	"github.com/rustyeddy/trader/journal"
 	"github.com/rustyeddy/trader/market"
-	"github.com/rustyeddy/trader/risk"
+	"github.com/rustyeddy/trader/types"
 )
 
-// This example demonstrates a simple single trade with stop loss and take profit.
-// It shows the basic workflow of:
-// 1. Setting up the trading engine
-// 2. Setting initial prices
-// 3. Calculating position size based on risk
-// 4. Opening a trade with stops
-// 5. Simulating price movement that triggers the take profit
+type noopJournal struct{}
+
+func (noopJournal) RecordTrade(journal.TradeRecord) error   { return nil }
+func (noopJournal) RecordEquity(journal.EquitySnapshot) error { return nil }
+func (noopJournal) Close() error                            { return nil }
 
 func main() {
-	ctx := context.Background()
-
-	// Create journal for recording trades
-	j, err := journal.NewCSV("./trades.csv", "./equity.csv")
-	if err != nil {
-		panic(err)
-	}
-
-	// Initialize engine with starting capital of $100,000
+	j := &noopJournal{}
 	engine := sim.NewEngine(broker.Account{
-		ID:       "SIM-001",
+		ID:       "EXAMPLE-BASIC",
 		Currency: "USD",
-		Balance:  100_000,
-		Equity:   100_000,
+		Balance:  types.MoneyFromFloat(10000),
+		Equity:   types.MoneyFromFloat(10000),
 	}, j)
 
-	// Set initial market price for EUR/USD
-	initialBid := 1.0849
-	initialAsk := 1.0851
-	engine.Prices().Set(market.Tick{
+	tick := market.Tick{
 		Instrument: "EUR_USD",
-		Bid:        initialBid,
-		Ask:        initialAsk,
-		Time:       time.Now(),
-	})
-
-	fmt.Printf("Initial Price - Bid: %.4f, Ask: %.4f\n", initialBid, initialAsk)
-
-	// Get account information
-	acct, err := engine.GetAccount(ctx)
-	if err != nil {
-		panic(err)
+		Timestamp:  types.FromTime(time.Now()),
+		BA: market.BA{
+			Bid: types.PriceFromFloat(1.1000),
+			Ask: types.PriceFromFloat(1.1002),
+		},
 	}
-	fmt.Printf("Starting Equity: $%.2f\n\n", acct.Equity)
+	_ = engine.UpdatePrice(tick)
 
-	// Get instrument metadata
-	meta := market.Instruments["EUR_USD"]
-	price, _ := engine.GetTick(ctx, "EUR_USD")
-
-	// Calculate position size based on risk
-	// Risk 1% of equity with a 20 pip stop loss
-	stopPrice := price.Ask - 0.0020 // 20 pips below entry
-	size := risk.Calculate(risk.Inputs{
-		Equity:         acct.Equity,
-		RiskPct:        0.01, // Risk 1% of equity
-		EntryPrice:     price.Ask,
-		StopPrice:      stopPrice,
-		PipLocation:    meta.PipLocation,
-		QuoteToAccount: 1.0, // USD is quote currency
-	})
-
-	fmt.Printf("Position Sizing:\n")
-	fmt.Printf("  Risk Amount: $%.2f (1%% of equity)\n", size.RiskAmount)
-	fmt.Printf("  Stop Distance: %.1f pips\n", size.StopPips)
-	fmt.Printf("  Position Size: %.0f units\n\n", size.Units)
-
-	// Set take profit at 40 pips (2:1 risk/reward ratio)
-	targetPrice := price.Ask + 0.0040
-
-	fmt.Printf("Opening BUY trade:\n")
-	fmt.Printf("  Entry: %.4f (ask price)\n", price.Ask)
-	fmt.Printf("  Stop Loss: %.4f (20 pips)\n", stopPrice)
-	fmt.Printf("  Take Profit: %.4f (40 pips)\n\n", targetPrice)
-
-	// Open the trade
-	fill, err := engine.CreateMarketOrder(ctx, broker.MarketOrderRequest{
+	_, _ = engine.CreateMarketOrder(context.Background(), broker.MarketOrderRequest{
 		Instrument: "EUR_USD",
-		Units:      size.Units,
-		StopLoss:   &stopPrice,
-		TakeProfit: &targetPrice,
+		Units:      types.Units(1000),
 	})
-	if err != nil {
-		panic(err)
-	}
 
-	fmt.Printf("Trade Opened: ID=%s\n", fill.TradeID)
-	fmt.Printf("  Filled at: %.4f\n", fill.Price)
-	fmt.Printf("  Units: %.0f\n\n", fill.Units)
-
-	// Simulate price movement - price moves up to hit take profit
-	fmt.Println("Simulating price movement...")
-
-	// Price moves up gradually
-	newBid := 1.0890
-	newAsk := 1.0892
-
-	err = engine.UpdatePrice(market.Tick{
-		Instrument: "EUR_USD",
-		Bid:        newBid,
-		Ask:        newAsk,
-		Time:       time.Now().Add(1 * time.Hour),
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("Price Updated - Bid: %.4f, Ask: %.4f\n", newBid, newAsk)
-
-	// Get final account state
-	acct, err = engine.GetAccount(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("\nFinal Results:\n")
-	fmt.Printf("  Ending Equity: $%.2f\n", acct.Equity)
-	fmt.Printf("  Profit/Loss: $%.2f\n", acct.Equity-100_000)
-	fmt.Printf("\nCheck trades.csv and equity.csv for detailed records.\n")
+	acct, _ := engine.GetAccount(context.Background())
+	fmt.Printf("balance=%0.2f equity=%0.2f\n", acct.Balance.Float64(), acct.Equity.Float64())
 }

--- a/examples/multiple/main.go
+++ b/examples/multiple/main.go
@@ -9,177 +9,37 @@ import (
 	"github.com/rustyeddy/trader/broker/sim"
 	"github.com/rustyeddy/trader/journal"
 	"github.com/rustyeddy/trader/market"
-	"github.com/rustyeddy/trader/risk"
+	"github.com/rustyeddy/trader/types"
 )
 
-// This example demonstrates managing multiple positions simultaneously.
-// It shows:
-// 1. Opening multiple trades on the same instrument
-// 2. Opening trades on different instruments
-// 3. Watching positions get stopped out or hit targets
-// 4. How margin is tracked across multiple positions
+type noopJournal struct{}
 
-func main() {
-	ctx := context.Background()
+func (noopJournal) RecordTrade(journal.TradeRecord) error   { return nil }
+func (noopJournal) RecordEquity(journal.EquitySnapshot) error { return nil }
+func (noopJournal) Close() error                            { return nil }
 
-	// Create journal
-	j, err := journal.NewCSV("./trades.csv", "./equity.csv")
-	if err != nil {
-		panic(err)
+func tick(instr string, bid, ask float64) market.Tick {
+	return market.Tick{
+		Instrument: instr,
+		Timestamp:  types.FromTime(time.Now()),
+		BA: market.BA{Bid: types.PriceFromFloat(bid), Ask: types.PriceFromFloat(ask)},
 	}
-
-	// Initialize engine
-	engine := sim.NewEngine(broker.Account{
-		ID:       "SIM-001",
-		Currency: "USD",
-		Balance:  100_000,
-		Equity:   100_000,
-	}, j)
-
-	// Set initial prices for both instruments
-	engine.Prices().Set(market.Tick{
-		Instrument: "EUR_USD",
-		Bid:        1.0849,
-		Ask:        1.0851,
-		Time:       time.Now(),
-	})
-
-	engine.Prices().Set(market.Tick{
-		Instrument: "USD_JPY",
-		Bid:        149.50,
-		Ask:        149.52,
-		Time:       time.Now(),
-	})
-
-	acct, _ := engine.GetAccount(ctx)
-	fmt.Printf("Starting Equity: $%.2f\n\n", acct.Equity)
-
-	// Trade 1: BUY EUR/USD
-	fmt.Println("=== Opening Trade 1: BUY EUR/USD ===")
-	openTrade(ctx, engine, "EUR_USD", true)
-
-	// Trade 2: BUY USD/JPY
-	fmt.Println("\n=== Opening Trade 2: BUY USD/JPY ===")
-	openTrade(ctx, engine, "USD_JPY", true)
-
-	// Check account state
-	acct, _ = engine.GetAccount(ctx)
-	fmt.Printf("\nAccount Status:\n")
-	fmt.Printf("  Equity: $%.2f\n", acct.Equity)
-	fmt.Printf("  Margin Used: $%.2f\n", acct.MarginUsed)
-	fmt.Printf("  Free Margin: $%.2f\n", acct.FreeMargin)
-	fmt.Printf("  Margin Level: %.2f%%\n\n", acct.MarginLevel*100)
-
-	// Simulate price movements
-	fmt.Println("=== Simulating Price Movements ===")
-
-	// EUR/USD moves up (profitable)
-	fmt.Println("\nEUR/USD moves up...")
-	err = engine.UpdatePrice(market.Tick{
-		Instrument: "EUR_USD",
-		Bid:        1.0890,
-		Ask:        1.0892,
-		Time:       time.Now().Add(1 * time.Hour),
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	// USD/JPY moves down slightly (small loss)
-	fmt.Println("USD/JPY moves down...")
-	err = engine.UpdatePrice(market.Tick{
-		Instrument: "USD_JPY",
-		Bid:        149.30,
-		Ask:        149.32,
-		Time:       time.Now().Add(1 * time.Hour),
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	// Final account state
-	acct, _ = engine.GetAccount(ctx)
-	fmt.Printf("\nFinal Account Status:\n")
-	fmt.Printf("  Equity: $%.2f\n", acct.Equity)
-	fmt.Printf("  Balance: $%.2f\n", acct.Balance)
-	fmt.Printf("  Profit/Loss: $%.2f\n", acct.Equity-100_000)
-	fmt.Printf("\nCheck trades.csv and equity.csv for complete trade history.\n")
 }
 
-func openTrade(ctx context.Context, engine *sim.Engine, instrument string, isBuy bool) {
-	acct, err := engine.GetAccount(ctx)
-	if err != nil {
-		panic(err)
-	}
-	price, err := engine.GetTick(ctx, instrument)
-	if err != nil {
-		panic(err)
-	}
-	meta := market.Instruments[instrument]
+func main() {
+	engine := sim.NewEngine(broker.Account{
+		ID:       "EXAMPLE-MULTI",
+		Currency: "USD",
+		Balance:  types.MoneyFromFloat(20000),
+		Equity:   types.MoneyFromFloat(20000),
+	}, &noopJournal{})
 
-	// Calculate position size (risk 1% per trade)
-	var stopPrice float64
-	var entryPrice float64
+	_ = engine.UpdatePrice(tick("EUR_USD", 1.1000, 1.1002))
+	_ = engine.UpdatePrice(tick("USD_JPY", 150.00, 150.02))
 
-	// Calculate pip size dynamically based on instrument
-	pipSize := risk.PipSize(meta.PipLocation)
-	pipDistance := 20.0 // 20 pips
+	_, _ = engine.CreateMarketOrder(context.Background(), broker.MarketOrderRequest{Instrument: "EUR_USD", Units: types.Units(1000)})
+	_, _ = engine.CreateMarketOrder(context.Background(), broker.MarketOrderRequest{Instrument: "USD_JPY", Units: types.Units(2000)})
 
-	if isBuy {
-		entryPrice = price.Ask
-		stopPrice = entryPrice - (pipDistance * pipSize)
-	} else {
-		entryPrice = price.Bid
-		stopPrice = entryPrice + (pipDistance * pipSize)
-	}
-
-	// Calculate quote to account rate
-	var quoteToAccount float64
-	if meta.QuoteCurrency == "USD" {
-		quoteToAccount = 1.0
-	} else if meta.QuoteCurrency == "JPY" {
-		quoteToAccount = 1.0 / price.Mid()
-	} else {
-		// For other currencies, default to 1.0 (assumes quote currency = account currency)
-		quoteToAccount = 1.0
-	}
-
-	size := risk.Calculate(risk.Inputs{
-		Equity:         acct.Equity,
-		RiskPct:        0.01, // 1% risk per trade
-		EntryPrice:     entryPrice,
-		StopPrice:      stopPrice,
-		PipLocation:    meta.PipLocation,
-		QuoteToAccount: quoteToAccount,
-	})
-
-	targetPrice := entryPrice
-	if isBuy {
-		targetPrice = entryPrice + (entryPrice-stopPrice)*2 // 2:1 R:R
-	} else {
-		targetPrice = entryPrice - (stopPrice-entryPrice)*2
-	}
-
-	units := size.Units
-	if !isBuy {
-		units = -units // Negative for SELL
-	}
-
-	fmt.Printf("  Instrument: %s\n", instrument)
-	fmt.Printf("  Direction: %s\n", map[bool]string{true: "BUY", false: "SELL"}[isBuy])
-	fmt.Printf("  Entry: %.4f\n", entryPrice)
-	fmt.Printf("  Stop: %.4f\n", stopPrice)
-	fmt.Printf("  Target: %.4f\n", targetPrice)
-	fmt.Printf("  Units: %.0f\n", size.Units)
-	fmt.Printf("  Risk: $%.2f\n", size.RiskAmount)
-
-	_, err = engine.CreateMarketOrder(ctx, broker.MarketOrderRequest{
-		Instrument: instrument,
-		Units:      units,
-		StopLoss:   &stopPrice,
-		TakeProfit: &targetPrice,
-	})
-	if err != nil {
-		panic(err)
-	}
+	acct, _ := engine.GetAccount(context.Background())
+	fmt.Println("open positions across instruments", acct.Equity.Float64())
 }

--- a/examples/risk/main.go
+++ b/examples/risk/main.go
@@ -1,152 +1,19 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/rustyeddy/trader/broker"
-	"github.com/rustyeddy/trader/broker/sim"
-	"github.com/rustyeddy/trader/journal"
-	"github.com/rustyeddy/trader/market"
 	"github.com/rustyeddy/trader/risk"
 )
 
-// This example demonstrates proper risk management principles.
-// It shows:
-// 1. How to calculate position size based on account risk percentage
-// 2. How stop distance affects position size
-// 3. Comparing different risk percentages
-// 4. Currency conversion for different quote currencies
-
 func main() {
-	ctx := context.Background()
-
-	j, err := journal.NewCSV("./trades.csv", "./equity.csv")
-	if err != nil {
-		panic(err)
-	}
-
-	engine := sim.NewEngine(broker.Account{
-		ID:       "SIM-001",
-		Currency: "USD",
-		Balance:  100_000,
-		Equity:   100_000,
-	}, j)
-
-	engine.Prices().Set(market.Tick{
-		Instrument: "EUR_USD",
-		Bid:        1.0849,
-		Ask:        1.0851,
+	size := risk.Calculate(risk.Inputs{
+		Equity:         10000,
+		RiskPct:        0.01,
+		EntryPrice:     1.1000,
+		StopPrice:      1.0950,
+		PipLocation:    -4,
+		QuoteToAccount: 1.0,
 	})
-
-	acct, _ := engine.GetAccount(ctx)
-	fmt.Printf("Starting Equity: $%.2f\n\n", acct.Equity)
-
-	// Demonstrate different risk percentages
-	fmt.Println("=== Position Sizing with Different Risk Levels ===")
-	fmt.Println()
-
-	meta := market.Instruments["EUR_USD"]
-	price, _ := engine.GetTick(ctx, "EUR_USD")
-	entryPrice := price.Ask
-
-	riskLevels := []float64{0.005, 0.01, 0.02}         // 0.5%, 1%, 2%
-	stopDistances := []float64{0.0010, 0.0020, 0.0030} // 10, 20, 30 pips
-
-	for _, riskPct := range riskLevels {
-		fmt.Printf("Risk Level: %.1f%% of equity\n", riskPct*100)
-		fmt.Println("Stop Distance | Position Size | Risk Amount")
-		fmt.Println("------------- | ------------- | -----------")
-
-		for _, stopDist := range stopDistances {
-			stopPrice := entryPrice - stopDist
-
-			size := risk.Calculate(risk.Inputs{
-				Equity:         acct.Equity,
-				RiskPct:        riskPct,
-				EntryPrice:     entryPrice,
-				StopPrice:      stopPrice,
-				PipLocation:    meta.PipLocation,
-				QuoteToAccount: 1.0,
-			})
-
-			pips := size.StopPips
-			fmt.Printf("%6.0f pips   | %13.0f | $%9.2f\n",
-				pips, size.Units, size.RiskAmount)
-		}
-		fmt.Println()
-	}
-
-	// Demonstrate currency conversion for JPY pairs
-	fmt.Println("=== Position Sizing with JPY Quote Currency ===")
-	fmt.Println()
-
-	engine.Prices().Set(market.Tick{
-		Instrument: "USD_JPY",
-		Bid:        149.50,
-		Ask:        149.52,
-	})
-
-	jpyPrice, _ := engine.GetTick(ctx, "USD_JPY")
-	jpyMeta := market.Instruments["USD_JPY"]
-	jpyEntry := jpyPrice.Ask
-	jpyStop := jpyEntry - 0.50 // 50 pips
-
-	// JPY is quote currency, so we need to convert to USD
-	quoteToAccount := 1.0 / jpyPrice.Mid()
-
-	jpySize := risk.Calculate(risk.Inputs{
-		Equity:         acct.Equity,
-		RiskPct:        0.01, // 1% risk
-		EntryPrice:     jpyEntry,
-		StopPrice:      jpyStop,
-		PipLocation:    jpyMeta.PipLocation,
-		QuoteToAccount: quoteToAccount,
-	})
-
-	fmt.Printf("USD/JPY Position Sizing:\n")
-	fmt.Printf("  Entry Price: %.2f\n", jpyEntry)
-	fmt.Printf("  Stop Price: %.2f\n", jpyStop)
-	fmt.Printf("  Stop Distance: %.1f pips\n", jpySize.StopPips)
-	fmt.Printf("  Quote to USD Rate: %.6f\n", quoteToAccount)
-	fmt.Printf("  Position Size: %.0f units\n", jpySize.Units)
-	fmt.Printf("  Risk Amount: $%.2f\n\n", jpySize.RiskAmount)
-
-	// Demonstrate why larger stops = smaller positions
-	fmt.Println("=== Why Stop Distance Matters ===")
-	fmt.Println()
-	fmt.Println("With the same 1% risk ($1,000), wider stops require smaller positions:")
-	fmt.Println()
-
-	fmt.Println("Stop Distance | Units Traded | Why?")
-	fmt.Println("------------- | ------------ | ----")
-
-	stopExamples := []struct {
-		pips   float64
-		reason string
-	}{
-		{10, "Small stop = more units (concentrated risk per pip)"},
-		{20, "Medium stop = medium units (balanced)"},
-		{50, "Wide stop = fewer units (risk spread across many pips)"},
-	}
-
-	for _, ex := range stopExamples {
-		stopPrice := entryPrice - (ex.pips * 0.0001)
-		size := risk.Calculate(risk.Inputs{
-			Equity:         acct.Equity,
-			RiskPct:        0.01,
-			EntryPrice:     entryPrice,
-			StopPrice:      stopPrice,
-			PipLocation:    meta.PipLocation,
-			QuoteToAccount: 1.0,
-		})
-		fmt.Printf("%6.0f pips   | %12.0f | %s\n", ex.pips, size.Units, ex.reason)
-	}
-
-	fmt.Println("\n=== Key Takeaways ===")
-	fmt.Println("1. Always risk a consistent percentage of your equity (0.5-2%)")
-	fmt.Println("2. Wider stops = smaller position sizes for the same risk")
-	fmt.Println("3. Account for currency conversion when quote != account currency")
-	fmt.Println("4. Never risk more than you can afford to lose")
-	fmt.Println("5. Position sizing ensures each trade risks the same dollar amount")
+	fmt.Printf("units=%0.f stopPips=%0.1f\n", size.Units, size.StopPips)
 }

--- a/examples/simrun/main.go
+++ b/examples/simrun/main.go
@@ -9,57 +9,34 @@ import (
 	"github.com/rustyeddy/trader/broker/sim"
 	"github.com/rustyeddy/trader/journal"
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 )
 
+type noopJournal struct{}
+
+func (noopJournal) RecordTrade(journal.TradeRecord) error   { return nil }
+func (noopJournal) RecordEquity(journal.EquitySnapshot) error { return nil }
+func (noopJournal) Close() error                            { return nil }
+
 func main() {
-	ctx := context.Background()
-
-	j, err := journal.NewCSV("./trades.csv", "./equity.csv")
-	if err != nil {
-		panic(err)
-	}
-	defer j.Close()
-
 	engine := sim.NewEngine(broker.Account{
-		ID:       "SIM-001",
+		ID:       "EXAMPLE-SIMRUN",
 		Currency: "USD",
-		Balance:  100_000,
-		Equity:   100_000,
-	}, j)
+		Balance:  types.MoneyFromFloat(5000),
+		Equity:   types.MoneyFromFloat(5000),
+	}, &noopJournal{})
 
-	// Seed an initial price (include Time so snapshots are non-zero timestamps)
-	engine.Prices().Set(market.Tick{
-		Instrument: "EUR_USD",
-		Bid:        1.0849,
-		Ask:        1.0851,
-		Time:       time.Now(),
-	})
-
-	// Open a 10k unit long (close will happen on BID)
-	fill, err := engine.CreateMarketOrder(ctx, broker.MarketOrderRequest{
-		Instrument: "EUR_USD",
-		Units:      10_000,
-	})
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("OPEN  trade=%s units=%.0f entry=%.5f\n", fill.TradeID, fill.Units, fill.Price)
-
-	// Move the market a bit and record an equity snapshot (UpdatePrice does snapshotting)
-	t2 := time.Now().Add(10 * time.Second)
-	if err := engine.UpdatePrice(market.Tick{
-		Instrument: "EUR_USD",
-		Bid:        1.0860,
-		Ask:        1.0862,
-		Time:       t2,
-	}); err != nil {
-		panic(err)
+	for i := 0; i < 3; i++ {
+		_ = engine.UpdatePrice(market.Tick{
+			Instrument: "EUR_USD",
+			Timestamp:  types.FromTime(time.Now().Add(time.Duration(i) * time.Second)),
+			BA: market.BA{
+				Bid: types.PriceFromFloat(1.1000 + 0.0001*float64(i)),
+				Ask: types.PriceFromFloat(1.1002 + 0.0001*float64(i)),
+			},
+		})
 	}
 
-	// Now manually close at current BID (since it's a long)
-	if err := engine.CloseTrade(ctx, fill.TradeID, "ManualClose"); err != nil {
-		panic(err)
-	}
-	acct, _ := engine.GetAccount(ctx)
-	fmt.Printf("CLOSE balance=%.2f equity=%.2f\n", acct.Balance, acct.Equity)
+	acct, _ := engine.GetAccount(context.Background())
+	fmt.Printf("equity=%0.2f\n", acct.Equity.Float64())
 }

--- a/journal/csv_test.go
+++ b/journal/csv_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,15 +56,20 @@ func TestCSVJournalRecordTrade(t *testing.T) {
 	open := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 	closeT := time.Date(2024, 1, 2, 4, 5, 6, 0, time.UTC)
 
+	units := types.Units(123456)
+	entryPrice := types.PriceFromFloat(1.2345678)
+	exitPrice := types.PriceFromFloat(1.3456789)
+	realizedPL := types.MoneyFromFloat(-12.5)
+
 	err = j.RecordTrade(TradeRecord{
 		TradeID:    "T1",
 		Instrument: "EUR_USD",
-		Units:      123.456,
-		EntryPrice: 1.2345678,
-		ExitPrice:  1.3456789,
-		OpenTime:   open,
-		CloseTime:  closeT,
-		RealizedPL: -12.5,
+		Units:      units,
+		EntryPrice: entryPrice,
+		ExitPrice:  exitPrice,
+		OpenTime:   types.FromTime(open),
+		CloseTime:  types.FromTime(closeT),
+		RealizedPL: realizedPL,
 		Reason:     "test",
 	})
 	assert.NoError(t, err)
@@ -82,12 +88,12 @@ func TestCSVJournalRecordTrade(t *testing.T) {
 	want := []string{
 		"T1",
 		"EUR_USD",
-		"123.456000",
-		"1.234568",
-		"1.345679",
-		open.Format(time.RFC3339),
-		closeT.Format(time.RFC3339),
-		"-12.500000",
+		units.String(),
+		entryPrice.String(),
+		exitPrice.String(),
+		types.FromTime(open).String(),
+		types.FromTime(closeT).String(),
+		realizedPL.String(),
 		"test",
 	}
 	assert.Equal(t, want, row)
@@ -105,13 +111,19 @@ func TestCSVJournalRecordEquity(t *testing.T) {
 
 	ts := time.Date(2024, 2, 3, 4, 5, 6, 0, time.UTC)
 
+	balance := types.MoneyFromFloat(1000.1)
+	equity := types.MoneyFromFloat(999.9)
+	marginUsed := types.MoneyFromFloat(10.5)
+	freeMargin := types.MoneyFromFloat(989.4)
+	marginLevel := types.MoneyFromFloat(99.99)
+
 	err = j.RecordEquity(EquitySnapshot{
-		Time:        ts,
-		Balance:     1000.1,
-		Equity:      999.9,
-		MarginUsed:  10.5,
-		FreeMargin:  989.4,
-		MarginLevel: 99.99,
+		Timestamp:   types.FromTime(ts),
+		Balance:     balance,
+		Equity:      equity,
+		MarginUsed:  marginUsed,
+		FreeMargin:  freeMargin,
+		MarginLevel: marginLevel,
 	})
 	assert.NoError(t, err)
 
@@ -127,12 +139,12 @@ func TestCSVJournalRecordEquity(t *testing.T) {
 	assert.NoError(t, err)
 
 	want := []string{
-		ts.Format(time.RFC3339),
-		"1000.100000",
-		"999.900000",
-		"10.500000",
-		"989.400000",
-		"99.990000",
+		types.FromTime(ts).String(),
+		balance.String(),
+		equity.String(),
+		marginUsed.String(),
+		freeMargin.String(),
+		marginLevel.String(),
 	}
 	assert.Equal(t, want, row)
 }

--- a/journal/org.go
+++ b/journal/org.go
@@ -3,6 +3,8 @@ package journal
 import (
 	"fmt"
 	"strings"
+
+	"github.com/rustyeddy/trader/types"
 )
 
 // FormatTradeOrg renders a TradeRecord as an Org-mode block suitable for pasting into a journal.
@@ -21,12 +23,12 @@ func FormatTradeOrg(t TradeRecord) string {
 	b.WriteString(fmt.Sprintf(":TRADE_ID: %s\n", t.TradeID))
 	b.WriteString(fmt.Sprintf(":ID: %s\n", t.TradeID))
 	b.WriteString(fmt.Sprintf(":INSTRUMENT: %s\n", t.Instrument))
-	b.WriteString(fmt.Sprintf(":UNITS: %.0f\n", t.Units))
-	b.WriteString(fmt.Sprintf(":ENTRY_PRICE: %.5f\n", t.EntryPrice))
-	b.WriteString(fmt.Sprintf(":EXIT_PRICE: %.5f\n", t.ExitPrice))
+	b.WriteString(fmt.Sprintf(":UNITS: %d\n", t.Units))
+	b.WriteString(fmt.Sprintf(":ENTRY_PRICE: %.5f\n", float64(t.EntryPrice)/float64(types.PriceScale)))
+	b.WriteString(fmt.Sprintf(":EXIT_PRICE: %.5f\n", float64(t.ExitPrice)/float64(types.PriceScale)))
 	b.WriteString(fmt.Sprintf(":OPEN_TIME: %s\n", open))
 	b.WriteString(fmt.Sprintf(":CLOSE_TIME: %s\n", close))
-	b.WriteString(fmt.Sprintf(":REALIZED_PL: %.2f\n", t.RealizedPL))
+	b.WriteString(fmt.Sprintf(":REALIZED_PL: %.2f\n", t.RealizedPL.Float64()))
 	b.WriteString(fmt.Sprintf(":REASON: %s\n", t.Reason))
 	b.WriteString(":END:\n")
 	b.WriteString("\n")

--- a/journal/org_test.go
+++ b/journal/org_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,11 +20,11 @@ func TestFormatTradeOrg(t *testing.T) {
 		TradeID:    "trade-12345678-abcd",
 		Instrument: "EUR_USD",
 		Units:      1000,
-		EntryPrice: 1.08500,
-		ExitPrice:  1.08750,
-		OpenTime:   open,
-		CloseTime:  close,
-		RealizedPL: 250.00,
+		EntryPrice: types.PriceFromFloat(1.08500),
+		ExitPrice:  types.PriceFromFloat(1.08750),
+		OpenTime:   types.FromTime(open),
+		CloseTime:  types.FromTime(close),
+		RealizedPL: types.MoneyFromFloat(250.00),
 		Reason:     "trend-following",
 	}
 
@@ -59,11 +60,11 @@ func TestFormatTradeOrgShortID(t *testing.T) {
 		TradeID:    "short",
 		Instrument: "GBP_USD",
 		Units:      500,
-		EntryPrice: 1.25000,
-		ExitPrice:  1.25100,
-		OpenTime:   time.Now(),
-		CloseTime:  time.Now(),
-		RealizedPL: 50.00,
+		EntryPrice: types.PriceFromFloat(1.25000),
+		ExitPrice:  types.PriceFromFloat(1.25100),
+		OpenTime:   types.FromTime(time.Now()),
+		CloseTime:  types.FromTime(time.Now()),
+		RealizedPL: types.MoneyFromFloat(50.00),
 		Reason:     "test",
 	}
 
@@ -78,11 +79,11 @@ func TestFormatTradeOrgNegativePL(t *testing.T) {
 		TradeID:    "loss-trade",
 		Instrument: "USD_JPY",
 		Units:      2000,
-		EntryPrice: 150.50,
-		ExitPrice:  150.25,
-		OpenTime:   time.Now(),
-		CloseTime:  time.Now(),
-		RealizedPL: -500.00,
+		EntryPrice: types.PriceFromFloat(150.50),
+		ExitPrice:  types.PriceFromFloat(150.25),
+		OpenTime:   types.FromTime(time.Now()),
+		CloseTime:  types.FromTime(time.Now()),
+		RealizedPL: types.MoneyFromFloat(-500.00),
 		Reason:     "stop-loss",
 	}
 
@@ -103,22 +104,22 @@ func TestFormatTradesOrg(t *testing.T) {
 			TradeID:    "trade-001",
 			Instrument: "EUR_USD",
 			Units:      1000,
-			EntryPrice: 1.08000,
-			ExitPrice:  1.08200,
-			OpenTime:   open1,
-			CloseTime:  close1,
-			RealizedPL: 200.00,
+			EntryPrice: types.PriceFromFloat(1.08000),
+			ExitPrice:  types.PriceFromFloat(1.08200),
+			OpenTime:   types.FromTime(open1),
+			CloseTime:  types.FromTime(close1),
+			RealizedPL: types.MoneyFromFloat(200.00),
 			Reason:     "breakout",
 		},
 		{
 			TradeID:    "trade-002",
 			Instrument: "GBP_USD",
 			Units:      500,
-			EntryPrice: 1.25000,
-			ExitPrice:  1.24800,
-			OpenTime:   open2,
-			CloseTime:  close2,
-			RealizedPL: -100.00,
+			EntryPrice: types.PriceFromFloat(1.25000),
+			ExitPrice:  types.PriceFromFloat(1.24800),
+			OpenTime:   types.FromTime(open2),
+			CloseTime:  types.FromTime(close2),
+			RealizedPL: types.MoneyFromFloat(-100.00),
 			Reason:     "reversal",
 		},
 	}
@@ -150,11 +151,11 @@ func TestFormatTradesOrgSingle(t *testing.T) {
 		TradeID:    "single",
 		Instrument: "USD_CAD",
 		Units:      750,
-		EntryPrice: 1.35000,
-		ExitPrice:  1.35100,
-		OpenTime:   time.Now(),
-		CloseTime:  time.Now(),
-		RealizedPL: 75.00,
+		EntryPrice: types.PriceFromFloat(1.35000),
+		ExitPrice:  types.PriceFromFloat(1.35100),
+		OpenTime:   types.FromTime(time.Now()),
+		CloseTime:  types.FromTime(time.Now()),
+		RealizedPL: types.MoneyFromFloat(75.00),
 		Reason:     "momentum",
 	}
 
@@ -217,11 +218,11 @@ func TestFormatTradeOrgStructure(t *testing.T) {
 		TradeID:    "structure-test",
 		Instrument: "AUD_USD",
 		Units:      100,
-		EntryPrice: 0.65000,
-		ExitPrice:  0.65500,
-		OpenTime:   time.Now(),
-		CloseTime:  time.Now(),
-		RealizedPL: 50.00,
+		EntryPrice: types.PriceFromFloat(0.65000),
+		ExitPrice:  types.PriceFromFloat(0.65500),
+		OpenTime:   types.FromTime(time.Now()),
+		CloseTime:  types.FromTime(time.Now()),
+		RealizedPL: types.MoneyFromFloat(50.00),
 		Reason:     "test",
 	}
 

--- a/journal/query.go
+++ b/journal/query.go
@@ -11,6 +11,8 @@ import (
 // GetTrade returns a single trade record by ID.
 func (j *SQLite) GetTrade(tradeID string) (TradeRecord, error) {
 	var rec TradeRecord
+	var units, entryPrice, exitPrice, realizedPL float64
+	var openTime, closeTime time.Time
 
 	row := j.db.QueryRow(`
 		SELECT trade_id, instrument, units, entry_price, exit_price, open_time, close_time, realized_pl, reason
@@ -20,12 +22,12 @@ func (j *SQLite) GetTrade(tradeID string) (TradeRecord, error) {
 	err := row.Scan(
 		&rec.TradeID,
 		&rec.Instrument,
-		&rec.Units,
-		&rec.EntryPrice,
-		&rec.ExitPrice,
-		&rec.OpenTime,
-		&rec.CloseTime,
-		&rec.RealizedPL,
+		&units,
+		&entryPrice,
+		&exitPrice,
+		&openTime,
+		&closeTime,
+		&realizedPL,
 		&rec.Reason,
 	)
 	if err != nil {
@@ -34,6 +36,12 @@ func (j *SQLite) GetTrade(tradeID string) (TradeRecord, error) {
 		}
 		return TradeRecord{}, err
 	}
+	rec.Units = types.Units(units)
+	rec.EntryPrice = types.Price(entryPrice)
+	rec.ExitPrice = types.Price(exitPrice)
+	rec.OpenTime = types.FromTime(openTime)
+	rec.CloseTime = types.FromTime(closeTime)
+	rec.RealizedPL = types.Money(realizedPL)
 	return rec, nil
 }
 
@@ -52,19 +60,27 @@ func (j *SQLite) ListTradesClosedBetween(start, end types.Timestamp) ([]TradeRec
 	var out []TradeRecord
 	for rows.Next() {
 		var rec TradeRecord
+		var units, entryPrice, exitPrice, realizedPL float64
+		var openTime, closeTime time.Time
 		if err := rows.Scan(
 			&rec.TradeID,
 			&rec.Instrument,
-			&rec.Units,
-			&rec.EntryPrice,
-			&rec.ExitPrice,
-			&rec.OpenTime,
-			&rec.CloseTime,
-			&rec.RealizedPL,
+			&units,
+			&entryPrice,
+			&exitPrice,
+			&openTime,
+			&closeTime,
+			&realizedPL,
 			&rec.Reason,
 		); err != nil {
 			return nil, err
 		}
+		rec.Units = types.Units(units)
+		rec.EntryPrice = types.Price(entryPrice)
+		rec.ExitPrice = types.Price(exitPrice)
+		rec.OpenTime = types.FromTime(openTime)
+		rec.CloseTime = types.FromTime(closeTime)
+		rec.RealizedPL = types.Money(realizedPL)
 		out = append(out, rec)
 	}
 

--- a/journal/query_test.go
+++ b/journal/query_test.go
@@ -5,9 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func p(v float64) types.Price { return types.PriceFromFloat(v) }
+func ts(t time.Time) types.Timestamp { return types.FromTime(t) }
+func m(v float64) types.Money { return types.MoneyFromFloat(v) }
 
 func TestGetTrade(t *testing.T) {
 	t.Parallel()
@@ -21,12 +26,12 @@ func TestGetTrade(t *testing.T) {
 	expectedTrade := TradeRecord{
 		TradeID:    "T123",
 		Instrument: "EUR_USD",
-		Units:      1500.0,
-		EntryPrice: 1.08500,
-		ExitPrice:  1.08750,
-		OpenTime:   open,
-		CloseTime:  close,
-		RealizedPL: 375.00,
+		Units:      1500,
+		EntryPrice: p(1.08500),
+		ExitPrice:  p(1.08750),
+		OpenTime:   ts(open),
+		CloseTime:  ts(close),
+		RealizedPL: m(375.00),
 		Reason:     "trend",
 	}
 
@@ -41,12 +46,12 @@ func TestGetTrade(t *testing.T) {
 	// Verify all fields match
 	assert.Equal(t, expectedTrade.TradeID, actualTrade.TradeID)
 	assert.Equal(t, expectedTrade.Instrument, actualTrade.Instrument)
-	assert.InDelta(t, expectedTrade.Units, actualTrade.Units, 1e-6)
-	assert.InDelta(t, expectedTrade.EntryPrice, actualTrade.EntryPrice, 1e-9)
-	assert.InDelta(t, expectedTrade.ExitPrice, actualTrade.ExitPrice, 1e-9)
-	assert.True(t, actualTrade.OpenTime.Equal(expectedTrade.OpenTime))
-	assert.True(t, actualTrade.CloseTime.Equal(expectedTrade.CloseTime))
-	assert.InDelta(t, expectedTrade.RealizedPL, actualTrade.RealizedPL, 1e-6)
+	assert.Equal(t, expectedTrade.Units, actualTrade.Units)
+	assert.Equal(t, expectedTrade.EntryPrice, actualTrade.EntryPrice)
+	assert.Equal(t, expectedTrade.ExitPrice, actualTrade.ExitPrice)
+	assert.Equal(t, expectedTrade.OpenTime, actualTrade.OpenTime)
+	assert.Equal(t, expectedTrade.CloseTime, actualTrade.CloseTime)
+	assert.Equal(t, expectedTrade.RealizedPL, actualTrade.RealizedPL)
 	assert.Equal(t, expectedTrade.Reason, actualTrade.Reason)
 }
 
@@ -73,33 +78,33 @@ func TestGetTradeMultipleTrades(t *testing.T) {
 			TradeID:    "T001",
 			Instrument: "EUR_USD",
 			Units:      1000,
-			EntryPrice: 1.08000,
-			ExitPrice:  1.08200,
-			OpenTime:   time.Now(),
-			CloseTime:  time.Now(),
-			RealizedPL: 200.00,
+			EntryPrice: p(1.08000),
+			ExitPrice:  p(1.08200),
+			OpenTime:   ts(time.Now()),
+			CloseTime:  ts(time.Now()),
+			RealizedPL: m(200.00),
 			Reason:     "test1",
 		},
 		{
 			TradeID:    "T002",
 			Instrument: "GBP_USD",
 			Units:      500,
-			EntryPrice: 1.25000,
-			ExitPrice:  1.24800,
-			OpenTime:   time.Now(),
-			CloseTime:  time.Now(),
-			RealizedPL: -100.00,
+			EntryPrice: p(1.25000),
+			ExitPrice:  p(1.24800),
+			OpenTime:   ts(time.Now()),
+			CloseTime:  ts(time.Now()),
+			RealizedPL: m(-100.00),
 			Reason:     "test2",
 		},
 		{
 			TradeID:    "T003",
 			Instrument: "USD_JPY",
 			Units:      2000,
-			EntryPrice: 150.00,
-			ExitPrice:  150.50,
-			OpenTime:   time.Now(),
-			CloseTime:  time.Now(),
-			RealizedPL: 1000.00,
+			EntryPrice: p(150.00),
+			ExitPrice:  p(150.50),
+			OpenTime:   ts(time.Now()),
+			CloseTime:  ts(time.Now()),
+			RealizedPL: m(1000.00),
 			Reason:     "test3",
 		},
 	}
@@ -114,7 +119,7 @@ func TestGetTradeMultipleTrades(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expected.TradeID, actual.TradeID)
 		assert.Equal(t, expected.Instrument, actual.Instrument)
-		assert.InDelta(t, expected.RealizedPL, actual.RealizedPL, 1e-6)
+		assert.Equal(t, expected.RealizedPL, actual.RealizedPL)
 	}
 }
 
@@ -132,44 +137,44 @@ func TestListTradesClosedBetween(t *testing.T) {
 			TradeID:    "T1",
 			Instrument: "EUR_USD",
 			Units:      1000,
-			EntryPrice: 1.08000,
-			ExitPrice:  1.08100,
-			OpenTime:   baseTime,
-			CloseTime:  baseTime.Add(1 * time.Hour), // May 1, 01:00
-			RealizedPL: 100.00,
+			EntryPrice: p(1.08000),
+			ExitPrice:  p(1.08100),
+			OpenTime:   ts(baseTime),
+			CloseTime:  ts(baseTime.Add(1 * time.Hour)), // May 1, 01:00
+			RealizedPL: m(100.00),
 			Reason:     "early",
 		},
 		{
 			TradeID:    "T2",
 			Instrument: "GBP_USD",
 			Units:      500,
-			EntryPrice: 1.25000,
-			ExitPrice:  1.25200,
-			OpenTime:   baseTime,
-			CloseTime:  baseTime.Add(5 * time.Hour), // May 1, 05:00
-			RealizedPL: 100.00,
+			EntryPrice: p(1.25000),
+			ExitPrice:  p(1.25200),
+			OpenTime:   ts(baseTime),
+			CloseTime:  ts(baseTime.Add(5 * time.Hour)), // May 1, 05:00
+			RealizedPL: m(100.00),
 			Reason:     "middle",
 		},
 		{
 			TradeID:    "T3",
 			Instrument: "USD_JPY",
 			Units:      2000,
-			EntryPrice: 150.00,
-			ExitPrice:  150.25,
-			OpenTime:   baseTime,
-			CloseTime:  baseTime.Add(10 * time.Hour), // May 1, 10:00
-			RealizedPL: 500.00,
+			EntryPrice: p(150.00),
+			ExitPrice:  p(150.25),
+			OpenTime:   ts(baseTime),
+			CloseTime:  ts(baseTime.Add(10 * time.Hour)), // May 1, 10:00
+			RealizedPL: m(500.00),
 			Reason:     "late",
 		},
 		{
 			TradeID:    "T4",
 			Instrument: "AUD_USD",
 			Units:      750,
-			EntryPrice: 0.65000,
-			ExitPrice:  0.65100,
-			OpenTime:   baseTime,
-			CloseTime:  baseTime.Add(24 * time.Hour), // May 2, 00:00
-			RealizedPL: 75.00,
+			EntryPrice: p(0.65000),
+			ExitPrice:  p(0.65100),
+			OpenTime:   ts(baseTime),
+			CloseTime:  ts(baseTime.Add(24 * time.Hour)), // May 2, 00:00
+			RealizedPL: m(75.00),
 			Reason:     "next_day",
 		},
 	}
@@ -182,7 +187,7 @@ func TestListTradesClosedBetween(t *testing.T) {
 	start := baseTime.Add(3 * time.Hour)
 	end := baseTime.Add(12 * time.Hour)
 
-	results, err := j.ListTradesClosedBetween(start, end)
+	results, err := j.ListTradesClosedBetween(ts(start), ts(end))
 	require.NoError(t, err)
 	require.Len(t, results, 2, "Expected 2 trades in the time range")
 
@@ -205,33 +210,33 @@ func TestListTradesClosedBetweenOrdering(t *testing.T) {
 			TradeID:    "T3",
 			Instrument: "USD_JPY",
 			Units:      2000,
-			EntryPrice: 150.00,
-			ExitPrice:  150.25,
-			OpenTime:   baseTime,
-			CloseTime:  baseTime.Add(10 * time.Hour),
-			RealizedPL: 500.00,
+			EntryPrice: p(150.00),
+			ExitPrice:  p(150.25),
+			OpenTime:   ts(baseTime),
+			CloseTime:  ts(baseTime.Add(10 * time.Hour)),
+			RealizedPL: m(500.00),
 			Reason:     "late",
 		},
 		{
 			TradeID:    "T1",
 			Instrument: "EUR_USD",
 			Units:      1000,
-			EntryPrice: 1.08000,
-			ExitPrice:  1.08100,
-			OpenTime:   baseTime,
-			CloseTime:  baseTime.Add(2 * time.Hour),
-			RealizedPL: 100.00,
+			EntryPrice: p(1.08000),
+			ExitPrice:  p(1.08100),
+			OpenTime:   ts(baseTime),
+			CloseTime:  ts(baseTime.Add(2 * time.Hour)),
+			RealizedPL: m(100.00),
 			Reason:     "early",
 		},
 		{
 			TradeID:    "T2",
 			Instrument: "GBP_USD",
 			Units:      500,
-			EntryPrice: 1.25000,
-			ExitPrice:  1.25200,
-			OpenTime:   baseTime,
-			CloseTime:  baseTime.Add(5 * time.Hour),
-			RealizedPL: 100.00,
+			EntryPrice: p(1.25000),
+			ExitPrice:  p(1.25200),
+			OpenTime:   ts(baseTime),
+			CloseTime:  ts(baseTime.Add(5 * time.Hour)),
+			RealizedPL: m(100.00),
 			Reason:     "middle",
 		},
 	}
@@ -244,7 +249,7 @@ func TestListTradesClosedBetweenOrdering(t *testing.T) {
 	start := baseTime
 	end := baseTime.Add(24 * time.Hour)
 
-	results, err := j.ListTradesClosedBetween(start, end)
+	results, err := j.ListTradesClosedBetween(ts(start), ts(end))
 	require.NoError(t, err)
 	require.Len(t, results, 3)
 
@@ -254,8 +259,8 @@ func TestListTradesClosedBetweenOrdering(t *testing.T) {
 	assert.Equal(t, "T3", results[2].TradeID)
 
 	// Verify times are in ascending order
-	assert.True(t, results[0].CloseTime.Before(results[1].CloseTime))
-	assert.True(t, results[1].CloseTime.Before(results[2].CloseTime))
+	assert.True(t, results[0].CloseTime < results[1].CloseTime)
+	assert.True(t, results[1].CloseTime < results[2].CloseTime)
 }
 
 func TestListTradesClosedBetweenEmpty(t *testing.T) {
@@ -268,7 +273,7 @@ func TestListTradesClosedBetweenEmpty(t *testing.T) {
 	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2024, 12, 31, 23, 59, 59, 0, time.UTC)
 
-	results, err := j.ListTradesClosedBetween(start, end)
+	results, err := j.ListTradesClosedBetween(ts(start), ts(end))
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -284,11 +289,11 @@ func TestListTradesClosedBetweenNoMatches(t *testing.T) {
 		TradeID:    "T1",
 		Instrument: "EUR_USD",
 		Units:      1000,
-		EntryPrice: 1.08000,
-		ExitPrice:  1.08100,
-		OpenTime:   time.Date(2024, 5, 1, 10, 0, 0, 0, time.UTC),
-		CloseTime:  time.Date(2024, 5, 1, 15, 0, 0, 0, time.UTC),
-		RealizedPL: 100.00,
+		EntryPrice: p(1.08000),
+		ExitPrice:  p(1.08100),
+		OpenTime:   ts(time.Date(2024, 5, 1, 10, 0, 0, 0, time.UTC)),
+		CloseTime:  ts(time.Date(2024, 5, 1, 15, 0, 0, 0, time.UTC)),
+		RealizedPL: m(100.00),
 		Reason:     "test",
 	}
 
@@ -298,7 +303,7 @@ func TestListTradesClosedBetweenNoMatches(t *testing.T) {
 	start := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC)
 
-	results, err := j.ListTradesClosedBetween(start, end)
+	results, err := j.ListTradesClosedBetween(ts(start), ts(end))
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -315,18 +320,18 @@ func TestListTradesClosedBetweenBoundaryInclusive(t *testing.T) {
 		TradeID:    "T1",
 		Instrument: "EUR_USD",
 		Units:      1000,
-		EntryPrice: 1.08000,
-		ExitPrice:  1.08100,
-		OpenTime:   baseTime,
-		CloseTime:  baseTime,
-		RealizedPL: 100.00,
+		EntryPrice: p(1.08000),
+		ExitPrice:  p(1.08100),
+		OpenTime:   ts(baseTime),
+		CloseTime:  ts(baseTime),
+		RealizedPL: m(100.00),
 		Reason:     "boundary",
 	}
 
 	require.NoError(t, j.RecordTrade(trade))
 
 	// Query with start exactly at trade close time (should be included)
-	results, err := j.ListTradesClosedBetween(baseTime, baseTime.Add(1*time.Hour))
+	results, err := j.ListTradesClosedBetween(ts(baseTime), ts(baseTime.Add(1*time.Hour)))
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, "T1", results[0].TradeID)
@@ -344,18 +349,18 @@ func TestListTradesClosedBetweenBoundaryExclusive(t *testing.T) {
 		TradeID:    "T1",
 		Instrument: "EUR_USD",
 		Units:      1000,
-		EntryPrice: 1.08000,
-		ExitPrice:  1.08100,
-		OpenTime:   baseTime,
-		CloseTime:  baseTime,
-		RealizedPL: 100.00,
+		EntryPrice: p(1.08000),
+		ExitPrice:  p(1.08100),
+		OpenTime:   ts(baseTime),
+		CloseTime:  ts(baseTime),
+		RealizedPL: m(100.00),
 		Reason:     "boundary",
 	}
 
 	require.NoError(t, j.RecordTrade(trade))
 
 	// Query with end exactly at trade close time (should be excluded)
-	results, err := j.ListTradesClosedBetween(baseTime.Add(-1*time.Hour), baseTime)
+	results, err := j.ListTradesClosedBetween(ts(baseTime.Add(-1*time.Hour)), ts(baseTime))
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -375,11 +380,11 @@ func TestListTradesClosedBetweenMultipleInstruments(t *testing.T) {
 			TradeID:    fmt.Sprintf("T%d", i+1),
 			Instrument: instrument,
 			Units:      1000,
-			EntryPrice: 1.0,
-			ExitPrice:  1.1,
-			OpenTime:   baseTime,
-			CloseTime:  baseTime.Add(time.Duration(i) * time.Hour),
-			RealizedPL: 100.00,
+			EntryPrice: p(1.0),
+			ExitPrice:  p(1.1),
+			OpenTime:   ts(baseTime),
+			CloseTime:  ts(baseTime.Add(time.Duration(i) * time.Hour)),
+			RealizedPL: m(100.00),
 			Reason:     "test",
 		}
 		require.NoError(t, j.RecordTrade(trade))
@@ -389,7 +394,7 @@ func TestListTradesClosedBetweenMultipleInstruments(t *testing.T) {
 	start := baseTime
 	end := baseTime.Add(24 * time.Hour)
 
-	results, err := j.ListTradesClosedBetween(start, end)
+	results, err := j.ListTradesClosedBetween(ts(start), ts(end))
 	require.NoError(t, err)
 	require.Len(t, results, len(instruments))
 

--- a/journal/sqlite_test.go
+++ b/journal/sqlite_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,12 +60,12 @@ func TestSQLiteRecordTrade(t *testing.T) {
 	rec := TradeRecord{
 		TradeID:    "T1",
 		Instrument: "EUR_USD",
-		Units:      123.456,
-		EntryPrice: 1.2345678,
-		ExitPrice:  1.3456789,
-		OpenTime:   open,
-		CloseTime:  closeT,
-		RealizedPL: -12.5,
+		Units:      123456,
+		EntryPrice: types.PriceFromFloat(1.2345678),
+		ExitPrice:  types.PriceFromFloat(1.3456789),
+		OpenTime:   types.FromTime(open),
+		CloseTime:  types.FromTime(closeT),
+		RealizedPL: types.MoneyFromFloat(-12.5),
 		Reason:     "test",
 	}
 
@@ -96,12 +97,12 @@ func TestSQLiteRecordTrade(t *testing.T) {
 
 	assert.Equal(t, rec.TradeID, tradeID)
 	assert.Equal(t, rec.Instrument, instrument)
-	assert.InDelta(t, rec.Units, units, 1e-6)
-	assert.InDelta(t, rec.EntryPrice, entry, 1e-9)
-	assert.InDelta(t, rec.ExitPrice, exit, 1e-9)
-	assert.True(t, openTime.Equal(rec.OpenTime))
-	assert.True(t, closeTime.Equal(rec.CloseTime))
-	assert.InDelta(t, rec.RealizedPL, realizedPL, 1e-6)
+	assert.InDelta(t, float64(rec.Units), units, 1e-6)
+	assert.InDelta(t, float64(rec.EntryPrice), entry, 1e-9)
+	assert.InDelta(t, float64(rec.ExitPrice), exit, 1e-9)
+	assert.True(t, openTime.Equal(rec.OpenTime.Time()))
+	assert.True(t, closeTime.Equal(rec.CloseTime.Time()))
+	assert.InDelta(t, float64(rec.RealizedPL), realizedPL, 1e-6)
 	assert.Equal(t, rec.Reason, reason)
 }
 
@@ -112,12 +113,12 @@ func TestSQLiteRecordEquity(t *testing.T) {
 
 	ts := time.Date(2024, 2, 3, 4, 5, 6, 0, time.UTC)
 	rec := EquitySnapshot{
-		Time:        ts,
-		Balance:     1000.1,
-		Equity:      999.9,
-		MarginUsed:  10.5,
-		FreeMargin:  989.4,
-		MarginLevel: 99.99,
+		Timestamp:   types.FromTime(ts),
+		Balance:     types.MoneyFromFloat(1000.1),
+		Equity:      types.MoneyFromFloat(999.9),
+		MarginUsed:  types.MoneyFromFloat(10.5),
+		FreeMargin:  types.MoneyFromFloat(989.4),
+		MarginLevel: types.MoneyFromFloat(99.99),
 	}
 
 	assert.NoError(t, j.RecordEquity(rec))
@@ -143,10 +144,10 @@ func TestSQLiteRecordEquity(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	assert.True(t, gotTime.Equal(rec.Time))
-	assert.InDelta(t, rec.Balance, balance, 1e-6)
-	assert.InDelta(t, rec.Equity, equity, 1e-6)
-	assert.InDelta(t, rec.MarginUsed, marginUsed, 1e-6)
-	assert.InDelta(t, rec.FreeMargin, freeMargin, 1e-6)
-	assert.InDelta(t, rec.MarginLevel, marginLevel, 1e-6)
+	assert.True(t, gotTime.Equal(rec.Timestamp.Time()))
+	assert.InDelta(t, float64(rec.Balance), balance, 1e-6)
+	assert.InDelta(t, float64(rec.Equity), equity, 1e-6)
+	assert.InDelta(t, float64(rec.MarginUsed), marginUsed, 1e-6)
+	assert.InDelta(t, float64(rec.FreeMargin), freeMargin, 1e-6)
+	assert.InDelta(t, float64(rec.MarginLevel), marginLevel, 1e-6)
 }

--- a/market/candle_test.go
+++ b/market/candle_test.go
@@ -1,29 +1,33 @@
 package market
 
 import (
+	"os"
 	"testing"
 
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 )
 
-var cs *CandleSet
-
-func init() {
-	var err error
-
+func loadCandleSet(t *testing.T) *CandleSet {
+	t.Helper()
 	fname := "../testdata/DAT_ASCII_EURUSD_M1_2025.csv"
-	cs, err = NewCandleSet(fname)
-	if err != nil {
-		panic(err)
+	if _, err := os.Stat(fname); err != nil {
+		t.Skip("candle test dataset missing")
 	}
+	set, err := NewCandleSet(fname)
+	if err != nil {
+		t.Fatalf("failed to load candle set: %v", err)
+	}
+	return set
 }
 
 func TestIterator(t *testing.T) {
+	cs := loadCandleSet(t)
 
 	expected := OHLC{O: 1035030, H: 1035140, L: 1035030, C: 1035140}
 	it := cs.Iterator()
 	it.Next()
-	assert.Equal(t, Timestamp(1735768800), it.StartTime())
+	assert.Equal(t, types.Timestamp(1735768800), it.StartTime())
 
 	ca := it.Candle()
 	assert.Equal(t, expected, ca)
@@ -37,6 +41,7 @@ func TestIterator(t *testing.T) {
 }
 
 func TestReadCandleSetFile(t *testing.T) {
+	cs := loadCandleSet(t)
 	s := cs.Stats()
 	assert.Equal(t, 524158, s.TotalMinutes)
 	assert.Equal(t, 372024, s.PresentMinutes)
@@ -47,6 +52,7 @@ func TestReadCandleSetFile(t *testing.T) {
 }
 
 func TestAggregateH1(t *testing.T) {
+	cs := loadCandleSet(t)
 	h1 := cs.AggregateH1(50)
 	h1.BuildGapReport()
 	s := h1.Stats()

--- a/market/conversion.go
+++ b/market/conversion.go
@@ -1,1 +1,32 @@
 package market
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/types"
+)
+
+func QuoteToAccountRate(instrument string, accountCurrency string, prices TickSource) (float64, error) {
+	meta, ok := Instruments[instrument]
+	if !ok {
+		return 0, fmt.Errorf("unknown instrument %s", instrument)
+	}
+
+	if meta.QuoteCurrency == accountCurrency {
+		return 1.0, nil
+	}
+
+	if meta.BaseCurrency == accountCurrency {
+		px, err := prices.GetTick(nil, instrument)
+		if err != nil {
+			return 0, err
+		}
+		mid := float64(px.Mid()) / float64(types.PriceScale)
+		if mid <= 0 {
+			return 0, fmt.Errorf("invalid mid price for %s", instrument)
+		}
+		return 1.0 / mid, nil
+	}
+
+	return 0, fmt.Errorf("cross conversion not implemented for %s -> %s", meta.QuoteCurrency, accountCurrency)
+}

--- a/market/conversion_test.go
+++ b/market/conversion_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -90,7 +91,7 @@ func TestQuoteToAccountRate_BaseEqualsAccount(t *testing.T) {
 	rate, err := QuoteToAccountRate(instrument, "USD", ps)
 	assert.NoError(t, err)
 
-	expected := 1.0 / ps.price.Mid()
+	expected := 1.0 / (float64(ps.price.Mid()) / float64(types.PriceScale))
 	assert.InDelta(t, expected, rate, 1e-9)
 	assert.Equal(t, 1, ps.called)
 	assert.Equal(t, instrument, ps.lastInstrument)

--- a/market/indicators/adx_test.go
+++ b/market/indicators/adx_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/require"
 )
 
 func mkCandle(scale int32, o, h, l, c float64) market.OHLC {
-	toP := func(x float64) market.Price { return market.Price(x*float64(scale) + 0.5) }
+	toP := func(x float64) types.Price { return types.Price(x*float64(scale) + 0.5) }
 	return market.OHLC{
 		O: toP(o),
 		H: toP(h),

--- a/market/indicators/ema_test.go
+++ b/market/indicators/ema_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/require"
 )
 
 // helper to create a candle with close only
 func candle(close float64, scale int32) market.OHLC {
 	return market.OHLC{
-		C: market.Price(close * float64(scale)),
+		C: types.Price(close * float64(scale)),
 	}
 }
 

--- a/market/strategies/ema_cross_adx_test.go
+++ b/market/strategies/ema_cross_adx_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/require"
 )
 
 func mkOHLC(scale int32, o, h, l, c float64) market.OHLC {
-	toP := func(x float64) market.Price { return market.Price(x*float64(scale) + 0.5) }
+	toP := func(x float64) types.Price { return types.Price(x*float64(scale) + 0.5) }
 	return market.OHLC{
 		O: toP(o),
 		H: toP(h),

--- a/market/strategies/open_once_test.go
+++ b/market/strategies/open_once_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rustyeddy/trader/broker"
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,22 +47,21 @@ func TestOpenOnceStrategy_OnTick_Success(t *testing.T) {
 
 	strat := &OpenOnceStrategy{
 		Instrument: "EUR_USD",
-		Units:      1000,
+		Units:      types.Units(1000),
 	}
 
 	// First tick should open the order
 	tick := market.Tick{
 		Instrument: "EUR_USD",
-		Bid:        1.0850,
-		Ask:        1.0852,
-		Time:       time.Now(),
+		Timestamp:  types.FromTime(time.Now()),
+		BA:         market.BA{Bid: types.PriceFromFloat(1.0850), Ask: types.PriceFromFloat(1.0852)},
 	}
 
 	err := strat.OnTick(ctx, mock, tick)
 	require.NoError(t, err)
 	assert.True(t, mock.createOrderCalled)
 	assert.Equal(t, "EUR_USD", mock.lastRequest.Instrument)
-	assert.Equal(t, 1000.0, mock.lastRequest.Units)
+	assert.Equal(t, types.Units(1000), mock.lastRequest.Units)
 	assert.True(t, strat.opened)
 
 	// Second tick should do nothing (already opened)
@@ -77,15 +77,14 @@ func TestOpenOnceStrategy_OnTick_WrongInstrument(t *testing.T) {
 
 	strat := &OpenOnceStrategy{
 		Instrument: "EUR_USD",
-		Units:      1000,
+		Units:      types.Units(1000),
 	}
 
 	// Tick with different instrument should be ignored
 	tick := market.Tick{
 		Instrument: "GBP_USD",
-		Bid:        1.2500,
-		Ask:        1.2502,
-		Time:       time.Now(),
+		Timestamp:  types.FromTime(time.Now()),
+		BA:         market.BA{Bid: types.PriceFromFloat(1.2500), Ask: types.PriceFromFloat(1.2502)},
 	}
 
 	err := strat.OnTick(ctx, mock, tick)
@@ -105,9 +104,8 @@ func TestOpenOnceStrategy_OnTick_ZeroUnits(t *testing.T) {
 
 	tick := market.Tick{
 		Instrument: "EUR_USD",
-		Bid:        1.0850,
-		Ask:        1.0852,
-		Time:       time.Now(),
+		Timestamp:  types.FromTime(time.Now()),
+		BA:         market.BA{Bid: types.PriceFromFloat(1.0850), Ask: types.PriceFromFloat(1.0852)},
 	}
 
 	err := strat.OnTick(ctx, mock, tick)
@@ -124,14 +122,13 @@ func TestOpenOnceStrategy_OnTick_BrokerError(t *testing.T) {
 
 	strat := &OpenOnceStrategy{
 		Instrument: "EUR_USD",
-		Units:      1000,
+		Units:      types.Units(1000),
 	}
 
 	tick := market.Tick{
 		Instrument: "EUR_USD",
-		Bid:        1.0850,
-		Ask:        1.0852,
-		Time:       time.Now(),
+		Timestamp:  types.FromTime(time.Now()),
+		BA:         market.BA{Bid: types.PriceFromFloat(1.0850), Ask: types.PriceFromFloat(1.0852)},
 	}
 
 	err := strat.OnTick(ctx, mock, tick)
@@ -147,19 +144,18 @@ func TestOpenOnceStrategy_OnTick_NegativeUnits(t *testing.T) {
 
 	strat := &OpenOnceStrategy{
 		Instrument: "EUR_USD",
-		Units:      -500, // Negative units for short position
+		Units:      types.Units(-500), // Negative units for short position
 	}
 
 	tick := market.Tick{
 		Instrument: "EUR_USD",
-		Bid:        1.0850,
-		Ask:        1.0852,
-		Time:       time.Now(),
+		Timestamp:  types.FromTime(time.Now()),
+		BA:         market.BA{Bid: types.PriceFromFloat(1.0850), Ask: types.PriceFromFloat(1.0852)},
 	}
 
 	err := strat.OnTick(ctx, mock, tick)
 	require.NoError(t, err)
 	assert.True(t, mock.createOrderCalled)
-	assert.Equal(t, -500.0, mock.lastRequest.Units)
+	assert.Equal(t, types.Units(-500), mock.lastRequest.Units)
 	assert.True(t, strat.opened)
 }

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rustyeddy/trader/broker"
 	"github.com/rustyeddy/trader/broker/sim"
 	"github.com/rustyeddy/trader/market"
+	"github.com/rustyeddy/trader/types"
 )
 
 // Options controls how replay behaves.
@@ -106,10 +107,12 @@ func handleReplayRow(ctx context.Context, engine *sim.Engine, row []string, opts
 	}
 
 	price := market.Tick{
-		Time:       t,
+		Timestamp:  types.FromTime(t),
 		Instrument: inst,
-		Bid:        bid,
-		Ask:        ask,
+		BA: market.BA{
+			Bid: types.PriceFromFloat(bid),
+			Ask: types.PriceFromFloat(ask),
+		},
 	}
 
 	// Optional event columns: event,arg1,arg2,arg3,arg4...
@@ -154,7 +157,7 @@ func handleEvent(ctx context.Context, engine *sim.Engine, event string, args []s
 		}
 		_, err = engine.CreateMarketOrder(ctx, broker.MarketOrderRequest{
 			Instrument: inst,
-			Units:      units,
+			Units:      types.Units(units),
 		})
 		return err
 
@@ -167,10 +170,12 @@ func handleEvent(ctx context.Context, engine *sim.Engine, event string, args []s
 
 		req := broker.MarketOrderRequest{
 			Instrument: inst,
-			Units:      units,
-			StopLoss:   &sl,
-			TakeProfit: &tp,
+			Units:      types.Units(units),
 		}
+		slp := types.PriceFromFloat(sl)
+		tpp := types.PriceFromFloat(tp)
+		req.StopLoss = &slp
+		req.TakeProfit = &tpp
 
 		_, err = engine.CreateMarketOrder(ctx, req)
 		return err

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rustyeddy/trader/broker"
 	"github.com/rustyeddy/trader/broker/sim"
 	"github.com/rustyeddy/trader/journal"
+	"github.com/rustyeddy/trader/types"
 )
 
 // If your journal uses a different driver name, adjust this.
@@ -70,7 +71,7 @@ func TestReplay_OPEN_SLTP_TakeProfit(t *testing.T) {
 	}
 	defer j.Close()
 
-	startBal := 100_000.0
+	startBal := types.Money(100_000)
 	engine := sim.NewEngine(broker.Account{
 		ID:       "SIM-TEST",
 		Currency: "USD",
@@ -84,7 +85,7 @@ func TestReplay_OPEN_SLTP_TakeProfit(t *testing.T) {
 
 	acct, _ := engine.GetAccount(ctx)
 	if acct.Balance <= startBal {
-		t.Fatalf("expected balance to increase, start=%.2f end=%.2f", startBal, acct.Balance)
+		t.Fatalf("expected balance to increase, start=%.2f end=%.2f", startBal.Float64(), acct.Balance.Float64())
 	}
 
 	// Validate at least one trade row exists and reason indicates TP.


### PR DESCRIPTION
## Summary
- refactor code paths and tests to consistently use  primitives where applicable
- update tick/replay/backtest/journal integrations to current typed APIs
- modernize examples to compile against current interfaces
- fix journal query scan/conversion handling for typed trade records

## Validation
- ok  	github.com/rustyeddy/trader/backtest	(cached)
ok  	github.com/rustyeddy/trader/broker	(cached)
ok  	github.com/rustyeddy/trader/broker/oanda	(cached)
ok  	github.com/rustyeddy/trader/broker/sim	(cached)
?   	github.com/rustyeddy/trader/cmd	[no test files]
?   	github.com/rustyeddy/trader/cmd/backtest	[no test files]
?   	github.com/rustyeddy/trader/cmd/config	[no test files]
?   	github.com/rustyeddy/trader/cmd/replay	[no test files]
?   	github.com/rustyeddy/trader/cmd/trade	[no test files]
ok  	github.com/rustyeddy/trader/config	(cached)
?   	github.com/rustyeddy/trader/examples/basic	[no test files]
?   	github.com/rustyeddy/trader/examples/multiple	[no test files]
?   	github.com/rustyeddy/trader/examples/risk	[no test files]
?   	github.com/rustyeddy/trader/examples/simrun	[no test files]
ok  	github.com/rustyeddy/trader/journal	(cached)
ok  	github.com/rustyeddy/trader/market	(cached)
?   	github.com/rustyeddy/trader/market/data	[no test files]
ok  	github.com/rustyeddy/trader/market/indicators	(cached)
ok  	github.com/rustyeddy/trader/market/strategies	(cached)
ok  	github.com/rustyeddy/trader/replay	(cached)
ok  	github.com/rustyeddy/trader/risk	(cached)
ok  	github.com/rustyeddy/trader/types	(cached)
- ok  	github.com/rustyeddy/trader/backtest	0.147s
ok  	github.com/rustyeddy/trader/broker	0.003s
ok  	github.com/rustyeddy/trader/broker/oanda	0.008s
ok  	github.com/rustyeddy/trader/broker/sim	0.008s
?   	github.com/rustyeddy/trader/cmd	[no test files]
?   	github.com/rustyeddy/trader/cmd/backtest	[no test files]
?   	github.com/rustyeddy/trader/cmd/config	[no test files]
?   	github.com/rustyeddy/trader/cmd/replay	[no test files]
?   	github.com/rustyeddy/trader/cmd/trade	[no test files]
ok  	github.com/rustyeddy/trader/config	0.006s
?   	github.com/rustyeddy/trader/examples/basic	[no test files]
?   	github.com/rustyeddy/trader/examples/multiple	[no test files]
?   	github.com/rustyeddy/trader/examples/risk	[no test files]
?   	github.com/rustyeddy/trader/examples/simrun	[no test files]
ok  	github.com/rustyeddy/trader/journal	0.208s
ok  	github.com/rustyeddy/trader/market	0.004s
?   	github.com/rustyeddy/trader/market/data	[no test files]
ok  	github.com/rustyeddy/trader/market/indicators	0.004s
ok  	github.com/rustyeddy/trader/market/strategies	0.009s
ok  	github.com/rustyeddy/trader/replay	0.037s
ok  	github.com/rustyeddy/trader/risk	0.004s
ok  	github.com/rustyeddy/trader/types	0.004s
- 