### PR TITLE
M1-01a: validate Price scale across asset classes (#33)

### DIFF
--- a/docs/arch/adr-004-exact-numeric-representation.org
+++ b/docs/arch/adr-004-exact-numeric-representation.org
@@ -75,11 +75,14 @@ The validation evidence is in =test/internal/numericstudy=, a test-only spike th
 parses and formats decimal text directly to and from scaled =int64= without
 passing through =float64=.
 
-No test compares the generated tables against the text below, so these tables
-can drift; regenerate and re-paste them whenever the asset matrix changes:
+Every table below sits between =# BEGIN numericstudy:= and =# END
+numericstudy:= markers and is generated from that package.
+=TestGeneratedTables= fails if any region no longer matches what the code
+produces, so these tables cannot drift from the evidence.  Do not hand-edit
+inside the markers; regenerate instead:
 
 #+begin_src sh
-go test ./test/internal/numericstudy/ -run TestGenerateReport -v
+go test ./test/internal/numericstudy/ -run TestGeneratedTables -update
 #+end_src
 
 **** Asset representation matrix
@@ -88,18 +91,20 @@ Stored =int64= at each candidate scale.  =—= means the value needs more
 decimal places than the scale can hold, and is therefore rejected rather than
 silently rounded.
 
-| Class   | Symbol    |          Price |       Tick | Dec |     1e5 |          1e6 |            1e8 |             1e9 |
-|---------+-----------+----------------+------------+-----+---------+--------------+----------------+-----------------|
-| FX      | EUR/USD   |        1.08473 |    0.00001 |   5 |  108473 |      1084730 |      108473000 |      1084730000 |
-| FX      | USD/JPY   |        147.325 |      0.001 |   3 | 14732500 |    147325000 |    14732500000 |    147325000000 |
-| Equity  | SPY       |         700.12 |       0.01 |   2 | 70012000 |    700120000 |    70012000000 |    700120000000 |
-| Equity  | BRK.A     |      750000.00 |       0.01 |   2 | 75000000000 | 750000000000 | 75000000000000 | 750000000000000 |
-| Equity  | sub-penny |         0.0001 |     0.0001 |   4 |      10 |          100 |          10000 |          100000 |
-| Futures | ES        |        6250.25 |       0.25 |   2 | 625025000 |   6250250000 |   625025000000 |   6250250000000 |
-| Futures | ZN        |     110.515625 |   0.015625 |   6 |       — |    110515625 |    11051562500 |    110515625000 |
-| Crypto  | BTC/USD   | 150000.12345678 | 0.00000001 |  8 |       — |            — | 15000012345678 | 150000123456780 |
-| Crypto  | SHIB/USD  |     0.00000001 | 0.00000001 |   8 |       — |            — |              1 |              10 |
-| Rate    | financing |       0.000125 |   0.000001 |   6 |       — |          125 |          12500 |          125000 |
+# BEGIN numericstudy:asset-matrix
+| Class   | Symbol    |           Price |       Tick | Dec |         1e5 |          1e6 |            1e8 |             1e9 |
+|---------+-----------+-----------------+------------+-----+-------------+--------------+----------------+-----------------|
+| FX      | EUR/USD   |         1.08473 |    0.00001 |   5 |      108473 |      1084730 |      108473000 |      1084730000 |
+| FX      | USD/JPY   |         147.325 |      0.001 |   3 |    14732500 |    147325000 |    14732500000 |    147325000000 |
+| Equity  | SPY       |          700.12 |       0.01 |   2 |    70012000 |    700120000 |    70012000000 |    700120000000 |
+| Equity  | BRK.A     |       750000.00 |       0.01 |   2 | 75000000000 | 750000000000 | 75000000000000 | 750000000000000 |
+| Equity  | SUB-PENNY |          0.0001 |     0.0001 |   4 |          10 |          100 |          10000 |          100000 |
+| Futures | ES        |         6250.25 |       0.25 |   2 |   625025000 |   6250250000 |   625025000000 |   6250250000000 |
+| Futures | ZN        |      110.515625 |   0.015625 |   6 |           — |    110515625 |    11051562500 |    110515625000 |
+| Crypto  | BTC/USD   | 150000.12345678 | 0.00000001 |   8 |           — |            — | 15000012345678 | 150000123456780 |
+| Crypto  | SHIB/USD  |      0.00000001 | 0.00000001 |   8 |           — |            — |              1 |              10 |
+| Rate    | FINANCING |        0.000125 |   0.000001 |   6 |           — |          125 |          12500 |          125000 |
+# END numericstudy:asset-matrix
 
 1e5 and 1e6 are disqualified outright: neither can represent satoshi
 precision, and 1e5 cannot represent the 64ths that Treasury futures expand to.
@@ -107,12 +112,14 @@ Both 1e8 and 1e9 represent every intended asset class exactly.
 
 **** Range and headroom
 
-| Scale | Decimals |      Max price |  Smallest unit | Headroom over 750000.00 |
-|-------+----------+----------------+----------------+-------------------------|
-| 1e5   |        5 | 92,233,720,368,547 |        0.00001 |           122,978,293 x |
-| 1e6   |        6 |  9,223,372,036,854 |       0.000001 |            12,297,829 x |
-| 1e8   |        8 |     92,233,720,368 |     0.00000001 |               122,978 x |
-| 1e9   |        9 |      9,223,372,036 |    0.000000001 |                12,297 x |
+# BEGIN numericstudy:range-headroom
+| Scale | Decimals |          Max price | Smallest unit | Headroom over 750000.00 |
+|-------+----------+--------------------+---------------+-------------------------|
+| 1e5   |        5 | 92,233,720,368,547 |       0.00001 |            122,978,293x |
+| 1e6   |        6 |  9,223,372,036,854 |      0.000001 |             12,297,829x |
+| 1e8   |        8 |     92,233,720,368 |    0.00000001 |                122,978x |
+| 1e9   |        9 |      9,223,372,036 |   0.000000001 |                 12,297x |
+# END numericstudy:range-headroom
 
 At 1e8 the maximum representable price is ~92.2 billion, roughly 122,000x the
 highest-priced listed equity.  Storage range is not the binding constraint at
@@ -124,12 +131,15 @@ Intermediate arithmetic decides it.  Margin to the =int64= ceiling for
 =Price x Quantity=, using whole unscaled quantities so only one operand
 carries a scale and no descaling divide is required:
 
-| Case             |      Quantity |     1e8 |   1e9 |
-|------------------+---------------+---------+-------|
-| BRK.A block      |        10,000 |    12 x |   1 x |
-| FX 10M notional  |    10,000,000 |  8503 x | 850 x |
-| FX 1B notional   | 1,000,000,000 |    85 x |   9 x |
-| BTC 1k coins     |         1,000 |   615 x |  61 x |
+# BEGIN numericstudy:notional-8v9
+| Case            |          Quantity |        1e8 |      1e9 |
+|-----------------+-------------------+------------+----------|
+| BRK.A block     |            10,000 |        12x |       1x |
+| FX 10M notional |        10,000,000 |     8,502x |     850x |
+| FX 1B notional  |     1,000,000,000 |        85x |       8x |
+| BTC 1k coins    |             1,000 |       614x |      61x |
+| SHIB 1e12 units | 1,000,000,000,000 | 9,223,372x | 922,337x |
+# END numericstudy:notional-8v9
 
 1e9 leaves the largest realistic notional essentially at the ceiling — a
 BRK.A-sized block consumes the entire =int64= range with 1x to spare.  1e8
@@ -143,6 +153,22 @@ like =Price x Rate=, the margins above no longer apply, and the operation
 requires a widened intermediate regardless of price scale.  That would not
 change the 1e8 selection — it still beats 1e9 by 10x — but it would move
 =Price x Quantity= from "safe in =int64=" to "must use the widened path".
+
+***** Margins at every candidate scale
+
+For completeness, the same product margins across all four candidates.  The
+=n/a= cells are assets the narrow scales cannot represent at all, which is why
+their apparently generous margins are not evidence of safety.
+
+# BEGIN numericstudy:notional-all
+| Case            |          Quantity |        1e5 |      1e6 |        1e8 |      1e9 |
+|-----------------+-------------------+------------+----------+------------+----------|
+| BRK.A block     |            10,000 |    12,297x |   1,229x |        12x |       1x |
+| FX 10M notional |        10,000,000 | 8,502,919x | 850,291x |     8,502x |     850x |
+| FX 1B notional  |     1,000,000,000 |    85,029x |   8,502x |        85x |       8x |
+| BTC 1k coins    |             1,000 |        n/a |      n/a |       614x |      61x |
+| SHIB 1e12 units | 1,000,000,000,000 |        n/a |      n/a | 9,223,372x | 922,337x |
+# END numericstudy:notional-all
 
 **** Consequences for intermediate arithmetic
 
@@ -160,10 +186,14 @@ Two findings belong to [[https://github.com/rustyeddy/trader/issues/38][#38]] an
    months of M1 data.  Rolling sums and averages need a widened accumulator or
    a running-mean formulation, not a raw =int64= total.
 
+# BEGIN numericstudy:rolling-sum
 | Scale | Bars of 750000.00 before overflow |
 |-------+-----------------------------------|
+| 1e5   |                       122,978,293 |
+| 1e6   |                        12,297,829 |
 | 1e8   |                           122,978 |
 | 1e9   |                            12,297 |
+# END numericstudy:rolling-sum
 
 **** Tick size stays separate from scale
 
@@ -180,13 +210,15 @@ These are provider quotation *conventions*, not decimal numbers.  Each must be
 normalized to plain decimal text in a provider adapter before reaching =Price=;
 the parser rejects all of them.
 
-| Format                       | Example       | Normalizes to | Reason                                              |
-|------------------------------+---------------+---------------+-----------------------------------------------------|
-| Treasury 32nds               | =110-16=      |         110.5 | =-= is a fraction separator, not a sign             |
-| Treasury 32nds + halves      | =110-16.5=    |    110.515625 | expands to 64ths; needs 6 decimals                  |
-| Grain eighths                | =575'6=       |        575.75 | apostrophe-delimited eighths of a cent              |
-| Scientific notation          | =1.5e-7=      |    0.00000015 | exponent form rejected; expand before parsing       |
-| Grouped thousands            | =750,000.00=  |     750000.00 | locale grouping is display, not exact input         |
+# BEGIN numericstudy:unsupported
+| Format                              | Example      | Normalizes to | Reason                                                    |
+|-------------------------------------+--------------+---------------+-----------------------------------------------------------|
+| Treasury 32nds (dash)               | =110-16=     |         110.5 | not decimal text; '-' is a fraction separator, not a sign |
+| Treasury 32nds plus halves/quarters | =110-16.5=   |    110.515625 | fraction of a 32nd; expands to 64ths, needing 6 decimals  |
+| Grain fractions in eighths          | =575'6=      |        575.75 | apostrophe-delimited eighths of a cent                    |
+| Scientific notation                 | =1.5e-7=     |    0.00000015 | exponent form is rejected; expand before parsing          |
+| Grouped thousands                   | =750,000.00= |     750000.00 | locale grouping is a display concern, not an exact input  |
+# END numericstudy:unsupported
 
 All of these are representable once normalized, so no intended instrument is
 excluded by the 1e8 choice — the constraint is on the adapter layer, not the
@@ -199,11 +231,13 @@ satisfies the precision policy.  Values finer than the 1e8 quantum are
 syntactically valid but not representable, and are rejected rather than
 silently rounded:
 
-| Value         | Digits | Note                                        |
-|---------------+--------+---------------------------------------------|
-| =0.000000015= |      9 | =1.5e-8= expanded; half of the 1e8 quantum  |
-| =0.000000001= |      9 | one 1e9 unit; below the 1e8 quantum         |
-| =1.000000005= |      9 | ordinary price carrying one digit too many  |
+# BEGIN numericstudy:subquantum
+| Value         | Digits | Note                                         |
+|---------------+--------+----------------------------------------------|
+| =0.000000015= |      9 | 1.5e-8 expanded; half of the 1e8 quantum     |
+| =0.000000001= |      9 | one 1e9 unit; below the 1e8 quantum entirely |
+| =1.000000005= |      9 | ordinary price carrying one digit too many   |
+# END numericstudy:subquantum
 
 Each is accepted at 1e9, confirming the failure is the precision policy rather
 than a parser defect (=TestSubQuantumValuesRejected=).  Whether adapters reject

--- a/docs/arch/adr-004-exact-numeric-representation.org
+++ b/docs/arch/adr-004-exact-numeric-representation.org
@@ -1,0 +1,191 @@
+#+title: ADR-004 Exact Numeric Representation
+#+startup: overview
+
+* Status
+
+Proposed
+
+Parent decision: [[https://github.com/rustyeddy/trader/issues/19][#19 — M1-01 Decide exact numeric representation]]
+
+This working ADR records decisions as the numeric-design sub-issues are resolved.
+It remains =Proposed= until [[https://github.com/rustyeddy/trader/issues/44][#44]] consolidates the evidence, completes the alternatives and consequences,
+and marks the decision =Accepted=.
+
+* Context
+
+Trader must represent authoritative prices, money, quantities, rates, balances,
+fees, margin, order values, fill values, and PnL without relying on binary
+floating-point approximation.  These values must round-trip through broker,
+configuration, storage, journal, and reporting boundaries while preserving
+clear domain semantics.
+
+Trader is intended to support more than FX.  The representation must be
+validated against equities, ETFs, futures, high-priced assets, large FX
+positions, fractional quantities, and small fees or financing values.
+
+The legacy Trader repository already contains scaled-integer =Price=, =Money=,
+=Rate=, accumulators, and fixed-point indicator implementations.  Under
+ADR-013, that repository is a selective code donor and behavior reference,
+not a dependency of the new Trader.
+
+* Decisions Reached
+
+** Authoritative backing representation
+
+Decision source: [[https://github.com/rustyeddy/trader/issues/19][#19]]
+
+The authoritative foundational numeric types use scaled signed =int64= values.
+
+The initial semantic types are:
+
+- =Price=
+- =Money=
+- =Quantity=
+- =Rate=
+
+=Currency= remains a separate domain concept used with =Money=; the precise
+ownership relationship is still open in [[https://github.com/rustyeddy/trader/issues/35][#35]].
+
+The public API must not expose one generic decimal type in place of these
+semantic types.  Distinct types prevent accidental substitution of price,
+quantity, money, and rate values.
+
+** Price representation versus instrument rules
+
+Decision source: [[https://github.com/rustyeddy/trader/issues/33][#33]]
+
+=Price= will use a fixed internal representation scale.  Instrument-specific
+market rules remain separate:
+
+- tick size
+- permitted price increment
+- display precision
+- provider quotation format
+
+The internal representation scale is not itself the instrument tick size.
+The final scale and supported range remain to be validated in #33 against FX,
+equities, futures, high-priced assets, and small-priced assets.
+
+** Exact input and output boundaries
+
+Decision source: [[https://github.com/rustyeddy/trader/issues/39][#39]]
+
+Decimal text and raw scaled integers are the preferred exact construction and
+serialization boundaries.  Parsing and formatting should avoid conversion
+through binary =float64= whenever practical.
+
+Any =float64= constructor retained for adapter interoperability must be
+explicitly named as a rounded or lossy boundary conversion.  It must not be the
+preferred path for configuration, broker decimal strings, persistence, or
+journal records.
+
+** Indicator arithmetic is not yet globally fixed
+
+Decision source: [[https://github.com/rustyeddy/trader/issues/41][#41]]
+
+The authoritative domain types remain scaled integers regardless of how an
+indicator performs internal analytical arithmetic.
+
+The fixed-point versus =float64= choice will be made per indicator
+implementation, not per invocation.  Public callers should pass and receive
+semantic Trader types where appropriate; callers should not manually perform
+representation conversions at every indicator call site.
+
+Alternative fixed-point and floating-point implementations may coexist
+internally while evidence is gathered.  Numeric representation should not be
+used as the permanent public package boundary unless a later decision finds a
+compelling reason.
+
+* Open Decision Work
+
+The following issues must be resolved before this ADR can be accepted:
+
+- [[https://github.com/rustyeddy/trader/issues/33][#33 — Validate Price scale across supported asset classes]]
+- [[https://github.com/rustyeddy/trader/issues/35][#35 — Decide Money currency ownership and arithmetic semantics]]
+- [[https://github.com/rustyeddy/trader/issues/36][#36 — Decide Quantity precision and asset constraints]]
+- [[https://github.com/rustyeddy/trader/issues/37][#37 — Define numeric type decision matrix]]
+- [[https://github.com/rustyeddy/trader/issues/38][#38 — Define rounding, overflow, and intermediate arithmetic policy]]
+- [[https://github.com/rustyeddy/trader/issues/39][#39 — Define exact parsing and formatting policy]]
+- [[https://github.com/rustyeddy/trader/issues/40][#40 — Define numeric serialization and persistence representation]]
+- [[https://github.com/rustyeddy/trader/issues/41][#41 — Define indicator fixed-point versus float64 policy]]
+- [[https://github.com/rustyeddy/trader/issues/42][#42 — Define numeric determinism guarantees]]
+- [[https://github.com/rustyeddy/trader/issues/43][#43 — Review reusable legacy Trader numeric code]]
+- [[https://github.com/rustyeddy/trader/issues/44][#44 — Draft and accept exact numeric representation ADR]]
+
+* Provisional Decision Matrix
+
+The unresolved cells must be completed by #33 and #35–#42.
+
+| Type     | Backing | Scale                  | Related metadata              | Current arithmetic direction |
+|----------+---------+------------------------+-------------------------------+------------------------------|
+| Price    | int64   | Fixed; value TBD       | Tick size belongs to listing  | Exact typed operations       |
+| Money    | int64   | TBD                    | Currency ownership TBD        | Cross-currency math forbidden|
+| Quantity | int64   | Fixed strategy TBD      | Increment belongs to listing  | Exact typed operations       |
+| Rate     | int64   | TBD                    | Semantic unit documented      | Explicit multiply/divide     |
+
+For every type, the final matrix must specify:
+
+- representation scale
+- signedness and zero-value policy
+- supported range
+- valid and intentionally absent operations
+- rounding rules
+- overflow behavior
+- parsing and formatting
+- JSON, text, CSV, configuration, and persistence representation
+
+* Consequences Identified So Far
+
+- Authoritative financial values do not depend on binary floating-point
+  representation.
+- Public APIs distinguish price, money, quantity, and rate at compile time.
+- Instrument tick size and quantity increment must be validated separately
+  from internal numeric scale.
+- Multiplication and division require explicit scale restoration, rounding,
+  and overflow handling.
+- Indicator implementations may choose different internal arithmetic while
+  retaining semantic public contracts.
+- Legacy fixed-point code and tests can be reused only after multi-asset and
+  package-boundary review.
+
+* Alternatives Under Consideration
+
+** Arbitrary-precision or third-party decimal throughout
+
+Not selected as the current direction.  It may simplify some decimal
+operations but risks exposing a third-party representation in public APIs and
+may add allocation and performance costs.  #43 must record whether any legacy
+or third-party helpers are still useful internally.
+
+** Raw float64 throughout
+
+Rejected for authoritative values because it cannot provide exact decimal
+broker and accounting semantics.
+
+** One generic decimal domain type
+
+Rejected as the primary public API because it permits accidental interchange
+of price, money, quantity, and rate values.
+
+** Fixed-point arithmetic for every indicator
+
+Not yet accepted or rejected.  #41 will determine when fixed-point behavior
+provides enough determinism or decision-boundary value to justify its added
+complexity.
+
+* Acceptance Gate
+
+ADR-004 may move from =Proposed= to =Accepted= only when:
+
+- #33 and #35–#43 are resolved or explicitly deferred with rationale.
+- Final scales and supported ranges are documented.
+- Money currency ownership and quantity semantics are decided.
+- The numeric decision matrix is complete.
+- Rounding, overflow, and intermediate arithmetic rules are explicit.
+- Exact parsing, formatting, serialization, and persistence formats are set.
+- Indicator arithmetic and determinism policies are set.
+- Legacy code has a documented transplant/adapt/reference/reject disposition.
+- Representative multi-asset evidence supports the decision.
+- #22 can implement the foundational types without reopening these decisions.
+- #44 reviews this record, integrates it into the canonical ADR registry, and
+  marks the ADR =Accepted=.

--- a/docs/arch/adr-004-exact-numeric-representation.org
+++ b/docs/arch/adr-004-exact-numeric-representation.org
@@ -7,26 +7,28 @@ Proposed
 
 Parent decision: [[https://github.com/rustyeddy/trader/issues/19][#19 — M1-01 Decide exact numeric representation]]
 
-This working ADR records decisions as the numeric-design sub-issues are resolved.
-It remains =Proposed= until [[https://github.com/rustyeddy/trader/issues/44][#44]] consolidates the evidence, completes the alternatives and consequences,
-and marks the decision =Accepted=.
+This working ADR records decisions as the numeric-design sub-issues
+are resolved.  It remains =Proposed= until [[https://github.com/rustyeddy/trader/issues/44][#44]] consolidates the
+evidence, completes the alternatives and consequences, and marks the
+decision =Accepted=.
 
 * Context
 
-Trader must represent authoritative prices, money, quantities, rates, balances,
-fees, margin, order values, fill values, and PnL without relying on binary
-floating-point approximation.  These values must round-trip through broker,
-configuration, storage, journal, and reporting boundaries while preserving
-clear domain semantics.
+Trader must represent authoritative prices, money, quantities, rates,
+balances, fees, margin, order values, fill values, and PnL without
+relying on binary floating-point approximation.  These values must
+round-trip through broker, configuration, storage, journal, and
+reporting boundaries while preserving clear domain semantics.
 
-Trader is intended to support more than FX.  The representation must be
-validated against equities, ETFs, futures, high-priced assets, large FX
-positions, fractional quantities, and small fees or financing values.
+Trader is intended to support more than FX.  The representation must
+be validated against equities, ETFs, futures, high-priced assets,
+large FX positions, fractional quantities, and small fees or financing
+values.
 
-The legacy Trader repository already contains scaled-integer =Price=, =Money=,
-=Rate=, accumulators, and fixed-point indicator implementations.  Under
-ADR-013, that repository is a selective code donor and behavior reference,
-not a dependency of the new Trader.
+The legacy Trader repository already contains scaled-integer =Price=,
+=Money=, =Rate=, accumulators, and fixed-point indicator
+implementations.  Under ADR-013, that repository is a selective code
+donor and behavior reference, not a dependency of the new Trader.
 
 * Decisions Reached
 
@@ -63,8 +65,121 @@ market rules remain separate:
 - provider quotation format
 
 The internal representation scale is not itself the instrument tick size.
-The final scale and supported range remain to be validated in #33 against FX,
-equities, futures, high-priced assets, and small-priced assets.
+
+*** Selected scale: 1e8 (8 decimal places)
+
+The internal =Price= scale is *1e8*: a decimal value =v= is stored as the
+=int64= =v * 100_000_000=.
+
+The validation evidence is in =test/internal/numericstudy=, a test-only spike that
+parses and formats decimal text directly to and from scaled =int64= without
+passing through =float64=.  Regenerate the tables below with:
+
+#+begin_src sh
+go test ./test/internal/numericstudy/ -run TestGenerateReport -v
+#+end_src
+
+**** Asset representation matrix
+
+Stored =int64= at each candidate scale.  =—= means the value needs more
+decimal places than the scale can hold, and is therefore rejected rather than
+silently rounded.
+
+| Class   | Symbol    |          Price |       Tick | Dec |     1e5 |          1e6 |            1e8 |             1e9 |
+|---------+-----------+----------------+------------+-----+---------+--------------+----------------+-----------------|
+| FX      | EUR/USD   |        1.08473 |    0.00001 |   5 |  108473 |      1084730 |      108473000 |      1084730000 |
+| FX      | USD/JPY   |        147.325 |      0.001 |   3 | 14732500 |    147325000 |    14732500000 |    147325000000 |
+| Equity  | SPY       |         700.12 |       0.01 |   2 | 70012000 |    700120000 |    70012000000 |    700120000000 |
+| Equity  | BRK.A     |      750000.00 |       0.01 |   2 | 75000000000 | 750000000000 | 75000000000000 | 750000000000000 |
+| Equity  | sub-penny |         0.0001 |     0.0001 |   4 |      10 |          100 |          10000 |          100000 |
+| Futures | ES        |        6250.25 |       0.25 |   2 | 625025000 |   6250250000 |   625025000000 |   6250250000000 |
+| Futures | ZN        |     110.515625 |   0.015625 |   6 |       — |    110515625 |    11051562500 |    110515625000 |
+| Crypto  | BTC/USD   | 150000.12345678 | 0.00000001 |  8 |       — |            — | 15000012345678 | 150000123456780 |
+| Crypto  | SHIB/USD  |     0.00000001 | 0.00000001 |   8 |       — |            — |              1 |              10 |
+| Rate    | financing |       0.000125 |   0.000001 |   6 |       — |          125 |          12500 |          125000 |
+
+1e5 and 1e6 are disqualified outright: neither can represent satoshi
+precision, and 1e5 cannot represent the 64ths that Treasury futures expand to.
+Both 1e8 and 1e9 represent every intended asset class exactly.
+
+**** Range and headroom
+
+| Scale | Decimals |      Max price |  Smallest unit | Headroom over 750000.00 |
+|-------+----------+----------------+----------------+-------------------------|
+| 1e5   |        5 | 92,233,720,368,547 |        0.00001 |           122,978,293 x |
+| 1e6   |        6 |  9,223,372,036,854 |       0.000001 |            12,297,829 x |
+| 1e8   |        8 |     92,233,720,368 |     0.00000001 |               122,978 x |
+| 1e9   |        9 |      9,223,372,036 |    0.000000001 |                12,297 x |
+
+At 1e8 the maximum representable price is ~92.2 billion, roughly 122,000x the
+highest-priced listed equity.  Storage range is not the binding constraint at
+either candidate scale.
+
+**** Why 1e8 over 1e9
+
+Intermediate arithmetic decides it.  Margin to the =int64= ceiling for
+=Price x Quantity=, where only one operand is scaled:
+
+| Case             |      Quantity |     1e8 |   1e9 |
+|------------------+---------------+---------+-------|
+| BRK.A block      |        10,000 |    12 x |   1 x |
+| FX 10M notional  |    10,000,000 |  8503 x | 850 x |
+| FX 1B notional   | 1,000,000,000 |    85 x |   9 x |
+| BTC 1k coins     |         1,000 |   615 x |  61 x |
+
+1e9 leaves the largest realistic notional essentially at the ceiling — a
+BRK.A-sized block consumes the entire =int64= range with 1x to spare.  1e8
+buys back an order of magnitude at the cost of one decimal place that no
+intended asset class needs.  8 decimals is also the natural stopping point:
+it is exactly satoshi precision, the widest decimal requirement Trader accepts.
+
+**** Consequences for intermediate arithmetic
+
+Two findings belong to [[https://github.com/rustyeddy/trader/issues/38][#38]] and are recorded here as evidence:
+
+1. *Double-scaled products overflow at every usable scale.*  =Price x Rate=
+   scales both operands, so the product carries the scale twice before the
+   descaling divide.  At 1e8, realistic pairs such as BRK.A x a financing rate,
+   or BTC/USD x a JPY conversion rate, overflow =int64=.  1e9 is worse.  This
+   is not fixable by choosing a different scale — it requires a widened
+   (128-bit) intermediate, demonstrated in =TestPriceTimesRateWidened=.
+
+2. *Naive accumulation overflows inside a single backtest.*  A plain =int64=
+   sum of 750000.00 bars overflows after ~122,978 bars at 1e8 — under three
+   months of M1 data.  Rolling sums and averages need a widened accumulator or
+   a running-mean formulation, not a raw =int64= total.
+
+| Scale | Bars of 750000.00 before overflow |
+|-------+-----------------------------------|
+| 1e8   |                           122,978 |
+| 1e9   |                            12,297 |
+
+**** Tick size stays separate from scale
+
+Instrument tick size is parsed into the same internal scale but remains an
+instrument property.  With both in one scale, increment validation is exact
+integer modulo (=price % tick == 0=) with no per-scale special cases; this is
+asserted in =TestPriceIsMultipleOfTick=.  Display precision is likewise
+independent: a value stored at 1e8 renders at whatever precision the
+instrument declares.
+
+**** Unsupported quotation formats
+
+These are provider quotation *conventions*, not decimal numbers.  Each must be
+normalized to plain decimal text in a provider adapter before reaching =Price=;
+the parser rejects all of them.
+
+| Format                       | Example       | Normalizes to | Reason                                              |
+|------------------------------+---------------+---------------+-----------------------------------------------------|
+| Treasury 32nds               | =110-16=      |         110.5 | =-= is a fraction separator, not a sign             |
+| Treasury 32nds + halves      | =110-16.5=    |    110.515625 | expands to 64ths; needs 6 decimals                  |
+| Grain eighths                | =575'6=       |        575.75 | apostrophe-delimited eighths of a cent              |
+| Scientific notation          | =1.5e-8=      |   0.000000015 | exponent form rejected; expand before parsing       |
+| Grouped thousands            | =750,000.00=  |     750000.00 | locale grouping is display, not exact input         |
+
+All of these are representable once normalized, so no intended instrument is
+excluded by the 1e8 choice — the constraint is on the adapter layer, not the
+representation.
 
 ** Exact input and output boundaries
 
@@ -100,7 +215,8 @@ compelling reason.
 
 The following issues must be resolved before this ADR can be accepted:
 
-- [[https://github.com/rustyeddy/trader/issues/33][#33 — Validate Price scale across supported asset classes]]
+- [X] [[https://github.com/rustyeddy/trader/issues/33][#33 — Validate Price scale across supported asset classes]] — resolved:
+  =Price= scale is 1e8.  Evidence in =test/internal/numericstudy=.
 - [[https://github.com/rustyeddy/trader/issues/35][#35 — Decide Money currency ownership and arithmetic semantics]]
 - [[https://github.com/rustyeddy/trader/issues/36][#36 — Decide Quantity precision and asset constraints]]
 - [[https://github.com/rustyeddy/trader/issues/37][#37 — Define numeric type decision matrix]]
@@ -114,11 +230,11 @@ The following issues must be resolved before this ADR can be accepted:
 
 * Provisional Decision Matrix
 
-The unresolved cells must be completed by #33 and #35–#42.
+The unresolved cells must be completed by #35–#42.
 
 | Type     | Backing | Scale                  | Related metadata              | Current arithmetic direction |
 |----------+---------+------------------------+-------------------------------+------------------------------|
-| Price    | int64   | Fixed; value TBD       | Tick size belongs to listing  | Exact typed operations       |
+| Price    | int64   | Fixed 1e8 (8 dp) (#33) | Tick size belongs to listing  | Exact typed operations; products need a widened intermediate |
 | Money    | int64   | TBD                    | Currency ownership TBD        | Cross-currency math forbidden|
 | Quantity | int64   | Fixed strategy TBD      | Increment belongs to listing  | Exact typed operations       |
 | Rate     | int64   | TBD                    | Semantic unit documented      | Explicit multiply/divide     |

--- a/docs/arch/adr-004-exact-numeric-representation.org
+++ b/docs/arch/adr-004-exact-numeric-representation.org
@@ -73,7 +73,10 @@ The internal =Price= scale is *1e8*: a decimal value =v= is stored as the
 
 The validation evidence is in =test/internal/numericstudy=, a test-only spike that
 parses and formats decimal text directly to and from scaled =int64= without
-passing through =float64=.  Regenerate the tables below with:
+passing through =float64=.
+
+No test compares the generated tables against the text below, so these tables
+can drift; regenerate and re-paste them whenever the asset matrix changes:
 
 #+begin_src sh
 go test ./test/internal/numericstudy/ -run TestGenerateReport -v
@@ -118,7 +121,8 @@ either candidate scale.
 **** Why 1e8 over 1e9
 
 Intermediate arithmetic decides it.  Margin to the =int64= ceiling for
-=Price x Quantity=, where only one operand is scaled:
+=Price x Quantity=, using whole unscaled quantities so only one operand
+carries a scale and no descaling divide is required:
 
 | Case             |      Quantity |     1e8 |   1e9 |
 |------------------+---------------+---------+-------|
@@ -132,6 +136,13 @@ BRK.A-sized block consumes the entire =int64= range with 1x to spare.  1e8
 buys back an order of magnitude at the cost of one decimal place that no
 intended asset class needs.  8 decimals is also the natural stopping point:
 it is exactly satoshi precision, the widest decimal requirement Trader accepts.
+
+These margins hold only for whole unscaled quantities.  If [[https://github.com/rustyeddy/trader/issues/36][#36]] gives
+=Quantity= its own scale, =Price x Quantity= becomes double-scaled exactly
+like =Price x Rate=, the margins above no longer apply, and the operation
+requires a widened intermediate regardless of price scale.  That would not
+change the 1e8 selection — it still beats 1e9 by 10x — but it would move
+=Price x Quantity= from "safe in =int64=" to "must use the widened path".
 
 **** Consequences for intermediate arithmetic
 
@@ -174,12 +185,41 @@ the parser rejects all of them.
 | Treasury 32nds               | =110-16=      |         110.5 | =-= is a fraction separator, not a sign             |
 | Treasury 32nds + halves      | =110-16.5=    |    110.515625 | expands to 64ths; needs 6 decimals                  |
 | Grain eighths                | =575'6=       |        575.75 | apostrophe-delimited eighths of a cent              |
-| Scientific notation          | =1.5e-8=      |   0.000000015 | exponent form rejected; expand before parsing       |
+| Scientific notation          | =1.5e-7=      |    0.00000015 | exponent form rejected; expand before parsing       |
 | Grouped thousands            | =750,000.00=  |     750000.00 | locale grouping is display, not exact input         |
 
 All of these are representable once normalized, so no intended instrument is
 excluded by the 1e8 choice — the constraint is on the adapter layer, not the
 representation.
+
+***** Normalization is necessary but not sufficient
+
+Converting a quotation to plain decimal text does not guarantee the result
+satisfies the precision policy.  Values finer than the 1e8 quantum are
+syntactically valid but not representable, and are rejected rather than
+silently rounded:
+
+| Value         | Digits | Note                                        |
+|---------------+--------+---------------------------------------------|
+| =0.000000015= |      9 | =1.5e-8= expanded; half of the 1e8 quantum  |
+| =0.000000001= |      9 | one 1e9 unit; below the 1e8 quantum         |
+| =1.000000005= |      9 | ordinary price carrying one digit too many  |
+
+Each is accepted at 1e9, confirming the failure is the precision policy rather
+than a parser defect (=TestSubQuantumValuesRejected=).  Whether adapters reject
+sub-quantum values or round them explicitly is decided by [[https://github.com/rustyeddy/trader/issues/38][#38]] and [[https://github.com/rustyeddy/trader/issues/39][#39]].
+
+***** Known parser gap: most negative value
+
+=FormatDecimal= renders =math.MinInt64=, but =ParseDecimal= cannot construct
+it: parsing builds the magnitude before negating, and that magnitude exceeds
+=MaxInt64=, so the guard fires one unit before the true negative bound.  The
+gap is exactly one representable value wide
+(=TestParseCannotConstructMinInt64=).
+
+[[https://github.com/rustyeddy/trader/issues/39][#39]] must make the negative-range policy explicit: either parsing accepts the
+full =int64= range, or the domain range is deliberately symmetric and the most
+negative value is not a valid =Price=.
 
 ** Exact input and output boundaries
 

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -204,7 +204,7 @@ ratified before =v0= freezes the instrument package.
 
 ** Status
 
-Proposed
+Work in Progress
 
 ** Context
 

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -204,7 +204,7 @@ ratified before =v0= freezes the instrument package.
 
 ** Status
 
-Work in Progress
+Proposed
 
 ** Context
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/rustyeddy/trader
 
 go 1.25.1
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/internal/numericstudy/README.md
+++ b/test/internal/numericstudy/README.md
@@ -23,19 +23,30 @@ Or write them straight to a file, with no test framing around them:
 NUMERICSTUDY_REPORT=report.org go test ./test/internal/numericstudy/ -run TestGenerateReport
 ```
 
-The tables come out as org-mode and paste directly into the ADR. They are
-computed from the same `Assets`, `Notionals`, and `Rates` data the assertions
-exercise, so regenerating always reflects current evidence.
-
-No test compares the generated output against the checked-in ADR text, so the
-tables in the document **can** drift. Regenerate and re-paste whenever
-`Assets`, `Notionals`, `Rates`, or `Candidates` change.
-
 Run everything, including the assertions behind the findings below:
 
 ```sh
 go test ./test/internal/numericstudy/ -v
 ```
+
+## The tables are generated, not hand-written
+
+Every table in this README and in ADR-004 sits between `numericstudy:` markers
+and is generated from `Assets`, `Notionals`, `Rates`, and `Candidates`.
+`TestGeneratedTables` fails if any region drifts from what the code produces,
+so **the documents cannot silently fall out of date**.
+
+Change the data, then regenerate both documents in place:
+
+```sh
+go test ./test/internal/numericstudy/ -run TestGeneratedTables -update
+```
+
+Do not hand-edit inside the markers — the next run will overwrite it, and CI
+fails in the meantime. Two companion tests keep the mechanism honest:
+`TestEveryFragmentIsUsed` catches a generated table that no document embeds,
+and `TestFragmentsRenderInBothFormats` checks the org and markdown renderers
+agree on structure.
 
 ## Recommendation: scale 1e8
 
@@ -58,12 +69,15 @@ billion, still far above anything we intend to trade.
 carries a scale and no descaling divide is needed. This is the favorable case —
 see the caveat below the table:
 
-| Case                    | Quantity      |   1e8 |  1e9 |
-| ----------------------- | ------------- | ----: | ---: |
-| BRK.A block             | 10,000        |  12×  |  1×  |
-| FX 10M notional         | 10,000,000    | 8503× | 850× |
-| FX 1B notional          | 1,000,000,000 |   85× |   9× |
-| BTC 1k coins            | 1,000         |  615× |  61× |
+<!-- BEGIN numericstudy:notional-8v9 -->
+| Case            |          Quantity |        1e8 |      1e9 |
+|-----------------|------------------:|-----------:|---------:|
+| BRK.A block     |            10,000 |        12x |       1x |
+| FX 10M notional |        10,000,000 |     8,502x |     850x |
+| FX 1B notional  |     1,000,000,000 |        85x |       8x |
+| BTC 1k coins    |             1,000 |       614x |      61x |
+| SHIB 1e12 units | 1,000,000,000,000 | 9,223,372x | 922,337x |
+<!-- END numericstudy:notional-8v9 -->
 
 1e9 leaves the largest realistic notional essentially *at* the ceiling — a
 BRK.A-sized block consumes the entire `int64` range with 1× to spare. 1e8 buys
@@ -101,10 +115,14 @@ path is valid.
 A plain `int64` sum of BRK.A-priced bars overflows after ~122,978 bars at 1e8 —
 under three months of M1 data.
 
+<!-- BEGIN numericstudy:rolling-sum -->
 | Scale | Bars of 750000.00 before overflow |
-| ----- | --------------------------------: |
+|-------|----------------------------------:|
+| 1e5   |                       122,978,293 |
+| 1e6   |                        12,297,829 |
 | 1e8   |                           122,978 |
 | 1e9   |                            12,297 |
+<!-- END numericstudy:rolling-sum -->
 
 Rolling sums and averages need a widened accumulator or a running-mean
 formulation, not a raw `int64` total.
@@ -125,13 +143,15 @@ These are provider quotation *conventions*, not decimal numbers. The parser
 rejects all of them; each must be normalized to plain decimal text in a
 provider adapter before reaching `Price`.
 
-| Format                  | Example      | Normalizes to | Reason                                        |
-| ----------------------- | ------------ | ------------- | --------------------------------------------- |
-| Treasury 32nds          | `110-16`     | 110.5         | `-` is a fraction separator, not a sign       |
-| Treasury 32nds + halves | `110-16.5`   | 110.515625    | expands to 64ths; needs 6 decimals            |
-| Grain eighths           | `575'6`      | 575.75        | apostrophe-delimited eighths of a cent        |
-| Scientific notation     | `1.5e-7`     | 0.00000015    | exponent form rejected; expand before parsing |
-| Grouped thousands       | `750,000.00` | 750000.00     | locale grouping is display, not exact input   |
+<!-- BEGIN numericstudy:unsupported -->
+| Format                              | Example      | Normalizes to | Reason                                                    |
+|-------------------------------------|--------------|--------------:|-----------------------------------------------------------|
+| Treasury 32nds (dash)               | `110-16`     |         110.5 | not decimal text; '-' is a fraction separator, not a sign |
+| Treasury 32nds plus halves/quarters | `110-16.5`   |    110.515625 | fraction of a 32nd; expands to 64ths, needing 6 decimals  |
+| Grain fractions in eighths          | `575'6`      |        575.75 | apostrophe-delimited eighths of a cent                    |
+| Scientific notation                 | `1.5e-7`     |    0.00000015 | exponent form is rejected; expand before parsing          |
+| Grouped thousands                   | `750,000.00` |     750000.00 | locale grouping is a display concern, not an exact input  |
+<!-- END numericstudy:unsupported -->
 
 All are representable once normalized, so **no intended instrument is excluded
 by the 1e8 choice** — the constraint lands on the adapter layer, not on the
@@ -144,11 +164,13 @@ fits the precision policy. A value finer than the 1e8 quantum is rejected even
 though it is syntactically valid — `1.5e-8` expands to `0.000000015`, which
 needs 9 decimals and **cannot** be represented at 1e8.
 
-| Value | Digits | Note |
-| --- | ---: | --- |
-| `0.000000015` | 9 | `1.5e-8` expanded; half of the 1e8 quantum |
-| `0.000000001` | 9 | one 1e9 unit; below the 1e8 quantum entirely |
-| `1.000000005` | 9 | ordinary price carrying one digit too many |
+<!-- BEGIN numericstudy:subquantum -->
+| Value         | Digits | Note                                         |
+|---------------|-------:|----------------------------------------------|
+| `0.000000015` |      9 | 1.5e-8 expanded; half of the 1e8 quantum     |
+| `0.000000001` |      9 | one 1e9 unit; below the 1e8 quantum entirely |
+| `1.000000005` |      9 | ordinary price carrying one digit too many   |
+<!-- END numericstudy:subquantum -->
 
 `TestSubQuantumValuesRejected` pins this: each is rejected at 1e8 with
 `ErrTooManyDecimals` and accepted at 1e9, confirming the failure is the
@@ -173,10 +195,12 @@ symmetric.
 | File               | Contents                                                                                |
 |--------------------|-----------------------------------------------------------------------------------------|
 | `scale.go`         | `ParseDecimal`, `FormatDecimal`, `FormatFixed`, `Canonical`, range and overflow helpers |
-| `assets.go`        | The asset matrix, notional and rate cases, unsupported-quotation list — all as data     |
+| `assets.go`        | The asset matrix, notional, rate, and sub-quantum cases — all as data                   |
+| `tables.go`        | Renders each table fragment in org or markdown from that data                           |
 | `scale_test.go`    | Round-trip, tick, boundary, and rejection tests                                         |
 | `overflow_test.go` | Intermediate-arithmetic evidence, plus 128-bit mul/div study helpers                    |
-| `report_test.go`   | Generates the org tables above                                                          |
+| `golden_test.go`   | Verifies (and with `-update`, rewrites) the generated regions in this file and the ADR  |
+| `report_test.go`   | Prints the full report for reading                                                      |
 
 Two deliberate choices in `scale.go`:
 

--- a/test/internal/numericstudy/README.md
+++ b/test/internal/numericstudy/README.md
@@ -1,0 +1,143 @@
+# numericstudy
+
+A design-investigation spike for
+[#33 — Validate `Price` scale across supported asset classes](https://github.com/rustyeddy/trader/issues/33),
+which feeds [ADR-004](../../../docs/arch/adr-004-exact-numeric-representation.org)
+under parent decision [#19](https://github.com/rustyeddy/trader/issues/19).
+
+**This is not the future `Price` type.** It lives under `test/internal/` so the
+import path itself keeps it out of production code — nothing outside `test/`
+can reference it. Delete or supersede it when #44 consolidates ADR-004.
+
+## Printing the report
+
+Print the validation tables to your terminal:
+
+```sh
+go test ./test/internal/numericstudy/ -run TestGenerateReport -v
+```
+
+Or write them straight to a file, with no test framing around them:
+
+```sh
+NUMERICSTUDY_REPORT=report.org go test ./test/internal/numericstudy/ -run TestGenerateReport
+```
+
+The tables come out as org-mode and paste directly into the ADR. They are
+generated from the same `Assets`, `Notionals`, and `Rates` data that the
+assertions exercise, so the document cannot drift from the evidence.
+
+Run everything, including the assertions behind the findings below:
+
+```sh
+go test ./test/internal/numericstudy/ -v
+```
+
+## Recommendation: scale 1e8
+
+`Price` uses a fixed internal scale of **1e8** — a decimal value `v` is stored
+as the `int64` `v * 100_000_000`.
+
+Four candidates were evaluated: 1e5, 1e6, 1e8, 1e9.
+
+**1e5 and 1e6 are disqualified on precision.** Neither represents satoshi
+precision (8 decimals), and 1e5 cannot represent the 64ths that Treasury
+futures expand to. Both 1e8 and 1e9 represent every intended asset class
+exactly, so precision alone does not separate them.
+
+**Storage range separates nothing either.** 1e8 tops out at ~92.2 billion,
+roughly 122,000× the highest-priced listed equity; 1e9 tops out at ~9.2
+billion, still far above anything we intend to trade.
+
+**Intermediate arithmetic decides it.** Margin to the `int64` ceiling for
+`Price × Quantity`, where only one operand is scaled:
+
+| Case                    | Quantity      |   1e8 |  1e9 |
+| ----------------------- | ------------- | ----: | ---: |
+| BRK.A block             | 10,000        |  12×  |  1×  |
+| FX 10M notional         | 10,000,000    | 8503× | 850× |
+| FX 1B notional          | 1,000,000,000 |   85× |   9× |
+| BTC 1k coins            | 1,000         |  615× |  61× |
+
+1e9 leaves the largest realistic notional essentially *at* the ceiling — a
+BRK.A-sized block consumes the entire `int64` range with 1× to spare. 1e8 buys
+back an order of magnitude for one decimal place that no intended asset class
+needs. 8 decimals is also the natural stopping point: it is exactly satoshi
+precision, the widest decimal requirement Trader accepts.
+
+## Findings for #38 (rounding, overflow, intermediate arithmetic)
+
+Two findings are the study's most consequential output, and neither is fixable
+by choosing a different scale.
+
+### 1. Double-scaled products overflow at every usable scale
+
+`Price × Rate` scales *both* operands, so the product carries the scale twice
+before the descaling divide. At 1e8, realistic pairs — BRK.A × a financing
+rate, BTC/USD × a JPY conversion rate — overflow `int64`. 1e9 is worse. 1e5
+escapes only because it cannot represent the wider assets at all, which is a
+symptom of being too narrow rather than evidence of safety.
+
+This requires a widened (128-bit) intermediate. `TestPriceTimesRateWidened`
+demonstrates one that works and agrees with the narrow path wherever the narrow
+path is valid.
+
+### 2. Naive accumulation overflows inside a single backtest
+
+A plain `int64` sum of BRK.A-priced bars overflows after ~122,978 bars at 1e8 —
+under three months of M1 data.
+
+| Scale | Bars of 750000.00 before overflow |
+| ----- | --------------------------------: |
+| 1e8   |                           122,978 |
+| 1e9   |                            12,297 |
+
+Rolling sums and averages need a widened accumulator or a running-mean
+formulation, not a raw `int64` total.
+
+## Tick size stays separate from the scale
+
+Instrument tick size is parsed into the same internal scale but remains an
+instrument property, distinct from the representation. With both in one scale,
+increment validation is exact integer modulo (`price % tick == 0`) with no
+per-scale special cases — asserted in `TestPriceIsMultipleOfTick`.
+
+Display precision is likewise independent: a value stored at 1e8 renders at
+whatever precision the instrument declares (`FormatFixed`).
+
+## Unsupported quotation formats
+
+These are provider quotation *conventions*, not decimal numbers. The parser
+rejects all of them; each must be normalized to plain decimal text in a
+provider adapter before reaching `Price`.
+
+| Format                  | Example      | Normalizes to | Reason                                        |
+| ----------------------- | ------------ | ------------- | --------------------------------------------- |
+| Treasury 32nds          | `110-16`     | 110.5         | `-` is a fraction separator, not a sign       |
+| Treasury 32nds + halves | `110-16.5`   | 110.515625    | expands to 64ths; needs 6 decimals            |
+| Grain eighths           | `575'6`      | 575.75        | apostrophe-delimited eighths of a cent        |
+| Scientific notation     | `1.5e-8`     | 0.000000015   | exponent form rejected; expand before parsing |
+| Grouped thousands       | `750,000.00` | 750000.00     | locale grouping is display, not exact input   |
+
+All are representable once normalized, so **no intended instrument is excluded
+by the 1e8 choice** — the constraint lands on the adapter layer, not on the
+representation.
+
+## How the code is organized
+
+| File               | Contents                                                                                |
+|--------------------|-----------------------------------------------------------------------------------------|
+| `scale.go`         | `ParseDecimal`, `FormatDecimal`, `FormatFixed`, `Canonical`, range and overflow helpers |
+| `assets.go`        | The asset matrix, notional and rate cases, unsupported-quotation list — all as data     |
+| `scale_test.go`    | Round-trip, tick, boundary, and rejection tests                                         |
+| `overflow_test.go` | Intermediate-arithmetic evidence, plus 128-bit mul/div study helpers                    |
+| `report_test.go`   | Generates the org tables above                                                          |
+
+Two deliberate choices in `scale.go`:
+
+- **No `float64` anywhere.** Decimal text converts directly to and from scaled
+  `int64`, digit by digit, with an overflow guard on each step.
+- **Parsing rejects rather than rounds.** `ErrTooManyDecimals`, `ErrOverflow`,
+  and `ErrSyntax` are distinct because losing precision and exceeding range
+  lead to different conclusions. A study that silently rounded would hide the
+  exact failures it exists to surface.

--- a/test/internal/numericstudy/README.md
+++ b/test/internal/numericstudy/README.md
@@ -24,8 +24,12 @@ NUMERICSTUDY_REPORT=report.org go test ./test/internal/numericstudy/ -run TestGe
 ```
 
 The tables come out as org-mode and paste directly into the ADR. They are
-generated from the same `Assets`, `Notionals`, and `Rates` data that the
-assertions exercise, so the document cannot drift from the evidence.
+computed from the same `Assets`, `Notionals`, and `Rates` data the assertions
+exercise, so regenerating always reflects current evidence.
+
+No test compares the generated output against the checked-in ADR text, so the
+tables in the document **can** drift. Regenerate and re-paste whenever
+`Assets`, `Notionals`, `Rates`, or `Candidates` change.
 
 Run everything, including the assertions behind the findings below:
 
@@ -50,7 +54,9 @@ roughly 122,000× the highest-priced listed equity; 1e9 tops out at ~9.2
 billion, still far above anything we intend to trade.
 
 **Intermediate arithmetic decides it.** Margin to the `int64` ceiling for
-`Price × Quantity`, where only one operand is scaled:
+`Price × Quantity`, using **whole, unscaled** quantities so only one operand
+carries a scale and no descaling divide is needed. This is the favorable case —
+see the caveat below the table:
 
 | Case                    | Quantity      |   1e8 |  1e9 |
 | ----------------------- | ------------- | ----: | ---: |
@@ -64,6 +70,14 @@ BRK.A-sized block consumes the entire `int64` range with 1× to spare. 1e8 buys
 back an order of magnitude for one decimal place that no intended asset class
 needs. 8 decimals is also the natural stopping point: it is exactly satoshi
 precision, the widest decimal requirement Trader accepts.
+
+**Caveat, pending [#36](https://github.com/rustyeddy/trader/issues/36).** These
+margins assume whole unscaled quantities. If `Quantity` gets its own scale,
+`Price × Quantity` becomes double-scaled exactly like `Price × Rate`, the
+margins above no longer apply, and production multiplication needs a widened
+intermediate regardless of the price scale. That would not change the 1e8
+recommendation — 1e8 still beats 1e9 by 10× — but it would move `Price ×
+Quantity` from "safe in `int64`" to "must use the widened path."
 
 ## Findings for #38 (rounding, overflow, intermediate arithmetic)
 
@@ -116,12 +130,43 @@ provider adapter before reaching `Price`.
 | Treasury 32nds          | `110-16`     | 110.5         | `-` is a fraction separator, not a sign       |
 | Treasury 32nds + halves | `110-16.5`   | 110.515625    | expands to 64ths; needs 6 decimals            |
 | Grain eighths           | `575'6`      | 575.75        | apostrophe-delimited eighths of a cent        |
-| Scientific notation     | `1.5e-8`     | 0.000000015   | exponent form rejected; expand before parsing |
+| Scientific notation     | `1.5e-7`     | 0.00000015    | exponent form rejected; expand before parsing |
 | Grouped thousands       | `750,000.00` | 750000.00     | locale grouping is display, not exact input   |
 
 All are representable once normalized, so **no intended instrument is excluded
 by the 1e8 choice** — the constraint lands on the adapter layer, not on the
 representation.
+
+### Normalization is necessary but not sufficient
+
+Converting a quotation to plain decimal text does not guarantee the result
+fits the precision policy. A value finer than the 1e8 quantum is rejected even
+though it is syntactically valid — `1.5e-8` expands to `0.000000015`, which
+needs 9 decimals and **cannot** be represented at 1e8.
+
+| Value | Digits | Note |
+| --- | ---: | --- |
+| `0.000000015` | 9 | `1.5e-8` expanded; half of the 1e8 quantum |
+| `0.000000001` | 9 | one 1e9 unit; below the 1e8 quantum entirely |
+| `1.000000005` | 9 | ordinary price carrying one digit too many |
+
+`TestSubQuantumValuesRejected` pins this: each is rejected at 1e8 with
+`ErrTooManyDecimals` and accepted at 1e9, confirming the failure is the
+precision policy rather than a parser defect. Whether adapters reject such
+values or round them explicitly is [#38](https://github.com/rustyeddy/trader/issues/38)
+and [#39](https://github.com/rustyeddy/trader/issues/39)'s call, not this
+study's.
+
+### Known parser gap: `math.MinInt64`
+
+`FormatDecimal` renders `math.MinInt64`, but `ParseDecimal` cannot construct
+it. Parsing builds the magnitude first and negates last, and the magnitude
+`9223372036854775808` exceeds `MaxInt64`, so the guard fires one unit before
+the true negative bound. The gap is exactly one representable value wide, and
+`TestParseCannotConstructMinInt64` documents it. The final negative-range
+policy belongs to [#39](https://github.com/rustyeddy/trader/issues/39): either
+the parser accepts the full `int64` range, or the domain range is deliberately
+symmetric.
 
 ## How the code is organized
 

--- a/test/internal/numericstudy/assets.go
+++ b/test/internal/numericstudy/assets.go
@@ -67,10 +67,16 @@ var Assets = []Asset{
 
 // Notional is an intermediate-arithmetic case: a realistic largest position
 // whose Price x Quantity product must not overflow int64 before the descale.
+//
+// Quantity here is a WHOLE, UNSCALED unit count, so only one operand carries a
+// scale and the product needs no descaling divide.  This is the favorable
+// case.  If #36 gives Quantity its own scale, these products become
+// double-scaled — like Price x Rate — and the margins below no longer apply;
+// production multiplication would then need a widened intermediate too.
 type Notional struct {
 	Name     string
 	Price    string // decimal text
-	Quantity int64  // whole units; fractional quantity is #36's problem
+	Quantity int64  // whole units; scaled quantity is #36's decision
 	Why      string
 }
 
@@ -112,6 +118,24 @@ var Rates = []struct {
 	{Name: "JPY cross 147.325", Rate: "147.325", Why: "large-magnitude conversion rate"},
 }
 
+// SubQuantumValues are values that are syntactically valid decimal text but
+// carry more precision than the selected scale can hold.
+//
+// Normalizing a quotation into plain decimal text is necessary but not
+// sufficient: the normalized result must still satisfy the precision policy.
+// A provider quoting below the 1e8 quantum cannot be represented exactly at
+// any price, and the adapter must reject or explicitly round it — the choice
+// belongs to #38 and #39, not to this study.
+var SubQuantumValues = []struct {
+	Value  string
+	Digits int
+	Note   string
+}{
+	{Value: "0.000000015", Digits: 9, Note: "1.5e-8 expanded; half of the 1e8 quantum"},
+	{Value: "0.000000001", Digits: 9, Note: "one 1e9 unit; below the 1e8 quantum entirely"},
+	{Value: "1.000000005", Digits: 9, Note: "ordinary price carrying one digit too many"},
+}
+
 // UnsupportedQuotations records provider quotation formats that this
 // representation cannot ingest directly.  Each must be normalized to plain
 // decimal text in a provider adapter before reaching Price.
@@ -141,8 +165,8 @@ var UnsupportedQuotations = []struct {
 	},
 	{
 		Format:  "Scientific notation",
-		Example: "1.5e-8",
-		Decimal: "0.000000015",
+		Example: "1.5e-7",
+		Decimal: "0.00000015",
 		Reason:  "exponent form is rejected; expand before parsing",
 	},
 	{

--- a/test/internal/numericstudy/assets.go
+++ b/test/internal/numericstudy/assets.go
@@ -1,0 +1,154 @@
+package numericstudy
+
+// Asset is one representative instrument in the validation matrix.
+type Asset struct {
+	Class    string // asset class, e.g. "FX", "Futures"
+	Symbol   string // representative symbol
+	Price    string // representative price as decimal text
+	TickSize string // instrument tick size as decimal text
+	Decimals int    // fraction digits the quotation actually requires
+	Note     string // non-obvious representation concerns
+}
+
+// Assets is the representative matrix from issue #33.  It deliberately
+// includes the extremes — the highest-priced and smallest-priced values we
+// intend to support — because those, not the typical values, decide the scale.
+var Assets = []Asset{
+	{
+		Class: "FX", Symbol: "EUR/USD",
+		Price: "1.08473", TickSize: "0.00001", Decimals: 5,
+	},
+	{
+		Class: "FX", Symbol: "USD/JPY",
+		Price: "147.325", TickSize: "0.001", Decimals: 3,
+		Note: "JPY pairs quote to 3 decimals; the pip is 0.01, not 0.0001",
+	},
+	{
+		Class: "Equity", Symbol: "SPY",
+		Price: "700.12", TickSize: "0.01", Decimals: 2,
+	},
+	{
+		Class: "Equity", Symbol: "BRK.A",
+		Price: "750000.00", TickSize: "0.01", Decimals: 2,
+		Note: "highest-priced listed equity; sets the practical range floor",
+	},
+	{
+		Class: "Equity", Symbol: "SUB-PENNY",
+		Price: "0.0001", TickSize: "0.0001", Decimals: 4,
+		Note: "sub-penny quotes are permitted below $1.00",
+	},
+	{
+		Class: "Futures", Symbol: "ES",
+		Price: "6250.25", TickSize: "0.25", Decimals: 2,
+		Note: "tick is 0.25 index points, a multiple of the 0.01 increment",
+	},
+	{
+		Class: "Futures", Symbol: "ZN",
+		Price: "110.515625", TickSize: "0.015625", Decimals: 6,
+		Note: "10-yr note quotes in 32nds and halves of 32nds; " +
+			"1/64 = 0.015625 exactly, so decimal form needs 6 decimals",
+	},
+	{
+		Class: "Crypto", Symbol: "BTC/USD",
+		Price: "150000.12345678", TickSize: "0.00000001", Decimals: 8,
+		Note: "satoshi precision is the widest decimal requirement we accept",
+	},
+	{
+		Class: "Crypto", Symbol: "SHIB/USD",
+		Price: "0.00000001", TickSize: "0.00000001", Decimals: 8,
+		Note: "smallest representable non-zero value at 8 decimals",
+	},
+	{
+		Class: "Rate", Symbol: "FINANCING",
+		Price: "0.000125", TickSize: "0.000001", Decimals: 6,
+		Note: "small financing/fee rates share the Price parsing path",
+	},
+}
+
+// Notional is an intermediate-arithmetic case: a realistic largest position
+// whose Price x Quantity product must not overflow int64 before the descale.
+type Notional struct {
+	Name     string
+	Price    string // decimal text
+	Quantity int64  // whole units; fractional quantity is #36's problem
+	Why      string
+}
+
+// Notionals are the multiplication cases exercised by the headroom study.
+var Notionals = []Notional{
+	{
+		Name: "BRK.A block", Price: "750000.00", Quantity: 10_000,
+		Why: "highest price x an institutional block",
+	},
+	{
+		Name: "FX 10M notional", Price: "1.08473", Quantity: 10_000_000,
+		Why: "typical institutional FX ticket size",
+	},
+	{
+		Name: "FX 1B notional", Price: "1.08473", Quantity: 1_000_000_000,
+		Why: "extreme FX notional; upper bound on realistic size",
+	},
+	{
+		Name: "BTC 1k coins", Price: "150000.12345678", Quantity: 1_000,
+		Why: "widest precision x a large position",
+	},
+	{
+		Name: "SHIB 1e12 units", Price: "0.00000001", Quantity: 1_000_000_000_000,
+		Why: "smallest price x the huge unit counts such tokens trade in",
+	},
+}
+
+// Rates are multiplier cases where BOTH operands are scaled, so the product
+// carries the scale twice and must be descaled once.  This double-scaled
+// intermediate, not the result, is the binding constraint on scale choice.
+var Rates = []struct {
+	Name string
+	Rate string // decimal text
+	Why  string
+}{
+	{Name: "commission 0.02%", Rate: "0.0002", Why: "per-fill fee applied to notional"},
+	{Name: "financing 3.75%", Rate: "0.0375", Why: "overnight carry on position value"},
+	{Name: "FX cross 1.08473", Rate: "1.08473", Why: "currency conversion of a money value"},
+	{Name: "JPY cross 147.325", Rate: "147.325", Why: "large-magnitude conversion rate"},
+}
+
+// UnsupportedQuotations records provider quotation formats that this
+// representation cannot ingest directly.  Each must be normalized to plain
+// decimal text in a provider adapter before reaching Price.
+var UnsupportedQuotations = []struct {
+	Format  string
+	Example string
+	Decimal string
+	Reason  string
+}{
+	{
+		Format:  "Treasury 32nds (dash)",
+		Example: "110-16",
+		Decimal: "110.5",
+		Reason:  "not decimal text; '-' is a fraction separator, not a sign",
+	},
+	{
+		Format:  "Treasury 32nds plus halves/quarters",
+		Example: "110-16.5",
+		Decimal: "110.515625",
+		Reason:  "fraction of a 32nd; expands to 64ths, needing 6 decimals",
+	},
+	{
+		Format:  "Grain fractions in eighths",
+		Example: "575'6",
+		Decimal: "575.75",
+		Reason:  "apostrophe-delimited eighths of a cent",
+	},
+	{
+		Format:  "Scientific notation",
+		Example: "1.5e-8",
+		Decimal: "0.000000015",
+		Reason:  "exponent form is rejected; expand before parsing",
+	},
+	{
+		Format:  "Grouped thousands",
+		Example: "750,000.00",
+		Decimal: "750000.00",
+		Reason:  "locale grouping is a display concern, not an exact input",
+	},
+}

--- a/test/internal/numericstudy/doc.go
+++ b/test/internal/numericstudy/doc.go
@@ -1,0 +1,23 @@
+// Package numericstudy is a design-investigation spike for
+// https://github.com/rustyeddy/trader/issues/33 — "Validate Price scale
+// across supported asset classes".
+//
+// It is NOT the future public Price implementation.  It lives under
+// test/internal so the import path itself keeps it out of production code:
+// nothing outside test/ can reference it.  Its purpose is to produce executable evidence for
+// ADR-004 (docs/arch/adr-004-exact-numeric-representation.org):
+//
+//   - which fixed internal scale represents FX, equities, futures,
+//     high-priced assets, crypto, and small-priced assets exactly;
+//   - what maximum price and overflow headroom each candidate scale leaves;
+//   - which quotation conventions cannot be represented as-is;
+//   - where intermediate arithmetic (Price x Quantity, Price x Rate, rolling
+//     sums) overflows int64 before the final descale.
+//
+// The parsing and formatting routines here deliberately avoid binary
+// floating point entirely: decimal text is converted directly to and from
+// scaled int64.
+//
+// This package should be deleted or superseded when #44 consolidates
+// ADR-004 and the real numeric types land.
+package numericstudy

--- a/test/internal/numericstudy/golden_test.go
+++ b/test/internal/numericstudy/golden_test.go
@@ -1,0 +1,189 @@
+package numericstudy
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// update rewrites the generated regions in the documents below instead of
+// asserting on them:
+//
+//	go test ./test/internal/numericstudy/ -run TestGeneratedTables -update
+var update = flag.Bool("update", false,
+	"rewrite generated table regions in the ADR and README")
+
+// generatedDoc is a document carrying machine-maintained table regions.
+type generatedDoc struct {
+	path   string // relative to the repository root
+	format Format
+}
+
+var generatedDocs = []generatedDoc{
+	{path: "docs/arch/adr-004-exact-numeric-representation.org", format: FormatOrg},
+	{path: "test/internal/numericstudy/README.md", format: FormatMarkdown},
+}
+
+// Marker syntax, in each format's comment form so the markers stay invisible
+// when the document is rendered:
+//
+//	org:      # BEGIN numericstudy:asset-matrix ... # END numericstudy:asset-matrix
+//	markdown: <!-- BEGIN numericstudy:asset-matrix --> ... <!-- END ... -->
+func markers(f Format, name string) (begin, end string) {
+	if f == FormatMarkdown {
+		return "<!-- BEGIN numericstudy:" + name + " -->",
+			"<!-- END numericstudy:" + name + " -->"
+	}
+	return "# BEGIN numericstudy:" + name, "# END numericstudy:" + name
+}
+
+var regionRe = map[Format]*regexp.Regexp{
+	FormatOrg: regexp.MustCompile(
+		`(?m)^# BEGIN numericstudy:([a-z0-9-]+)$\n([\s\S]*?)^# END numericstudy:([a-z0-9-]+)$`),
+	FormatMarkdown: regexp.MustCompile(
+		`(?m)^<!-- BEGIN numericstudy:([a-z0-9-]+) -->$\n([\s\S]*?)^<!-- END numericstudy:([a-z0-9-]+) -->$`),
+}
+
+// TestGeneratedTables is the guarantee behind the claim that the checked-in
+// tables track the evidence: every marked region in the ADR and README must
+// equal the fragment this package generates for it.  Change the asset matrix
+// without regenerating and this test fails.
+//
+// Run with -update to rewrite the regions in place.
+func TestGeneratedTables(t *testing.T) {
+	root := repoRoot(t)
+
+	for _, doc := range generatedDocs {
+		t.Run(doc.path, func(t *testing.T) {
+			path := filepath.Join(root, doc.path)
+			raw, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			frag := Fragments(doc.format)
+			re := regionRe[doc.format]
+
+			seen := map[string]bool{}
+			var mismatched []string
+
+			updated := re.ReplaceAllStringFunc(string(raw), func(m string) string {
+				sub := re.FindStringSubmatch(m)
+				name, body, closing := sub[1], sub[2], sub[3]
+
+				require.Equal(t, name, closing,
+					"mismatched BEGIN/END marker names in %s", doc.path)
+
+				want, ok := frag[name]
+				if !ok {
+					t.Errorf("%s: unknown fragment %q; known: %v",
+						doc.path, name, fragmentNames(frag))
+					return m
+				}
+				seen[name] = true
+
+				if body != want {
+					mismatched = append(mismatched, name)
+				}
+
+				begin, end := markers(doc.format, name)
+				return begin + "\n" + want + end
+			})
+
+			require.NotEmpty(t, seen,
+				"%s has no numericstudy markers; generated tables are unguarded",
+				doc.path)
+
+			if *update {
+				require.NoError(t, os.WriteFile(path, []byte(updated), 0o644))
+				t.Logf("updated %d region(s) in %s", len(seen), doc.path)
+				return
+			}
+
+			assert.Empty(t, mismatched,
+				"%s is stale in %v — regenerate with:\n"+
+					"  go test ./test/internal/numericstudy/ -run TestGeneratedTables -update",
+				doc.path, mismatched)
+		})
+	}
+}
+
+// TestEveryFragmentIsUsed keeps the generator honest in the other direction: a
+// fragment nobody embeds is dead code that will silently rot.
+func TestEveryFragmentIsUsed(t *testing.T) {
+	root := repoRoot(t)
+	used := map[string]bool{}
+
+	for _, doc := range generatedDocs {
+		raw, err := os.ReadFile(filepath.Join(root, doc.path))
+		require.NoError(t, err)
+		for _, m := range regionRe[doc.format].FindAllStringSubmatch(string(raw), -1) {
+			used[m[1]] = true
+		}
+	}
+
+	for name := range Fragments(FormatOrg) {
+		assert.True(t, used[name],
+			"fragment %q is generated but embedded in no document", name)
+	}
+}
+
+// TestFragmentsRenderInBothFormats guards the renderer itself: every fragment
+// must produce a non-empty, well-formed table in org and markdown alike.
+func TestFragmentsRenderInBothFormats(t *testing.T) {
+	for _, f := range []Format{FormatOrg, FormatMarkdown} {
+		for name, body := range Fragments(f) {
+			t.Run(fmt.Sprintf("%d/%s", f, name), func(t *testing.T) {
+				lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+				require.GreaterOrEqual(t, len(lines), 3,
+					"want header, rule, and at least one row")
+
+				// The org rule row separates columns with "+", so count both
+				// delimiters to compare column counts across formats.
+				delims := func(s string) int {
+					return strings.Count(s, "|") + strings.Count(s, "+")
+				}
+
+				want := delims(lines[0])
+				for i, ln := range lines {
+					assert.True(t, strings.HasPrefix(ln, "|"),
+						"line %d must start a table row: %q", i, ln)
+					assert.Equal(t, want, delims(ln),
+						"line %d has a different column count: %q", i, ln)
+				}
+			})
+		}
+	}
+}
+
+func fragmentNames(frag map[string]string) []string {
+	out := make([]string, 0, len(frag))
+	for k := range frag {
+		out = append(out, k)
+	}
+	return out
+}
+
+// repoRoot walks up from the package directory to the module root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	for range 10 {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, dir, parent, "reached filesystem root without go.mod")
+		dir = parent
+	}
+	t.Fatal("could not locate repository root")
+	return ""
+}

--- a/test/internal/numericstudy/overflow_test.go
+++ b/test/internal/numericstudy/overflow_test.go
@@ -1,0 +1,268 @@
+package numericstudy
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Storage range is not the binding constraint on scale choice — intermediate
+// arithmetic is.  These tests measure where products overflow int64 before the
+// descaling divide, which is the evidence #38 needs for its overflow policy.
+
+// TestPriceTimesQuantity multiplies a scaled price by a whole quantity.  Only
+// one operand is scaled, so the product carries the scale once and no descale
+// is needed; the constraint is purely magnitude.
+func TestPriceTimesQuantity(t *testing.T) {
+	for _, sc := range Candidates {
+		for _, n := range Notionals {
+			t.Run(sc.Name+"/"+n.Name, func(t *testing.T) {
+				p, err := ParseDecimal(n.Price, sc)
+				if err != nil {
+					t.Skipf("price not representable at %s: %v", sc.Name, err)
+				}
+
+				overflows := MulOverflows(p, n.Quantity)
+				switch sc.Name {
+				case "1e8":
+					assert.False(t, overflows,
+						"1e8 must hold every realistic notional")
+				case "1e9":
+					// Recorded, not required: 1e9 is expected to survive these
+					// cases but with far less margin.  See TestScaleMargins.
+					t.Logf("1e9 %s overflows=%v", n.Name, overflows)
+				}
+			})
+		}
+	}
+}
+
+// TestScaleMargins is the finding that separates 1e8 from 1e9: both represent
+// every asset in the matrix, but 1e9 leaves the largest realistic notional
+// close to the int64 ceiling while 1e8 leaves two orders of magnitude.
+func TestScaleMargins(t *testing.T) {
+	worst := Notionals[0] // BRK.A block: highest price x institutional size
+	require.Equal(t, "BRK.A block", worst.Name)
+
+	margin := func(name string) float64 {
+		sc := scaleByName(t, name)
+		p, err := ParseDecimal(worst.Price, sc)
+		require.NoError(t, err)
+		require.False(t, MulOverflows(p, worst.Quantity))
+		return float64(math.MaxInt64) / float64(p*worst.Quantity)
+	}
+
+	m8, m9 := margin("1e8"), margin("1e9")
+	t.Logf("%s margin to int64 ceiling: 1e8=%.1fx 1e9=%.1fx", worst.Name, m8, m9)
+
+	assert.Greater(t, m8, 10.0, "1e8 must leave an order of magnitude spare")
+	assert.Less(t, m9, 10.0, "1e9 is expected to be the tight option")
+	assert.InDelta(t, 10.0, m8/m9, 0.1, "the two scales differ by exactly 10x")
+}
+
+// TestPriceTimesRate is the decisive intermediate case: both operands are
+// scaled, so the product carries the scale twice and must be descaled once.
+// The double-scaled intermediate overflows int64 at EVERY candidate scale for
+// realistic inputs, so a widened intermediate is mandatory regardless of which
+// scale is chosen.  This is a policy finding for #38, not a scale-tuning knob.
+func TestPriceTimesRate(t *testing.T) {
+	anyOverflow := map[string]bool{}
+
+	for _, sc := range Candidates {
+		for _, a := range Assets {
+			for _, r := range Rates {
+				p, err := ParseDecimal(a.Price, sc)
+				if err != nil {
+					continue
+				}
+				rate, err := ParseDecimal(r.Rate, sc)
+				if err != nil {
+					continue
+				}
+				if MulOverflows(p, rate) {
+					anyOverflow[sc.Name] = true
+					t.Logf("%s: %s x %s overflows the double-scaled intermediate",
+						sc.Name, a.Symbol, r.Name)
+				}
+			}
+		}
+	}
+
+	// 1e8 and 1e9 are the only candidates that can represent the whole asset
+	// matrix, and both overflow on realistic Price x Rate pairs.
+	for _, name := range []string{"1e8", "1e9"} {
+		assert.True(t, anyOverflow[name],
+			"scale %s: expected at least one realistic Price x Rate to overflow "+
+				"int64 without a widened intermediate", name)
+	}
+
+	// 1e5 escapes only because it cannot represent crypto or ZN at all, so its
+	// operands never get large enough — that is a symptom of being too narrow,
+	// not evidence that it is safe.
+	assert.False(t, anyOverflow["1e5"],
+		"1e5 avoids overflow only by failing to represent the wider assets")
+}
+
+// TestPriceTimesRateWidened shows the same products are safe once the
+// intermediate is widened, confirming the fix belongs in the arithmetic
+// policy rather than in the choice of scale.
+func TestPriceTimesRateWidened(t *testing.T) {
+	sc := scaleByName(t, "1e8")
+	for _, a := range Assets {
+		for _, r := range Rates {
+			p, err := ParseDecimal(a.Price, sc)
+			require.NoError(t, err)
+			rate, err := ParseDecimal(r.Rate, sc)
+			require.NoError(t, err)
+
+			// Widen to 128 bits, descale once, and require the result back in
+			// int64 range.
+			hi, lo := mul128(p, rate)
+			got, ok := div128(hi, lo, sc.Factor)
+			assert.True(t, ok,
+				"%s x %s must fit int64 after descaling", a.Symbol, r.Name)
+
+			if ok && !MulOverflows(p, rate) {
+				assert.Equal(t, p*rate/sc.Factor, got,
+					"widened path must agree with the narrow path when both work")
+			}
+		}
+	}
+}
+
+// TestRollingSum covers accumulation, and is the second policy finding: a
+// naive int64 price accumulator overflows far sooner than the storage range
+// suggests.  At the scales that can represent our whole asset matrix, a sum of
+// high-priced bars exhausts int64 well inside a single backtest, so rolling
+// sums and averages need a widened accumulator or a running mean.
+func TestRollingSum(t *testing.T) {
+	const bars = 1_000_000 // ~10 years of M1 bars
+
+	capacity := map[string]int64{}
+
+	for _, sc := range Candidates {
+		t.Run(sc.Name, func(t *testing.T) {
+			p, err := ParseDecimal("750000.00", sc)
+			require.NoError(t, err)
+
+			var acc int64
+			var n int64
+			for range bars {
+				if AddOverflows(acc, p) {
+					break
+				}
+				acc += p
+				n++
+			}
+			capacity[sc.Name] = n
+
+			// The loop stops at either overflow or the requested bar count.
+			assert.Equal(t, min(math.MaxInt64/p, int64(bars)), n,
+				"the accumulator must hold exactly MaxInt64/price bars")
+			t.Logf("%s: holds %d bars of 750000.00 (%d requested, ceiling %d)",
+				sc.Name, n, bars, math.MaxInt64/p)
+		})
+	}
+
+	assert.Less(t, capacity["1e8"], int64(bars),
+		"1e8 must be shown to overflow inside a 1M-bar backtest, so #38 cannot "+
+			"treat plain int64 accumulation as safe")
+	assert.Equal(t, int64(bars), capacity["1e5"],
+		"the narrow scales survive the full run only because they carry less "+
+			"precision")
+}
+
+// mul128 returns the full 128-bit product of two int64 values as a
+// (high, low) pair, sign-extended.  Study helper only: the real
+// implementation belongs with the arithmetic policy in #38.
+func mul128(a, b int64) (hi int64, lo uint64) {
+	neg := (a < 0) != (b < 0)
+	ua, ub := abs64(a), abs64(b)
+
+	h, l := umul128(ua, ub)
+	if !neg {
+		return int64(h), l
+	}
+	// Two's-complement negate the 128-bit magnitude.
+	l = ^l + 1
+	h = ^h
+	if l == 0 {
+		h++
+	}
+	return int64(h), l
+}
+
+func umul128(a, b uint64) (hi, lo uint64) {
+	const mask = 0xFFFFFFFF
+	a0, a1 := a&mask, a>>32
+	b0, b1 := b&mask, b>>32
+
+	w0 := a0 * b0
+	t := a1*b0 + w0>>32
+	w1, w2 := t&mask, t>>32
+	w1 += a0 * b1
+
+	hi = a1*b1 + w2 + w1>>32
+	lo = a * b
+	return hi, lo
+}
+
+// div128 divides a 128-bit signed value by a positive int64 divisor,
+// truncating toward zero, and reports whether the quotient fits in int64.
+func div128(hi int64, lo uint64, d int64) (int64, bool) {
+	neg := hi < 0
+	uhi, ulo := uint64(hi), lo
+	if neg {
+		ulo = ^ulo + 1
+		uhi = ^uhi
+		if ulo == 0 {
+			uhi++
+		}
+	}
+
+	ud := uint64(d)
+	if uhi >= ud {
+		return 0, false // quotient needs more than 64 bits
+	}
+
+	// Long division of the 128-bit magnitude, bit by bit.
+	var q, rem uint64
+	for i := 127; i >= 0; i-- {
+		var bit uint64
+		if i >= 64 {
+			bit = (uhi >> (i - 64)) & 1
+		} else {
+			bit = (ulo >> i) & 1
+		}
+		// rem cannot reach the top bit here because uhi < ud.
+		rem = rem<<1 | bit
+		if rem >= ud {
+			rem -= ud
+			if i < 64 {
+				q |= 1 << i
+			} else {
+				return 0, false
+			}
+		}
+	}
+
+	if neg {
+		if q > 1<<63 {
+			return 0, false
+		}
+		return -int64(q), true
+	}
+	if q > math.MaxInt64 {
+		return 0, false
+	}
+	return int64(q), true
+}
+
+func abs64(v int64) uint64 {
+	if v < 0 {
+		return uint64(-(v + 1)) + 1
+	}
+	return uint64(v)
+}

--- a/test/internal/numericstudy/report_test.go
+++ b/test/internal/numericstudy/report_test.go
@@ -9,13 +9,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// reportSections is the order the report prints its tables in, with the
+// heading each one appears under.  The names match the fragment names embedded
+// in the ADR and README, so the printed report and the documents are the same
+// content rendered once.
+var reportSections = []struct{ name, heading string }{
+	{"asset-matrix", "Asset representation matrix"},
+	{"range-headroom", "Range and headroom per candidate scale"},
+	{"notional-all", "Price x Quantity headroom (whole unscaled quantities)"},
+	{"rolling-sum", "Rolling-sum capacity"},
+	{"subquantum", "Sub-quantum values (valid decimals, not representable at 1e8)"},
+	{"unsupported", "Unsupported quotation formats"},
+}
+
 // TestGenerateReport prints the validation tables for ADR-004 in org-mode
-// syntax, computed from the same data the assertions above exercise.
+// syntax, computed from the same data the assertions exercise.
 //
-// Nothing compares this output against the checked-in ADR text, so the tables
-// in the document CAN drift if the matrix changes and nobody re-pastes them.
-// Regenerate and re-paste whenever Assets, Notionals, Rates, or Candidates
-// change.
+// The tables checked into the ADR and README are the same fragments, verified
+// by TestGeneratedTables — so this report is for reading, not for pasting.
+// To refresh the documents, run that test with -update instead.
 //
 // Print it to the terminal:
 //
@@ -24,91 +36,16 @@ import (
 // Or write it straight to a file, with no test framing around it:
 //
 //	NUMERICSTUDY_REPORT=report.org go test ./test/internal/numericstudy/ -run TestGenerateReport
-//
-// The report goes to stdout via fmt rather than t.Log so the org tables come
-// out unindented and paste directly into the ADR.
 func TestGenerateReport(t *testing.T) {
+	frag := Fragments(FormatOrg)
+
 	var b strings.Builder
-
-	b.WriteString("\n** Asset representation matrix\n\n")
-	b.WriteString("| Class | Symbol | Price | Tick | Dec |")
-	for _, sc := range Candidates {
-		b.WriteString(" " + sc.Name + " stored |")
+	for _, s := range reportSections {
+		body, ok := frag[s.name]
+		require.True(t, ok, "report references unknown fragment %q", s.name)
+		fmt.Fprintf(&b, "\n** %s\n\n%s", s.heading, body)
 	}
-	b.WriteString("\n|---\n")
-
-	for _, a := range Assets {
-		fmt.Fprintf(&b, "| %s | %s | %s | %s | %d |",
-			a.Class, a.Symbol, a.Price, a.TickSize, a.Decimals)
-		for _, sc := range Candidates {
-			v, err := ParseDecimal(a.Price, sc)
-			if err != nil {
-				b.WriteString(" — |")
-				continue
-			}
-			if got := FormatDecimal(v, sc); got != Canonical(a.Price) {
-				fmt.Fprintf(&b, " INEXACT(%s) |", got)
-				continue
-			}
-			fmt.Fprintf(&b, " %d |", v)
-		}
-		b.WriteString("\n")
-	}
-
 	b.WriteString("\n=—= means the value needs more decimals than the scale holds.\n")
-
-	b.WriteString("\n** Range and headroom per candidate scale\n\n")
-	b.WriteString("| Scale | Decimals | Max price | Smallest unit | Headroom over 750000.00 |\n|---\n")
-	for _, sc := range Candidates {
-		smallest := FormatDecimal(1, sc)
-		head := "n/a"
-		if v, err := ParseDecimal("750000.00", sc); err == nil {
-			head = fmt.Sprintf("%dx", Headroom(v, sc))
-		}
-		fmt.Fprintf(&b, "| %s | %d | %s | %s | %s |\n",
-			sc.Name, sc.Decimals, MaxPriceText(sc), smallest, head)
-	}
-
-	b.WriteString("\n** Intermediate arithmetic headroom\n\n")
-	b.WriteString("| Case | Quantity |")
-	for _, sc := range Candidates {
-		b.WriteString(" " + sc.Name + " |")
-	}
-	b.WriteString("\n|---\n")
-	for _, n := range Notionals {
-		fmt.Fprintf(&b, "| %s | %d |", n.Name, n.Quantity)
-		for _, sc := range Candidates {
-			p, err := ParseDecimal(n.Price, sc)
-			if err != nil {
-				b.WriteString(" n/a |")
-				continue
-			}
-			if MulOverflows(p, n.Quantity) {
-				b.WriteString(" OVERFLOW |")
-				continue
-			}
-			margin := float64(maxInt64) / float64(p*n.Quantity)
-			fmt.Fprintf(&b, " %.0fx spare |", margin)
-		}
-		b.WriteString("\n")
-	}
-
-	b.WriteString("\n** Rolling-sum capacity (bars of 750000.00 before int64 overflow)\n\n")
-	b.WriteString("| Scale | Bars |\n|---\n")
-	for _, sc := range Candidates {
-		v, err := ParseDecimal("750000.00", sc)
-		if err != nil {
-			continue
-		}
-		fmt.Fprintf(&b, "| %s | %d |\n", sc.Name, maxInt64/v)
-	}
-
-	b.WriteString("\n** Unsupported quotation formats\n\n")
-	b.WriteString("| Format | Example | Normalized decimal | Reason |\n|---\n")
-	for _, q := range UnsupportedQuotations {
-		fmt.Fprintf(&b, "| %s | =%s= | %s | %s |\n",
-			q.Format, q.Example, q.Decimal, q.Reason)
-	}
 
 	if path := os.Getenv("NUMERICSTUDY_REPORT"); path != "" {
 		require.NoError(t, os.WriteFile(path, []byte(b.String()), 0o644))
@@ -122,5 +59,3 @@ func TestGenerateReport(t *testing.T) {
 		fmt.Print(b.String())
 	}
 }
-
-const maxInt64 = int64(^uint64(0) >> 1)

--- a/test/internal/numericstudy/report_test.go
+++ b/test/internal/numericstudy/report_test.go
@@ -1,0 +1,117 @@
+package numericstudy
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateReport prints the validation tables for ADR-004 in org-mode
+// syntax, generated from the same data the assertions above exercise so the
+// document cannot drift from the evidence.
+//
+// Print it to the terminal:
+//
+//	go test ./test/internal/numericstudy/ -run TestGenerateReport -v
+//
+// Or write it straight to a file, with no test framing around it:
+//
+//	NUMERICSTUDY_REPORT=report.org go test ./test/internal/numericstudy/ -run TestGenerateReport
+//
+// The report goes to stdout via fmt rather than t.Log so the org tables come
+// out unindented and paste directly into the ADR.
+func TestGenerateReport(t *testing.T) {
+	var b strings.Builder
+
+	b.WriteString("\n** Asset representation matrix\n\n")
+	b.WriteString("| Class | Symbol | Price | Tick | Dec |")
+	for _, sc := range Candidates {
+		b.WriteString(" " + sc.Name + " stored |")
+	}
+	b.WriteString("\n|---\n")
+
+	for _, a := range Assets {
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %d |",
+			a.Class, a.Symbol, a.Price, a.TickSize, a.Decimals)
+		for _, sc := range Candidates {
+			v, err := ParseDecimal(a.Price, sc)
+			if err != nil {
+				b.WriteString(" — |")
+				continue
+			}
+			if got := FormatDecimal(v, sc); got != Canonical(a.Price) {
+				fmt.Fprintf(&b, " INEXACT(%s) |", got)
+				continue
+			}
+			fmt.Fprintf(&b, " %d |", v)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n=—= means the value needs more decimals than the scale holds.\n")
+
+	b.WriteString("\n** Range and headroom per candidate scale\n\n")
+	b.WriteString("| Scale | Decimals | Max price | Smallest unit | Headroom over 750000.00 |\n|---\n")
+	for _, sc := range Candidates {
+		smallest := FormatDecimal(1, sc)
+		head := "n/a"
+		if v, err := ParseDecimal("750000.00", sc); err == nil {
+			head = fmt.Sprintf("%dx", Headroom(v, sc))
+		}
+		fmt.Fprintf(&b, "| %s | %d | %s | %s | %s |\n",
+			sc.Name, sc.Decimals, MaxPriceText(sc), smallest, head)
+	}
+
+	b.WriteString("\n** Intermediate arithmetic headroom\n\n")
+	b.WriteString("| Case | Quantity |")
+	for _, sc := range Candidates {
+		b.WriteString(" " + sc.Name + " |")
+	}
+	b.WriteString("\n|---\n")
+	for _, n := range Notionals {
+		fmt.Fprintf(&b, "| %s | %d |", n.Name, n.Quantity)
+		for _, sc := range Candidates {
+			p, err := ParseDecimal(n.Price, sc)
+			if err != nil {
+				b.WriteString(" n/a |")
+				continue
+			}
+			if MulOverflows(p, n.Quantity) {
+				b.WriteString(" OVERFLOW |")
+				continue
+			}
+			margin := float64(maxInt64) / float64(p*n.Quantity)
+			fmt.Fprintf(&b, " %.0fx spare |", margin)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n** Rolling-sum capacity (bars of 750000.00 before int64 overflow)\n\n")
+	b.WriteString("| Scale | Bars |\n|---\n")
+	for _, sc := range Candidates {
+		v, err := ParseDecimal("750000.00", sc)
+		if err != nil {
+			continue
+		}
+		fmt.Fprintf(&b, "| %s | %d |\n", sc.Name, maxInt64/v)
+	}
+
+	b.WriteString("\n** Unsupported quotation formats\n\n")
+	b.WriteString("| Format | Example | Normalized decimal | Reason |\n|---\n")
+	for _, q := range UnsupportedQuotations {
+		fmt.Fprintf(&b, "| %s | =%s= | %s | %s |\n",
+			q.Format, q.Example, q.Decimal, q.Reason)
+	}
+
+	if path := os.Getenv("NUMERICSTUDY_REPORT"); path != "" {
+		require.NoError(t, os.WriteFile(path, []byte(b.String()), 0o644))
+		t.Logf("report written to %s", path)
+		return
+	}
+	fmt.Print(b.String())
+}
+
+const maxInt64 = int64(^uint64(0) >> 1)

--- a/test/internal/numericstudy/report_test.go
+++ b/test/internal/numericstudy/report_test.go
@@ -10,8 +10,12 @@ import (
 )
 
 // TestGenerateReport prints the validation tables for ADR-004 in org-mode
-// syntax, generated from the same data the assertions above exercise so the
-// document cannot drift from the evidence.
+// syntax, computed from the same data the assertions above exercise.
+//
+// Nothing compares this output against the checked-in ADR text, so the tables
+// in the document CAN drift if the matrix changes and nobody re-pastes them.
+// Regenerate and re-paste whenever Assets, Notionals, Rates, or Candidates
+// change.
 //
 // Print it to the terminal:
 //
@@ -111,7 +115,12 @@ func TestGenerateReport(t *testing.T) {
 		t.Logf("report written to %s", path)
 		return
 	}
-	fmt.Print(b.String())
+
+	// Only print when explicitly asked, so a plain `go test ./...` (and
+	// therefore `make check`) stays quiet.
+	if testing.Verbose() {
+		fmt.Print(b.String())
+	}
 }
 
 const maxInt64 = int64(^uint64(0) >> 1)

--- a/test/internal/numericstudy/scale.go
+++ b/test/internal/numericstudy/scale.go
@@ -242,9 +242,14 @@ func MulOverflows(a, b int64) bool {
 	if a == 0 || b == 0 {
 		return false
 	}
-	if a == math.MinInt64 || b == math.MinInt64 {
+
+	// MinInt64 has no positive twin, so negating it overflows.  This is the
+	// one case the division check below cannot catch: Go defines
+	// MinInt64 / -1 as MinInt64, so p/b == a holds spuriously.
+	if (a == math.MinInt64 && b == -1) || (b == math.MinInt64 && a == -1) {
 		return true
 	}
+
 	p := a * b
 	return p/b != a
 }

--- a/test/internal/numericstudy/scale.go
+++ b/test/internal/numericstudy/scale.go
@@ -1,0 +1,262 @@
+package numericstudy
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// Scale is a candidate fixed internal representation scale for Price.
+//
+// A decimal value v is stored as the int64 round(v * Factor), where Factor is
+// exactly 10**Decimals.  The scale is a property of the representation, not of
+// any instrument: instrument tick size, permitted increment, and display
+// precision are separate concerns (see TickSize on Asset and FormatFixed).
+type Scale struct {
+	Name     string
+	Decimals int
+	Factor   int64
+}
+
+// Candidates are the internal scales evaluated by this study.
+var Candidates = []Scale{
+	{Name: "1e5", Decimals: 5, Factor: 100_000},
+	{Name: "1e6", Decimals: 6, Factor: 1_000_000},
+	{Name: "1e8", Decimals: 8, Factor: 100_000_000},
+	{Name: "1e9", Decimals: 9, Factor: 1_000_000_000},
+}
+
+// Parse errors.  They are distinct so the study can report *why* a
+// representative value fails at a candidate scale: losing precision and
+// exceeding range lead to different conclusions.
+var (
+	// ErrTooManyDecimals means the value carries more significant fraction
+	// digits than the scale can hold.  The value is rejected rather than
+	// rounded: this study must surface inexact values, not hide them.
+	ErrTooManyDecimals = errors.New("numericstudy: more fraction digits than scale")
+
+	// ErrOverflow means the scaled value does not fit in int64.
+	ErrOverflow = errors.New("numericstudy: scaled value overflows int64")
+
+	// ErrSyntax means the text is not a plain decimal number.
+	ErrSyntax = errors.New("numericstudy: malformed decimal text")
+)
+
+// ParseDecimal converts plain decimal text to a scaled int64 without passing
+// through binary floating point.  Accepted syntax is an optional '-' followed
+// by digits, optionally followed by '.' and more digits.  Exponents, grouping
+// separators, leading '+', and surrounding whitespace are rejected: exact
+// boundaries should be strict, and provider-specific formats belong in an
+// adapter (see Asset.Note for quotation conventions this cannot represent).
+func ParseDecimal(s string, sc Scale) (int64, error) {
+	if s == "" {
+		return 0, fmt.Errorf("%w: empty", ErrSyntax)
+	}
+
+	neg := false
+	if s[0] == '-' {
+		neg = true
+		s = s[1:]
+		if s == "" {
+			return 0, fmt.Errorf("%w: bare sign", ErrSyntax)
+		}
+	}
+
+	intPart, fracPart := s, ""
+	if i := strings.IndexByte(s, '.'); i >= 0 {
+		intPart, fracPart = s[:i], s[i+1:]
+		if strings.ContainsRune(fracPart, '.') {
+			return 0, fmt.Errorf("%w: multiple decimal points in %q", ErrSyntax, s)
+		}
+		if fracPart == "" {
+			return 0, fmt.Errorf("%w: trailing decimal point in %q", ErrSyntax, s)
+		}
+	}
+	if intPart == "" {
+		return 0, fmt.Errorf("%w: missing integer digits in %q", ErrSyntax, s)
+	}
+	if err := checkDigits(intPart); err != nil {
+		return 0, err
+	}
+	if err := checkDigits(fracPart); err != nil {
+		return 0, err
+	}
+
+	// Trailing fraction zeros carry no value, so "750000.00" is exactly
+	// representable at every scale.  Trim before the precision check.
+	significant := strings.TrimRight(fracPart, "0")
+	if len(significant) > sc.Decimals {
+		return 0, fmt.Errorf("%w: %q needs %d decimals, scale %s holds %d",
+			ErrTooManyDecimals, s, len(significant), sc.Name, sc.Decimals)
+	}
+
+	// Right-pad the fraction to the scale so int+frac is the scaled integer
+	// in base 10; then accumulate digit by digit with an overflow guard.
+	digits := intPart + significant + strings.Repeat("0", sc.Decimals-len(significant))
+
+	var v int64
+	for i := 0; i < len(digits); i++ {
+		d := int64(digits[i] - '0')
+		if v > (math.MaxInt64-d)/10 {
+			return 0, fmt.Errorf("%w: %q at scale %s", ErrOverflow, s, sc.Name)
+		}
+		v = v*10 + d
+	}
+
+	if neg {
+		v = -v
+	}
+	return v, nil
+}
+
+func checkDigits(s string) error {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return fmt.Errorf("%w: non-digit %q", ErrSyntax, s[i])
+		}
+	}
+	return nil
+}
+
+// FormatDecimal renders a scaled int64 as canonical decimal text: no trailing
+// fraction zeros, no trailing decimal point, and a single "0" for zero.  This
+// is the representation-level form; use FormatFixed for display precision.
+func FormatDecimal(v int64, sc Scale) string {
+	neg := v < 0
+
+	// Negate through uint64 so math.MinInt64 does not wrap.
+	var mag uint64
+	if neg {
+		mag = uint64(-(v + 1)) + 1
+	} else {
+		mag = uint64(v)
+	}
+
+	factor := uint64(sc.Factor)
+	whole := mag / factor
+	frac := mag % factor
+
+	out := fmt.Sprintf("%d", whole)
+	if frac != 0 {
+		f := fmt.Sprintf("%0*d", sc.Decimals, frac)
+		out += "." + strings.TrimRight(f, "0")
+	}
+	if neg && (whole != 0 || frac != 0) {
+		out = "-" + out
+	}
+	return out
+}
+
+// FormatFixed renders a scaled int64 with exactly decimals fraction digits,
+// truncating toward zero when decimals is smaller than the scale.  It exists
+// to demonstrate that instrument display precision is independent of the
+// internal representation scale; truncation here is a study convenience, not a
+// rounding policy (that belongs to #38).
+func FormatFixed(v int64, sc Scale, decimals int) string {
+	if decimals < 0 {
+		decimals = 0
+	}
+
+	neg := v < 0
+	var mag uint64
+	if neg {
+		mag = uint64(-(v + 1)) + 1
+	} else {
+		mag = uint64(v)
+	}
+
+	factor := uint64(sc.Factor)
+	whole := mag / factor
+	frac := mag % factor
+
+	out := fmt.Sprintf("%d", whole)
+	if decimals > 0 {
+		f := fmt.Sprintf("%0*d", sc.Decimals, frac)
+		if decimals <= len(f) {
+			f = f[:decimals]
+		} else {
+			f += strings.Repeat("0", decimals-len(f))
+		}
+		out += "." + f
+	}
+	if neg {
+		out = "-" + out
+	}
+	return out
+}
+
+// Canonical returns the canonical decimal text for s, independent of any
+// scale: trailing fraction zeros and redundant leading zeros are removed.
+// Round-trip tests compare FormatDecimal(ParseDecimal(s)) against Canonical(s)
+// rather than against s itself, because "750000.00" and "750000" denote the
+// same value.
+func Canonical(s string) string {
+	neg := strings.HasPrefix(s, "-")
+	if neg {
+		s = s[1:]
+	}
+
+	intPart, fracPart := s, ""
+	if i := strings.IndexByte(s, '.'); i >= 0 {
+		intPart, fracPart = s[:i], s[i+1:]
+	}
+
+	intPart = strings.TrimLeft(intPart, "0")
+	if intPart == "" {
+		intPart = "0"
+	}
+	fracPart = strings.TrimRight(fracPart, "0")
+
+	out := intPart
+	if fracPart != "" {
+		out += "." + fracPart
+	}
+	if neg && out != "0" {
+		out = "-" + out
+	}
+	return out
+}
+
+// MaxPrice returns the largest whole price representable at sc.
+func MaxPrice(sc Scale) int64 { return math.MaxInt64 / sc.Factor }
+
+// MaxPriceText returns MaxPrice as decimal text.
+func MaxPriceText(sc Scale) string { return fmt.Sprintf("%d", MaxPrice(sc)) }
+
+// Headroom returns how many times larger MaxPrice is than the given scaled
+// price.  It answers "how much range is left above this asset" and is 0 when
+// the price already exceeds the representable maximum.
+func Headroom(scaled int64, sc Scale) int64 {
+	if scaled <= 0 {
+		return 0
+	}
+	return math.MaxInt64 / scaled
+}
+
+// MulOverflows reports whether a*b overflows int64.  Scaled multiplication
+// (Price x Quantity, Price x Rate) forms a double-scaled intermediate before
+// the descale divide, so the intermediate — not the result — is what
+// constrains the usable scale.
+func MulOverflows(a, b int64) bool {
+	if a == 0 || b == 0 {
+		return false
+	}
+	if a == math.MinInt64 || b == math.MinInt64 {
+		return true
+	}
+	p := a * b
+	return p/b != a
+}
+
+// AddOverflows reports whether a+b overflows int64.  Used for the rolling-sum
+// accumulation case.
+func AddOverflows(a, b int64) bool {
+	if b > 0 && a > math.MaxInt64-b {
+		return true
+	}
+	if b < 0 && a < math.MinInt64-b {
+		return true
+	}
+	return false
+}

--- a/test/internal/numericstudy/scale_test.go
+++ b/test/internal/numericstudy/scale_test.go
@@ -265,14 +265,72 @@ func TestUnsupportedQuotationsAreRejected(t *testing.T) {
 	}
 }
 
+// TestSubQuantumValuesRejected records the limit of normalization: turning a
+// provider quotation into plain decimal text does not guarantee the result is
+// representable.  Values finer than the 1e8 quantum are rejected outright
+// rather than silently rounded, so #38 and #39 must decide whether adapters
+// reject or explicitly round them.
+func TestSubQuantumValuesRejected(t *testing.T) {
+	sc := scaleByName(t, "1e8")
+	for _, v := range SubQuantumValues {
+		t.Run(v.Value, func(t *testing.T) {
+			require.Greater(t, v.Digits, sc.Decimals)
+
+			_, err := ParseDecimal(v.Value, sc)
+			assert.ErrorIs(t, err, ErrTooManyDecimals, v.Note)
+
+			// The same value is representable at 1e9, confirming the failure
+			// is the precision policy and not a parser defect.
+			_, err = ParseDecimal(v.Value, scaleByName(t, "1e9"))
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestParseCannotConstructMinInt64 documents an asymmetry between the parser
+// and the formatter: FormatDecimal renders math.MinInt64, but ParseDecimal
+// cannot construct it.  Parsing builds the magnitude first and negates last,
+// and the magnitude 9223372036854775808 exceeds MaxInt64, so the guard fires
+// one unit before the true negative bound.
+//
+// The study does not paper over this; the final negative-range policy belongs
+// to #39, which must decide whether the parser accepts the full int64 range or
+// the domain range is deliberately symmetric.
+func TestParseCannotConstructMinInt64(t *testing.T) {
+	sc := scaleByName(t, "1e8")
+
+	assert.Equal(t, "-92233720368.54775808", FormatDecimal(math.MinInt64, sc))
+
+	_, err := ParseDecimal("-92233720368.54775808", sc)
+	assert.ErrorIs(t, err, ErrOverflow,
+		"known gap: the most negative value cannot be parsed back")
+
+	// One unit inside the bound round-trips normally, so the gap is exactly
+	// one representable value wide.
+	v, err := ParseDecimal("-92233720368.54775807", sc)
+	require.NoError(t, err)
+	assert.Equal(t, int64(math.MinInt64+1), v)
+	assert.Equal(t, "-92233720368.54775807", FormatDecimal(v, sc))
+}
+
 func TestMulOverflows(t *testing.T) {
 	assert.False(t, MulOverflows(0, math.MaxInt64))
 	assert.False(t, MulOverflows(math.MaxInt64, 0))
 	assert.False(t, MulOverflows(math.MaxInt64, 1))
 	assert.False(t, MulOverflows(-1, math.MaxInt64))
 	assert.True(t, MulOverflows(math.MaxInt64, 2))
-	assert.True(t, MulOverflows(math.MinInt64, 1), "MinInt64 has no positive twin")
 	assert.True(t, MulOverflows(1<<32, 1<<32))
+
+	// Signed boundary.  MinInt64 x 1 is exact; only negation overflows,
+	// because MinInt64 has no positive twin.  Go defines MinInt64 / -1 as
+	// MinInt64, so the usual p/b != a check misses MinInt64 x -1 and it
+	// needs an explicit guard.
+	assert.False(t, MulOverflows(math.MinInt64, 1))
+	assert.False(t, MulOverflows(1, math.MinInt64))
+	assert.True(t, MulOverflows(math.MinInt64, -1))
+	assert.True(t, MulOverflows(-1, math.MinInt64))
+	assert.True(t, MulOverflows(math.MinInt64, 2))
+	assert.True(t, MulOverflows(math.MinInt64, math.MinInt64))
 }
 
 func TestAddOverflows(t *testing.T) {

--- a/test/internal/numericstudy/scale_test.go
+++ b/test/internal/numericstudy/scale_test.go
@@ -1,0 +1,295 @@
+package numericstudy
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRoundTrip is the core evidence for #33: every representative asset
+// price, at every candidate scale, either round-trips exactly or fails for a
+// documented reason.  A scale that cannot hold a value we intend to support is
+// disqualified, and the subtest name says which pair failed.
+func TestRoundTrip(t *testing.T) {
+	for _, sc := range Candidates {
+		for _, a := range Assets {
+			t.Run(sc.Name+"/"+a.Symbol, func(t *testing.T) {
+				v, err := ParseDecimal(a.Price, sc)
+				if a.Decimals > sc.Decimals {
+					require.ErrorIs(t, err, ErrTooManyDecimals,
+						"%s needs %d decimals; scale %s holds %d",
+						a.Symbol, a.Decimals, sc.Name, sc.Decimals)
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, Canonical(a.Price), FormatDecimal(v, sc),
+					"round trip must be exact")
+			})
+		}
+	}
+}
+
+// TestTickSizeRepresentable checks that instrument tick sizes parse exactly.
+// Tick size is an instrument rule, not the representation scale, but a scale
+// that cannot express a tick cannot validate price increments either.
+func TestTickSizeRepresentable(t *testing.T) {
+	for _, sc := range Candidates {
+		for _, a := range Assets {
+			t.Run(sc.Name+"/"+a.Symbol, func(t *testing.T) {
+				v, err := ParseDecimal(a.TickSize, sc)
+				if a.Decimals > sc.Decimals {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, Canonical(a.TickSize), FormatDecimal(v, sc))
+				assert.Positive(t, v, "tick size must be non-zero at this scale")
+			})
+		}
+	}
+}
+
+// TestPriceIsMultipleOfTick confirms the separation of concerns: with prices
+// and ticks in the same internal scale, "is this price on a valid increment?"
+// is exact integer modulo, with no scale-specific special cases.
+func TestPriceIsMultipleOfTick(t *testing.T) {
+	sc := scaleByName(t, "1e9")
+	for _, a := range Assets {
+		t.Run(a.Symbol, func(t *testing.T) {
+			p, err := ParseDecimal(a.Price, sc)
+			require.NoError(t, err)
+			tick, err := ParseDecimal(a.TickSize, sc)
+			require.NoError(t, err)
+			assert.Zero(t, p%tick, "%s price must sit on a tick boundary", a.Symbol)
+		})
+	}
+}
+
+// TestRangeHeadroom documents the maximum whole price at each scale and
+// asserts the highest-priced asset we intend to support still fits with room
+// to spare.
+func TestRangeHeadroom(t *testing.T) {
+	want := map[string]int64{
+		"1e5": 92_233_720_368_547,
+		"1e6": 9_223_372_036_854,
+		"1e8": 92_233_720_368,
+		"1e9": 9_223_372_036,
+	}
+	for _, sc := range Candidates {
+		t.Run(sc.Name, func(t *testing.T) {
+			require.Equal(t, want[sc.Name], MaxPrice(sc))
+
+			if sc.Decimals < 2 {
+				return
+			}
+			v, err := ParseDecimal("750000.00", sc)
+			require.NoError(t, err, "BRK.A-class price must be representable")
+			assert.Greater(t, Headroom(v, sc), int64(1_000),
+				"want at least 1000x headroom above the highest-priced asset")
+		})
+	}
+}
+
+// TestMaxBoundary walks the exact edge of representability at each scale.
+func TestMaxBoundary(t *testing.T) {
+	for _, sc := range Candidates {
+		t.Run(sc.Name, func(t *testing.T) {
+			max := MaxPriceText(sc)
+
+			v, err := ParseDecimal(max, sc)
+			require.NoError(t, err)
+			assert.Equal(t, max, FormatDecimal(v, sc))
+
+			past := strconv.FormatInt(MaxPrice(sc)+1, 10)
+			_, err = ParseDecimal(past, sc)
+			assert.ErrorIs(t, err, ErrOverflow, "one whole unit past max must overflow")
+		})
+	}
+}
+
+// TestSmallestRepresentable checks the other end of the range: one scale unit.
+func TestSmallestRepresentable(t *testing.T) {
+	cases := map[string]string{
+		"1e5": "0.00001",
+		"1e6": "0.000001",
+		"1e8": "0.00000001",
+		"1e9": "0.000000001",
+	}
+	for _, sc := range Candidates {
+		t.Run(sc.Name, func(t *testing.T) {
+			text := cases[sc.Name]
+			v, err := ParseDecimal(text, sc)
+			require.NoError(t, err)
+			assert.Equal(t, int64(1), v)
+			assert.Equal(t, text, FormatDecimal(v, sc))
+
+			// Half a unit is not representable and must be rejected, not
+			// silently rounded to 0 or 1.
+			_, err = ParseDecimal(text+"5", sc)
+			assert.ErrorIs(t, err, ErrTooManyDecimals)
+		})
+	}
+}
+
+func TestParseRejects(t *testing.T) {
+	sc := scaleByName(t, "1e9")
+	cases := []struct {
+		name, in string
+		wantErr  error
+	}{
+		{"empty", "", ErrSyntax},
+		{"bare sign", "-", ErrSyntax},
+		{"leading plus", "+1.5", ErrSyntax},
+		{"double dot", "1.2.3", ErrSyntax},
+		{"trailing dot", "1.", ErrSyntax},
+		{"leading dot", ".5", ErrSyntax},
+		{"space", " 1.5", ErrSyntax},
+		{"trailing space", "1.5 ", ErrSyntax},
+		{"grouped", "750,000.00", ErrSyntax},
+		{"exponent", "1.5e-8", ErrSyntax},
+		{"treasury dash", "110-16", ErrSyntax},
+		{"grain apostrophe", "575'6", ErrSyntax},
+		{"letters", "abc", ErrSyntax},
+		{"nan", "NaN", ErrSyntax},
+		{"inf", "Inf", ErrSyntax},
+		{"too many decimals", "1.0000000001", ErrTooManyDecimals},
+		{"overflow", "99999999999.0", ErrOverflow},
+		{"negative overflow", "-99999999999.0", ErrOverflow},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := ParseDecimal(c.in, sc)
+			assert.ErrorIs(t, err, c.wantErr)
+		})
+	}
+}
+
+func TestParseAccepts(t *testing.T) {
+	sc := scaleByName(t, "1e9")
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		{"0", 0},
+		{"-0", 0},
+		{"0.0", 0},
+		{"-0.0", 0},
+		{"1", 1_000_000_000},
+		{"-1", -1_000_000_000},
+		{"000123.4500", 123_450_000_000},
+		{"1.08473", 1_084_730_000},
+		{"-1.08473", -1_084_730_000},
+		{"0.000000001", 1},
+		{"-0.000000001", -1},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			v, err := ParseDecimal(c.in, sc)
+			require.NoError(t, err)
+			assert.Equal(t, c.want, v)
+		})
+	}
+}
+
+// TestFormatNegativeAndZero pins the sign and zero handling that a naive
+// int64 division would get wrong.
+func TestFormatNegativeAndZero(t *testing.T) {
+	sc := scaleByName(t, "1e9")
+	cases := []struct {
+		v    int64
+		want string
+	}{
+		{0, "0"},
+		{1, "0.000000001"},
+		{-1, "-0.000000001"},
+		{-500_000_000, "-0.5"},
+		{-1_500_000_000, "-1.5"},
+		{math.MaxInt64, "9223372036.854775807"},
+		{math.MinInt64, "-9223372036.854775808"},
+	}
+	for _, c := range cases {
+		t.Run(c.want, func(t *testing.T) {
+			assert.Equal(t, c.want, FormatDecimal(c.v, sc))
+		})
+	}
+}
+
+// TestFormatFixed demonstrates that display precision is chosen per
+// instrument and is independent of the internal scale.
+func TestFormatFixed(t *testing.T) {
+	sc := scaleByName(t, "1e9")
+	v, err := ParseDecimal("1.08473", sc)
+	require.NoError(t, err)
+
+	assert.Equal(t, "1", FormatFixed(v, sc, 0))
+	assert.Equal(t, "1.08", FormatFixed(v, sc, 2))
+	assert.Equal(t, "1.08473", FormatFixed(v, sc, 5))
+	assert.Equal(t, "1.084730000000", FormatFixed(v, sc, 12))
+	assert.Equal(t, "-1.08473", FormatFixed(-v, sc, 5))
+}
+
+func TestCanonical(t *testing.T) {
+	cases := map[string]string{
+		"750000.00":  "750000",
+		"1.08473":    "1.08473",
+		"0.00000001": "0.00000001",
+		"000123.450": "123.45",
+		"-0.0":       "0",
+		"-1.500":     "-1.5",
+		"0":          "0",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, want, Canonical(in))
+		})
+	}
+}
+
+// TestUnsupportedQuotationsAreRejected proves the documented unsupported
+// formats really do fail at the parse boundary, and that the decimal each one
+// normalizes to is representable once an adapter has converted it.
+func TestUnsupportedQuotationsAreRejected(t *testing.T) {
+	sc := scaleByName(t, "1e9")
+	for _, q := range UnsupportedQuotations {
+		t.Run(q.Format, func(t *testing.T) {
+			_, err := ParseDecimal(q.Example, sc)
+			require.Error(t, err, "raw quotation must not parse")
+
+			v, err := ParseDecimal(q.Decimal, sc)
+			require.NoError(t, err, "normalized decimal must parse")
+			assert.Equal(t, Canonical(q.Decimal), FormatDecimal(v, sc))
+		})
+	}
+}
+
+func TestMulOverflows(t *testing.T) {
+	assert.False(t, MulOverflows(0, math.MaxInt64))
+	assert.False(t, MulOverflows(math.MaxInt64, 0))
+	assert.False(t, MulOverflows(math.MaxInt64, 1))
+	assert.False(t, MulOverflows(-1, math.MaxInt64))
+	assert.True(t, MulOverflows(math.MaxInt64, 2))
+	assert.True(t, MulOverflows(math.MinInt64, 1), "MinInt64 has no positive twin")
+	assert.True(t, MulOverflows(1<<32, 1<<32))
+}
+
+func TestAddOverflows(t *testing.T) {
+	assert.False(t, AddOverflows(math.MaxInt64, 0))
+	assert.False(t, AddOverflows(math.MaxInt64-1, 1))
+	assert.True(t, AddOverflows(math.MaxInt64, 1))
+	assert.False(t, AddOverflows(math.MinInt64+1, -1))
+	assert.True(t, AddOverflows(math.MinInt64, -1))
+}
+
+func scaleByName(t *testing.T, name string) Scale {
+	t.Helper()
+	for _, sc := range Candidates {
+		if sc.Name == name {
+			return sc
+		}
+	}
+	t.Fatalf("unknown scale %q", name)
+	return Scale{}
+}

--- a/test/internal/numericstudy/tables.go
+++ b/test/internal/numericstudy/tables.go
@@ -1,0 +1,297 @@
+package numericstudy
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Format selects the markup a table fragment is rendered in.  The same data
+// backs both, so the ADR (org) and README (markdown) cannot disagree.
+type Format int
+
+const (
+	FormatOrg Format = iota
+	FormatMarkdown
+)
+
+// column is one rendered column: a header, an alignment, and its cells.
+type column struct {
+	header string
+	right  bool
+	cells  []string
+}
+
+// renderTable lays out columns as an aligned org or markdown table.  Alignment
+// is cosmetic in both formats, but keeps the checked-in docs readable and
+// makes regeneration diffs small.
+func renderTable(f Format, cols []column) string {
+	rows := 0
+	for _, c := range cols {
+		rows = max(rows, len(c.cells))
+	}
+
+	// Column widths are counted in runes, not bytes: the "—" used for
+	// unrepresentable values is three bytes wide but one column wide.
+	width := make([]int, len(cols))
+	for i, c := range cols {
+		width[i] = utf8.RuneCountInString(c.header)
+		for _, v := range c.cells {
+			width[i] = max(width[i], utf8.RuneCountInString(v))
+		}
+	}
+
+	pad := func(i int, s string) string {
+		gap := strings.Repeat(" ", width[i]-utf8.RuneCountInString(s))
+		if cols[i].right {
+			return gap + s
+		}
+		return s + gap
+	}
+
+	var b strings.Builder
+
+	b.WriteString("|")
+	for i, c := range cols {
+		b.WriteString(" " + pad(i, c.header) + " |")
+	}
+	b.WriteString("\n")
+
+	// Separator: org uses +, markdown uses | and encodes alignment in the rule.
+	b.WriteString("|")
+	for i := range cols {
+		rule := strings.Repeat("-", width[i]+2)
+		if f == FormatMarkdown {
+			if cols[i].right {
+				rule = strings.Repeat("-", width[i]+1) + ":"
+			}
+			b.WriteString(rule + "|")
+			continue
+		}
+		b.WriteString(rule)
+		if i == len(cols)-1 {
+			b.WriteString("|")
+		} else {
+			b.WriteString("+")
+		}
+	}
+	b.WriteString("\n")
+
+	for r := range rows {
+		b.WriteString("|")
+		for i, c := range cols {
+			v := ""
+			if r < len(c.cells) {
+				v = c.cells[r]
+			}
+			b.WriteString(" " + pad(i, v) + " |")
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// code wraps an inline literal in the target format's verbatim markup.
+func code(f Format, s string) string {
+	if f == FormatMarkdown {
+		return "`" + s + "`"
+	}
+	return "=" + s + "="
+}
+
+// commas groups an integer with thousands separators.
+func commas(v int64) string {
+	s := fmt.Sprintf("%d", v)
+	neg := strings.HasPrefix(s, "-")
+	if neg {
+		s = s[1:]
+	}
+
+	var parts []string
+	for len(s) > 3 {
+		parts = append([]string{s[len(s)-3:]}, parts...)
+		s = s[:len(s)-3]
+	}
+	parts = append([]string{s}, parts...)
+
+	out := strings.Join(parts, ",")
+	if neg {
+		out = "-" + out
+	}
+	return out
+}
+
+// scaledCells renders one asset's stored value at every candidate scale.
+func scaledCells(price string) []string {
+	out := make([]string, 0, len(Candidates))
+	for _, sc := range Candidates {
+		v, err := ParseDecimal(price, sc)
+		switch {
+		case err != nil:
+			out = append(out, "—")
+		case FormatDecimal(v, sc) != Canonical(price):
+			out = append(out, "INEXACT")
+		default:
+			out = append(out, fmt.Sprintf("%d", v))
+		}
+	}
+	return out
+}
+
+// Fragments renders every generated table, keyed by the name used in the
+// document markers.  Adding a fragment here makes it available to any document
+// that opens a matching marker pair.
+func Fragments(f Format) map[string]string {
+	frag := map[string]string{}
+
+	// Asset representation matrix -------------------------------------------
+	cols := []column{
+		{header: "Class", cells: pluck(Assets, func(a Asset) string { return a.Class })},
+		{header: "Symbol", cells: pluck(Assets, func(a Asset) string { return a.Symbol })},
+		{header: "Price", right: true, cells: pluck(Assets, func(a Asset) string { return a.Price })},
+		{header: "Tick", right: true, cells: pluck(Assets, func(a Asset) string { return a.TickSize })},
+		{header: "Dec", right: true, cells: pluck(Assets, func(a Asset) string { return fmt.Sprint(a.Decimals) })},
+	}
+	for i, sc := range Candidates {
+		cells := make([]string, 0, len(Assets))
+		for _, a := range Assets {
+			cells = append(cells, scaledCells(a.Price)[i])
+		}
+		cols = append(cols, column{header: sc.Name, right: true, cells: cells})
+	}
+	frag["asset-matrix"] = renderTable(f, cols)
+
+	// Range and headroom ----------------------------------------------------
+	var name, dec, maxp, unit, head []string
+	for _, sc := range Candidates {
+		name = append(name, sc.Name)
+		dec = append(dec, fmt.Sprint(sc.Decimals))
+		maxp = append(maxp, commas(MaxPrice(sc)))
+		unit = append(unit, FormatDecimal(1, sc))
+		if v, err := ParseDecimal("750000.00", sc); err == nil {
+			head = append(head, commas(Headroom(v, sc))+"x")
+		} else {
+			head = append(head, "n/a")
+		}
+	}
+	frag["range-headroom"] = renderTable(f, []column{
+		{header: "Scale", cells: name},
+		{header: "Decimals", right: true, cells: dec},
+		{header: "Max price", right: true, cells: maxp},
+		{header: "Smallest unit", right: true, cells: unit},
+		{header: "Headroom over 750000.00", right: true, cells: head},
+	})
+
+	// Price x Quantity margins ----------------------------------------------
+	frag["notional-all"] = notionalTable(f, Candidates)
+	frag["notional-8v9"] = notionalTable(f, []Scale{
+		mustScale("1e8"), mustScale("1e9"),
+	})
+
+	// Rolling-sum capacity --------------------------------------------------
+	var rsScale, rsBars []string
+	for _, sc := range Candidates {
+		v, err := ParseDecimal("750000.00", sc)
+		if err != nil {
+			continue
+		}
+		rsScale = append(rsScale, sc.Name)
+		rsBars = append(rsBars, commas(MaxPriceCeil(v)))
+	}
+	frag["rolling-sum"] = renderTable(f, []column{
+		{header: "Scale", cells: rsScale},
+		{header: "Bars of 750000.00 before overflow", right: true, cells: rsBars},
+	})
+
+	// Sub-quantum values ----------------------------------------------------
+	frag["subquantum"] = renderTable(f, []column{
+		{header: "Value", cells: pluckSub(func(i int) string { return code(f, SubQuantumValues[i].Value) })},
+		{header: "Digits", right: true, cells: pluckSub(func(i int) string { return fmt.Sprint(SubQuantumValues[i].Digits) })},
+		{header: "Note", cells: pluckSub(func(i int) string { return SubQuantumValues[i].Note })},
+	})
+
+	// Unsupported quotation formats -----------------------------------------
+	var uf, ue, ud, ur []string
+	for _, q := range UnsupportedQuotations {
+		uf = append(uf, q.Format)
+		ue = append(ue, code(f, q.Example))
+		ud = append(ud, q.Decimal)
+		ur = append(ur, q.Reason)
+	}
+	frag["unsupported"] = renderTable(f, []column{
+		{header: "Format", cells: uf},
+		{header: "Example", cells: ue},
+		{header: "Normalizes to", right: true, cells: ud},
+		{header: "Reason", cells: ur},
+	})
+
+	return frag
+}
+
+func notionalTable(f Format, scales []Scale) string {
+	cols := []column{
+		{header: "Case", cells: pluckNotional(func(n Notional) string { return n.Name })},
+		{header: "Quantity", right: true, cells: pluckNotional(func(n Notional) string { return commas(n.Quantity) })},
+	}
+	for _, sc := range scales {
+		cells := make([]string, 0, len(Notionals))
+		for _, n := range Notionals {
+			p, err := ParseDecimal(n.Price, sc)
+			switch {
+			case err != nil:
+				cells = append(cells, "n/a")
+			case MulOverflows(p, n.Quantity):
+				cells = append(cells, "OVERFLOW")
+			default:
+				cells = append(cells, commas(MaxPriceCeil(p*n.Quantity))+"x")
+			}
+		}
+		cols = append(cols, column{header: sc.Name, right: true, cells: cells})
+	}
+	return renderTable(f, cols)
+}
+
+// MaxPriceCeil reports how many times v divides into the int64 ceiling — the
+// margin remaining above an already-computed intermediate.
+func MaxPriceCeil(v int64) int64 {
+	if v <= 0 {
+		return 0
+	}
+	return maxInt64 / v
+}
+
+const maxInt64 = int64(^uint64(0) >> 1)
+
+func mustScale(name string) Scale {
+	for _, sc := range Candidates {
+		if sc.Name == name {
+			return sc
+		}
+	}
+	panic("numericstudy: unknown scale " + name)
+}
+
+func pluck(in []Asset, fn func(Asset) string) []string {
+	out := make([]string, 0, len(in))
+	for _, a := range in {
+		out = append(out, fn(a))
+	}
+	return out
+}
+
+func pluckNotional(fn func(Notional) string) []string {
+	out := make([]string, 0, len(Notionals))
+	for _, n := range Notionals {
+		out = append(out, fn(n))
+	}
+	return out
+}
+
+func pluckSub(fn func(int) string) []string {
+	out := make([]string, 0, len(SubQuantumValues))
+	for i := range SubQuantumValues {
+		out = append(out, fn(i))
+	}
+	return out
+}


### PR DESCRIPTION
Resolves #33. Feeds ADR-004 under parent decision #19.

A code-backed design investigation, not an implementation of the final `Price` type. It produces the evidence ADR-004 needs to fix the internal `Price` scale.

## Recommendation: fixed internal `Price` scale of 1e8

A decimal value `v` is stored as the `int64` `v * 100_000_000`.

Four candidates were evaluated — 1e5, 1e6, 1e8, 1e9 — against FX, equities, futures, high-priced assets, crypto, small-priced assets, and rates.

**Precision eliminates 1e5 and 1e6.** Neither represents satoshi precision, and 1e5 cannot represent the 64ths Treasury futures expand to.

**Storage range separates nothing.** 1e8 tops out at ~92.2 billion (~122,000× the highest-priced listed equity); 1e9 at ~9.2 billion. Both are far above anything we intend to trade.

**Intermediate arithmetic decides it.** Margin to the `int64` ceiling for `Price × Quantity`, using whole unscaled quantities:

| Case | Quantity | 1e8 | 1e9 |
|---|---:|---:|---:|
| BRK.A block | 10,000 | **12×** | **1×** |
| FX 10M notional | 10,000,000 | 8,502× | 850× |
| FX 1B notional | 1,000,000,000 | 85× | 8× |
| BTC 1k coins | 1,000 | 614× | 61× |

1e9 leaves the largest realistic notional essentially *at* the ceiling. 1e8 buys back an order of magnitude for one decimal place no intended asset class needs, and 8 decimals is exactly satoshi precision — the widest decimal requirement Trader accepts.

**Caveat, pending #36.** These margins assume whole unscaled quantities, so only one operand carries a scale. If `Quantity` gets its own scale, these products become double-scaled like `Price × Rate` and need widened arithmetic too. That does not change the 1e8 selection — still 10× better than 1e9 — but it moves the operation from "safe in `int64`" to "must use the widened path."

## Two findings for #38

Neither is fixable by choosing a different scale. Both are posted to #38 with the boundary items attached:

1. **Double-scaled products overflow at every usable scale.** `Price × Rate` scales both operands, so the product carries the scale twice before descaling. At 1e8, BRK.A × a financing rate and BTC/USD × a JPY conversion rate both overflow `int64`; 1e9 is worse. A widened 128-bit intermediate is required — `TestPriceTimesRateWidened` demonstrates one that agrees with the narrow path wherever the narrow path is valid.
2. **Naive accumulation overflows inside a single backtest.** A plain `int64` sum of high-priced bars dies after ~122,978 bars at 1e8, under three months of M1 data. Rolling sums need a widened accumulator or a running mean.

## Documentation cannot drift from the evidence

Every table in ADR-004 and the study README sits between `numericstudy:` markers and is generated from `Assets`, `Notionals`, `Rates`, `Candidates`, and `SubQuantumValues`. `TestGeneratedTables` re-renders each region and fails if the checked-in text differs, naming the stale fragment and the fix:

```
docs/arch/adr-004-exact-numeric-representation.org is stale in [notional-8v9] — regenerate with:
  go test ./test/internal/numericstudy/ -run TestGeneratedTables -update
```

Markers use each format's comment syntax so they stay invisible when rendered (`# BEGIN numericstudy:<name>` in org, an HTML comment in markdown), and one renderer emits both formats, so the ADR and README cannot disagree either.

Two companion tests keep the mechanism honest. `TestEveryFragmentIsUsed` fails on a generated table no document embeds — it immediately caught one the report printed but nothing recorded, so the ADR now carries the full four-scale margin table as evidence. `TestFragmentsRenderInBothFormats` checks both renderers agree on structure.

**Reviewer note:** do not hand-edit inside the markers; run the `-update` command instead.

## What's here

| Path | Contents |
|---|---|
| `test/internal/numericstudy/scale.go` | `ParseDecimal`, `FormatDecimal`, `FormatFixed`, `Canonical`, range and overflow helpers |
| `test/internal/numericstudy/assets.go` | Asset matrix, notional, rate, and sub-quantum cases — all as data |
| `test/internal/numericstudy/tables.go` | Renders each table fragment in org or markdown |
| `test/internal/numericstudy/scale_test.go` | Round-trip, tick, boundary, and rejection tests |
| `test/internal/numericstudy/overflow_test.go` | Intermediate-arithmetic evidence, plus 128-bit mul/div study helpers |
| `test/internal/numericstudy/golden_test.go` | Verifies (and with `-update`, rewrites) generated regions |
| `test/internal/numericstudy/report_test.go` | Prints the full report for reading |
| `test/internal/numericstudy/README.md` | Findings summary |
| `docs/arch/adr-004-exact-numeric-representation.org` | Decision, tables, consequences; #33 marked resolved |
| `docs/arch/adr-decisions.org` | ADR-004 status corrected to `Proposed` |

Two deliberate choices in the harness:

- **No `float64` on any path.** Decimal text converts directly to and from scaled `int64`, digit by digit, with an overflow guard on each step.
- **Parsing rejects rather than rounds.** `ErrTooManyDecimals`, `ErrOverflow`, and `ErrSyntax` are distinct, because losing precision and exceeding range lead to different conclusions. Silent rounding would hide the exact failures the study exists to surface.

The package sits under `test/internal/` so the import path itself keeps it out of production code — nothing outside `test/` can reference it. It should be deleted or superseded when #44 consolidates ADR-004.

## Review round: what changed

Six items from the #33 review, addressed in `4325ca2` and `7f5eb8e`. Two were real defects:

- **`MulOverflows` was wrong at the signed boundary.** It reported `MinInt64 × 1` as overflow, which is exact. The subtlety is why a guard is needed at all: Go defines `MinInt64 / -1` as `MinInt64`, so the standard `p/b != a` check passes *spuriously* on `MinInt64 × -1` and misses a genuine overflow. Explicit guard added, both operand orders tested.
- **The scientific-notation row asserted a value the scale rejects.** `1.5e-8` expands to `0.000000015`, which needs 9 decimals. Beyond correcting the example, added `SubQuantumValues` and `TestSubQuantumValuesRejected` to state the general point: normalization is necessary but not sufficient. Those values are rejected at 1e8 and accepted at 1e9, proving the failure is the precision policy rather than a parser defect.

The rest: ADR-004 status `Work in Progress` → `Proposed` (it was the registry's only entry not using a defined status); `Price × Quantity` qualified as whole unscaled quantities everywhere it appears, with the #36 consequence recorded; the `ParseDecimal`/`math.MinInt64` gap documented and pinned by `TestParseCannotConstructMinInt64`, forwarded to #39; and the unbacked "cannot drift" claim replaced with the mechanism above.

Also found while building the generator: column widths were measured in bytes, so the multi-byte `—` marking unrepresentable values misaligned every column after it — now counted in runes.

## Notes for review

- `testify` is added as a dependency per AGENTS.md, hence the new `go.sum`.
- The ADR diff also carries a pre-existing text reflow that was already in the working tree before this work.
- Margin columns use integer division, so a few values differ in the last digit from figures quoted in earlier #33 comments (8,503× → 8,502×, 615× → 614×, 9× → 8×). The figures the argument rests on, 12× against 1×, are unchanged.
- The report print is gated on `-v`, so `make check` output stays clean. `NUMERICSTUDY_REPORT=<path>` writes it to a file.

## Verification

`make check` passes (`fmt-check`, `vet`, `test`, `race`). Coverage 95.9% of the study package — down from 98.1% because the new rendering code has branches only reachable on malformed input.

Confirmed by hand that corrupting a checked-in table fails `TestGeneratedTables` and that `-update` restores it.

```sh
go test ./test/internal/numericstudy/ -run TestGenerateReport -v          # read the report
go test ./test/internal/numericstudy/ -run TestGeneratedTables -update    # refresh the docs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsfxQH4YBP5DA1LpAafWyt
