### PR TITLE
M1-01a follow-up: numericstudy review cleanups (#33)

### DIFF
--- a/test/internal/numericstudy/README.md
+++ b/test/internal/numericstudy/README.md
@@ -200,12 +200,18 @@ symmetric.
 | `scale_test.go`    | Round-trip, tick, boundary, and rejection tests                                         |
 | `overflow_test.go` | Intermediate-arithmetic evidence, plus 128-bit mul/div study helpers                    |
 | `golden_test.go`   | Verifies (and with `-update`, rewrites) the generated regions in this file and the ADR  |
+| `nofloat_test.go`  | Fails if `float32`/`float64` or a float literal appears anywhere in the package         |
 | `report_test.go`   | Prints the full report for reading                                                      |
 
 Two deliberate choices in `scale.go`:
 
-- **No `float64` anywhere.** Decimal text converts directly to and from scaled
-  `int64`, digit by digit, with an overflow guard on each step.
+- **No binary floating point anywhere, including the reporting.** Parsing,
+  formatting, round trips, tick checks, and every overflow and margin
+  calculation are integer arithmetic end to end: decimal text converts directly
+  to and from scaled `int64`, digit by digit, with an overflow guard on each
+  step. A study arguing against binary floating point should not lean on it to
+  reach its conclusions, so `TestNoFloatingPoint` fails if `float32` or
+  `float64` appears anywhere in the package.
 - **Parsing rejects rather than rounds.** `ErrTooManyDecimals`, `ErrOverflow`,
   and `ErrSyntax` are distinct because losing precision and exceeding range
   lead to different conclusions. A study that silently rounded would hide the

--- a/test/internal/numericstudy/nofloat_test.go
+++ b/test/internal/numericstudy/nofloat_test.go
@@ -1,0 +1,65 @@
+package numericstudy
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoFloatingPoint enforces the study's central claim: this package reaches
+// its conclusions without binary floating point at any point, including the
+// margin and headroom reporting.
+//
+// An earlier revision computed margins in float64, which made the README's
+// "no float64" claim false in exactly the place a reader would care about — a
+// study arguing against binary floating point should not depend on it to
+// produce its evidence.  This test keeps that from coming back.
+//
+// It parses each file rather than grepping so identifiers in comments and
+// strings, including this comment, do not trip it.
+func TestNoFloatingPoint(t *testing.T) {
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	checked := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		checked++
+
+		t.Run(e.Name(), func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, filepath.Join(dir, e.Name()), nil, 0)
+			require.NoError(t, err)
+
+			ast.Inspect(file, func(n ast.Node) bool {
+				switch v := n.(type) {
+				case *ast.Ident:
+					if v.Name == "float64" || v.Name == "float32" {
+						t.Errorf("%s: %s used at %s",
+							e.Name(), v.Name, fset.Position(v.Pos()))
+					}
+				case *ast.BasicLit:
+					if v.Kind == token.FLOAT || v.Kind == token.IMAG {
+						t.Errorf("%s: floating-point literal %s at %s",
+							e.Name(), v.Value, fset.Position(v.Pos()))
+					}
+				}
+				return true
+			})
+		})
+	}
+
+	assert.Greater(t, checked, 1, "expected to scan the package's Go files")
+}

--- a/test/internal/numericstudy/overflow_test.go
+++ b/test/internal/numericstudy/overflow_test.go
@@ -46,20 +46,27 @@ func TestScaleMargins(t *testing.T) {
 	worst := Notionals[0] // BRK.A block: highest price x institutional size
 	require.Equal(t, "BRK.A block", worst.Name)
 
-	margin := func(name string) float64 {
+	// Computed in integer arithmetic throughout: a study arguing against
+	// binary floating point should not lean on it to reach its conclusion.
+	product := func(name string) int64 {
 		sc := scaleByName(t, name)
 		p, err := ParseDecimal(worst.Price, sc)
 		require.NoError(t, err)
 		require.False(t, MulOverflows(p, worst.Quantity))
-		return float64(math.MaxInt64) / float64(p*worst.Quantity)
+		return p * worst.Quantity
 	}
 
-	m8, m9 := margin("1e8"), margin("1e9")
-	t.Logf("%s margin to int64 ceiling: 1e8=%.1fx 1e9=%.1fx", worst.Name, m8, m9)
+	p8, p9 := product("1e8"), product("1e9")
+	m8, m9 := MaxPriceCeil(p8), MaxPriceCeil(p9)
+	t.Logf("%s margin to int64 ceiling: 1e8=%dx 1e9=%dx", worst.Name, m8, m9)
 
-	assert.Greater(t, m8, 10.0, "1e8 must leave an order of magnitude spare")
-	assert.Less(t, m9, 10.0, "1e9 is expected to be the tight option")
-	assert.InDelta(t, 10.0, m8/m9, 0.1, "the two scales differ by exactly 10x")
+	assert.Greater(t, m8, int64(10), "1e8 must leave an order of magnitude spare")
+	assert.Less(t, m9, int64(10), "1e9 is expected to be the tight option")
+
+	// One decimal place apart, so the intermediates differ by exactly 10x.
+	// Asserting on the products rather than the margins keeps this exact:
+	// the margins are truncating quotients and would only agree approximately.
+	assert.Equal(t, p8*10, p9, "the two scales differ by exactly 10x")
 }
 
 // TestPriceTimesRate is the decisive intermediate case: both operands are

--- a/test/internal/numericstudy/scale.go
+++ b/test/internal/numericstudy/scale.go
@@ -9,10 +9,15 @@ import (
 
 // Scale is a candidate fixed internal representation scale for Price.
 //
-// A decimal value v is stored as the int64 round(v * Factor), where Factor is
-// exactly 10**Decimals.  The scale is a property of the representation, not of
-// any instrument: instrument tick size, permitted increment, and display
-// precision are separate concerns (see TickSize on Asset and FormatFixed).
+// A decimal value v is stored as the int64 v * Factor, where Factor is exactly
+// 10**Decimals.  There is no rounding: a value is accepted only if it scales
+// to an integer exactly, and ParseDecimal rejects anything finer with
+// ErrTooManyDecimals.  The eventual production rounding policy is #38's
+// decision, not this study's.
+//
+// The scale is a property of the representation, not of any instrument:
+// instrument tick size, permitted increment, and display precision are
+// separate concerns (see TickSize on Asset and FormatFixed).
 type Scale struct {
 	Name     string
 	Decimals int
@@ -180,10 +185,20 @@ func FormatFixed(v int64, sc Scale, decimals int) string {
 		}
 		out += "." + f
 	}
-	if neg {
+
+	// Truncating toward zero can erase the whole magnitude, e.g. -1 at scale
+	// 1e9 shown with 2 decimals.  Emit "0.00", not "-0.00": the sign would
+	// claim a precision the display does not have.
+	if neg && !isDisplayZero(out) {
 		out = "-" + out
 	}
 	return out
+}
+
+// isDisplayZero reports whether rendered decimal text is all zero digits, so
+// a sign would be meaningless.
+func isDisplayZero(s string) bool {
+	return strings.Trim(s, "0.") == ""
 }
 
 // Canonical returns the canonical decimal text for s, independent of any

--- a/test/internal/numericstudy/scale_test.go
+++ b/test/internal/numericstudy/scale_test.go
@@ -3,6 +3,7 @@ package numericstudy
 import (
 	"math"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -229,6 +230,48 @@ func TestFormatFixed(t *testing.T) {
 	assert.Equal(t, "1.08473", FormatFixed(v, sc, 5))
 	assert.Equal(t, "1.084730000000", FormatFixed(v, sc, 12))
 	assert.Equal(t, "-1.08473", FormatFixed(-v, sc, 5))
+}
+
+// TestFormatFixedNoNegativeZero pins the sign rule at low display precision.
+// Truncating toward zero can erase the entire magnitude, and a "-0.00" would
+// assert a precision the display does not have.
+func TestFormatFixedNoNegativeZero(t *testing.T) {
+	sc := scaleByName(t, "1e9")
+
+	cases := []struct {
+		name     string
+		v        int64
+		decimals int
+		want     string
+	}{
+		{"smallest negative, no decimals", -1, 0, "0"},
+		{"smallest negative, 2 decimals", -1, 2, "0.00"},
+		{"smallest negative, full scale", -1, 9, "-0.000000001"},
+		{"truncates to zero at 2dp", -4_000_000, 2, "0.00"},
+		{"survives at 3dp", -4_000_000, 3, "-0.004"},
+		{"exact zero", 0, 2, "0.00"},
+		{"negative one still signed", -1_000_000_000, 2, "-1.00"},
+		{"rounds nothing away", -1_500_000_000, 0, "-1"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, FormatFixed(c.v, sc, c.decimals))
+		})
+	}
+
+	// Sweep the range where truncation bites: no output may be a signed zero.
+	for _, sc := range Candidates {
+		for _, v := range []int64{-1, -9, -99, -999, -12345, -999999999} {
+			for d := range sc.Decimals + 1 {
+				got := FormatFixed(v, sc, d)
+				if strings.Trim(got, "0.") == "" {
+					assert.NotContains(t, got, "-",
+						"scale %s, v=%d, %d decimals: signed zero", sc.Name, v, d)
+				}
+			}
+		}
+	}
 }
 
 func TestCanonical(t *testing.T) {


### PR DESCRIPTION
Follow-up to #45, addressing the three cleanup items from its post-merge review. None change the 1e8 `Price`-scale conclusion; #33 stays closed.

## 1. The "no `float64`" claim was false

`TestScaleMargins` computed and compared margins in `float64` — false in exactly the place a reader would care about, since a study arguing against binary floating point should not depend on it to produce its evidence.

`TestScaleMargins` now works in integer arithmetic throughout. It asserts on the *products* rather than the margins for the 10× relationship, because the margins are truncating quotients and would only agree approximately.

That left the package with no `float64` at all, so `nofloat_test.go` now enforces it: each file is parsed and any `float32`/`float64` identifier or floating-point literal fails the test. Parsing rather than grepping means identifiers in comments and strings — including that test's own doc comment — do not trip it.

Verified by hand:

```
--- FAIL: TestNoFloatingPoint/tables.go
    tables.go: float64 used at tables.go:299:17
    tables.go: floating-point literal 1.5 at tables.go:299:34
```

README wording tightened to match, and it now names the test rather than asserting the property on trust.

## 2. `FormatFixed` emitted signed zero

`-1` at scale 1e9 shown with 2 decimals gave `-0.00`. Truncation toward zero had erased the whole magnitude, and the surviving sign claimed a precision the display does not have.

The sign is now suppressed when the rendered magnitude is zero. `TestFormatFixedNoNegativeZero` covers the explicit cases plus a sweep over every candidate scale and display precision, so no combination can produce a signed zero. Cases like `-1.00` and `-0.004` keep their sign correctly.

## 3. `Scale` doc comment said "round"

It described storage as `round(v * Factor)` while the study deliberately rejects excess precision with `ErrTooManyDecimals`. It now states that a value is accepted only if it scales to an integer exactly, and points at #38 for the eventual production rounding policy — so later implementation work does not inherit the wrong assumption.

## Also

Copilot flagged symbol-casing drift between the ADR tables and `assets.go` (`sub-penny` vs `SUB-PENNY`, `financing` vs `FINANCING`). That resolved itself when the tables became generated in `7f5eb8e` — the regions now reproduce the data verbatim, so no action was needed.

## Verification

`make check` passes (`fmt-check`, `vet`, `test`, `race`). Coverage 96.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsfxQH4YBP5DA1LpAafWyt
