### PR TITLE
M1-01c: validate Quantity scale and asset constraints (#36)

### DIFF
--- a/docs/arch/adr-004-exact-numeric-representation.org
+++ b/docs/arch/adr-004-exact-numeric-representation.org
@@ -285,6 +285,157 @@ Related decisions this issue deliberately did not settle: scaled =Quantity=
 multiplication semantics remain with [[https://github.com/rustyeddy/trader/issues/36][#36]]; widened intermediates, accumulation,
 and rounding remain with [[https://github.com/rustyeddy/trader/issues/38][#38]]; exact parsing boundaries remain with [[https://github.com/rustyeddy/trader/issues/39][#39]].
 
+** Quantity representation and asset constraints
+
+Decision source: [[https://github.com/rustyeddy/trader/issues/36][#36]]
+
+=Quantity= uses a single fixed Trader-wide scale of *1e8*, backed by signed
+=int64= — the same scale as =Price=.  A decimal quantity =v= is stored as the
+=int64= =v * 100_000_000=.
+
+- smallest representable quantity: =0.00000001= (one satoshi)
+- maximum whole-unit quantity: =92,233,720,368= (~92.2 billion)
+- quantities above that bound are rejected as out of range, never truncated
+- positions in extremely high-supply tokens above the bound are outside the
+  initial supported domain
+
+The evidence is in =test/internal/quantitystudy=, a test-only spike that reuses
+=test/internal/numericstudy= for exact decimal parsing, table rendering, and
+the generated-documentation guard.  Regenerate the tables with:
+
+#+begin_src sh
+go test ./test/internal/quantitystudy/ -run TestGeneratedTables -update
+#+end_src
+
+*** Quantity representation matrix
+
+=PRECISION= marks a value needing more decimals than the scale holds; =RANGE=
+marks one exceeding =int64= at that scale.  The two are reported separately
+because they lead to different conclusions: precision narrows which asset
+classes a scale can serve, range bounds the supported domain.
+
+# BEGIN quantitystudy:quantity-matrix
+| Class    | Symbol  |      Quantity | Dec | Integral |                 1e6 |               1e7 |                1e8 |                 1e9 |
+|----------+---------+---------------+-----+----------+---------------------+-------------------+--------------------+---------------------|
+| FX       | EUR/USD |             1 |   0 | no       |             1000000 |          10000000 |          100000000 |          1000000000 |
+| FX       | EUR/USD |         10000 |   0 | no       |         10000000000 |      100000000000 |      1000000000000 |      10000000000000 |
+| FX       | EUR/USD |      10000000 |   0 | no       |      10000000000000 |   100000000000000 |   1000000000000000 |   10000000000000000 |
+| FX       | EUR/USD |    1000000000 |   0 | no       |    1000000000000000 | 10000000000000000 | 100000000000000000 | 1000000000000000000 |
+| Equity   | SPY     |             1 |   0 | no       |             1000000 |          10000000 |          100000000 |          1000000000 |
+| Equity   | SPY     |           0.5 |   1 | no       |              500000 |           5000000 |           50000000 |           500000000 |
+| Equity   | SPY     |      0.000001 |   6 | no       |                   1 |                10 |                100 |                1000 |
+| Futures  | ES      |             1 |   0 | yes      |             1000000 |          10000000 |          100000000 |          1000000000 |
+| Futures  | ES      |             3 |   0 | yes      |             3000000 |          30000000 |          300000000 |          3000000000 |
+| Futures  | ES      |         10000 |   0 | yes      |         10000000000 |      100000000000 |      1000000000000 |      10000000000000 |
+| Crypto   | BTC     |             1 |   0 | no       |             1000000 |          10000000 |          100000000 |          1000000000 |
+| Crypto   | BTC     |    0.00000001 |   8 | no       |           PRECISION |         PRECISION |                  1 |                  10 |
+| Token    | SHIB    | 1000000000000 |   0 | no       | 1000000000000000000 |             RANGE |              RANGE |               RANGE |
+| Boundary | ZERO    |             0 |   0 | no       |                   0 |                 0 |                  0 |                   0 |
+# END quantitystudy:quantity-matrix
+
+*** The precision and range frontier
+
+No scaled =int64= holds both extremes of the pressure matrix.  One satoshi
+needs 8 fraction digits; a trillion whole units at 8 fraction digits needs
+1e20, which is 67 bits against =int64='s 63.
+
+# BEGIN quantitystudy:frontier
+| Scale | Smallest unit |   Max whole units | Holds 1 satoshi | Holds 1e12 units |
+|-------+---------------+-------------------+-----------------+------------------|
+| 1e6   |      0.000001 | 9,223,372,036,854 | no              | yes              |
+| 1e7   |     0.0000001 |   922,337,203,685 | no              | no               |
+| 1e8   |    0.00000001 |    92,233,720,368 | yes             | no               |
+| 1e9   |   0.000000001 |     9,223,372,036 | yes             | no               |
+# END quantitystudy:frontier
+
+Only 1e6 holds a trillion units, and it cannot represent a satoshi.  Only 1e8
+and 1e9 represent a satoshi, and neither reaches a trillion units.  Trading
+range for precision is not a free move — it swaps which asset class is
+excluded.
+
+The trillion-unit row is a deliberate range-pressure case, not a requirement.
+It is retained in the evidence to mark the boundary rather than removed or
+quietly made to pass, and =TestOutOfDomainQuantityIsRejected= asserts it fails
+with a range error specifically, so the boundary is visible in behaviour.
+
+*** Why 1e8
+
+Both 1e8 and 1e9 cover every intended asset class exactly.  1e9 spends a ninth
+decimal place that nothing in the matrix needs and pays a factor of ten in
+supported range for it.  1e8 also matches the =Price= scale fixed by [[https://github.com/rustyeddy/trader/issues/33][#33]],
+keeping both scales in one mental model.
+
+Explicitly rejected: per-asset-class quantity scales, and a widened =Quantity=
+backing type, adopted solely for the pressure case.  Either would add
+substantial complexity to all quantity arithmetic, serialization, and public
+APIs for a requirement Trader does not currently have.
+
+If a future concrete broker or supported instrument requires positions above
+the bound, this decision reopens with actual provider constraints and usage
+evidence.  The likely options then are a widened backing representation or a
+specialised asset-unit model — not silent scale variation inside =Quantity=.
+
+*** Representation scale versus instrument rules
+
+The scale says what can be stored; instrument rules say what may be traded.
+The study models them separately:
+
+#+begin_src go
+type QuantityRules struct {
+    Increment    int64 // smallest tradable step
+    Minimum      int64 // smallest permitted order size
+    Maximum      int64 // largest permitted order size
+    IntegralOnly bool  // whole units only, e.g. futures contracts
+}
+#+end_src
+
+# BEGIN quantitystudy:instrument-rules
+| Symbol  |  Increment |  Minimum |   Maximum | Integral only |
+|---------+------------+----------+-----------+---------------|
+| EUR/USD |          1 |        1 | 100000000 | no            |
+| SPY     |   0.000001 | 0.000001 |         — | no            |
+| ES      |          1 |        1 |     10000 | yes           |
+| BTC     | 0.00000001 |   0.0001 |         — | no            |
+| SHIB    |          1 |     1000 |         — | no            |
+# END quantitystudy:instrument-rules
+
+Holding quantity and increment in the same scale makes increment validation
+exact integer modulo, with no tolerance and no rounding.  Integral-only
+instruments are validated the same way against the scale factor.
+
+*** Zero and sign policy
+
+Zero is representable and is a valid =Quantity=: a flat position, a fully
+closed lot.  Only order construction rejects it, so instrument conformance and
+order validity remain separate questions.
+
+Public order quantities are non-negative.  Direction is never encoded in the
+quantity sign; side belongs to the order.  A negative quantity is a programming
+error, and the most negative =int64= is rejected as a quantity rather than
+mishandled.
+
+*** Consequence for intermediate arithmetic
+
+With =Price= at 1e8 and =Quantity= also scaled, =Price x Quantity= is
+double-scaled — the same shape as =Price x Rate= — so the intermediate
+overflows =int64= before the descaling divide.
+
+# BEGIN quantitystudy:notional
+| Case            |           Price |      Quantity |      1e6 |      1e7 |      1e8 |      1e9 |
+|-----------------+-----------------+---------------+----------+----------+----------+----------|
+| BRK.A block     |       750000.00 |         10000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| FX 10M notional |         1.08473 |      10000000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| FX 1B notional  |         1.08473 |    1000000000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| BTC 1k coins    | 150000.12345678 |          1000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| SPY fractional  |          700.12 |           0.5 |     263x |      26x |       2x | OVERFLOW |
+| SHIB 1e12 units |      0.00000001 | 1000000000000 |       9x |      n/a |      n/a |      n/a |
+# END quantitystudy:notional
+
+This confirms the caveat recorded above from [[https://github.com/rustyeddy/trader/issues/33][#33]]: scaling =Quantity= is what
+pushes the product past =int64=, and notional calculation must use the widened
+path owned by [[https://github.com/rustyeddy/trader/issues/38][#38]].  The same block that is comfortable with a whole unscaled
+quantity overflows with a scaled one.
+
 ** Exact input and output boundaries
 
 Decision source: [[https://github.com/rustyeddy/trader/issues/39][#39]]
@@ -323,7 +474,9 @@ The following issues must be resolved before this ADR can be accepted:
   =Price= scale is 1e8.  Evidence in =test/internal/numericstudy= and final
   review disposition recorded above.
 - [[https://github.com/rustyeddy/trader/issues/35][#35 — Decide Money currency ownership and arithmetic semantics]]
-- [[https://github.com/rustyeddy/trader/issues/36][#36 — Decide Quantity precision and asset constraints]]
+- [X] [[https://github.com/rustyeddy/trader/issues/36][#36 — Decide Quantity precision and asset constraints]] — resolved:
+  =Quantity= scale is 1e8, backed by signed =int64=, with a bounded supported
+  range.  Evidence in =test/internal/quantitystudy=.
 - [[https://github.com/rustyeddy/trader/issues/37][#37 — Define numeric type decision matrix]]
 - [[https://github.com/rustyeddy/trader/issues/38][#38 — Define rounding, overflow, and intermediate arithmetic policy]]
 - [[https://github.com/rustyeddy/trader/issues/39][#39 — Define exact parsing and formatting policy]]
@@ -335,13 +488,13 @@ The following issues must be resolved before this ADR can be accepted:
 
 * Provisional Decision Matrix
 
-The unresolved cells must be completed by #35–#42.
+The unresolved cells must be completed by #35, #37–#42.
 
 | Type     | Backing | Scale                  | Related metadata              | Current arithmetic direction |
 |----------+---------+------------------------+-------------------------------+------------------------------|
 | Price    | int64   | Fixed 1e8 (8 dp) (#33) | Tick size belongs to listing  | Exact typed operations; products need a widened intermediate |
 | Money    | int64   | TBD                    | Currency ownership TBD        | Cross-currency math forbidden|
-| Quantity | int64   | Fixed strategy TBD      | Increment belongs to listing  | Exact typed operations       |
+| Quantity | int64   | Fixed 1e8 (8 dp) (#36) | Increment belongs to listing  | Exact typed operations; non-negative, zero valid, products need a widened intermediate |
 | Rate     | int64   | TBD                    | Semantic unit documented      | Explicit multiply/divide     |
 
 For every type, the final matrix must specify:

--- a/test/internal/numericstudy/golden.go
+++ b/test/internal/numericstudy/golden.go
@@ -1,0 +1,171 @@
+package numericstudy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+)
+
+// This file holds the machine-maintained-documentation machinery shared by the
+// numeric design studies.  It lives in a normal file rather than a _test.go so
+// sibling study packages can import it — Go does not export test files across
+// package boundaries.  It deliberately takes no *testing.T: it computes
+// results, and each study's test asserts on them.
+
+// Doc is a document carrying generated table regions.
+type Doc struct {
+	Path   string // relative to the repository root
+	Format Format
+}
+
+// Syncer renders a study's table fragments into marked regions of documents
+// and reports whether the checked-in text still matches.
+//
+// Namespace keys the markers so several studies can write into the same
+// document without colliding: numericstudy owns "numericstudy:<fragment>" and
+// a quantity study owns "quantitystudy:<fragment>".
+type Syncer struct {
+	Namespace string
+	Docs      []Doc
+	Fragments func(Format) map[string]string
+}
+
+// Markers returns the begin and end marker lines for a fragment, in each
+// format's comment syntax so they stay invisible when the document renders:
+//
+//	org:      # BEGIN numericstudy:asset-matrix
+//	markdown: <!-- BEGIN numericstudy:asset-matrix -->
+func (s Syncer) Markers(f Format, name string) (begin, end string) {
+	if f == FormatMarkdown {
+		return "<!-- BEGIN " + s.Namespace + ":" + name + " -->",
+			"<!-- END " + s.Namespace + ":" + name + " -->"
+	}
+	return "# BEGIN " + s.Namespace + ":" + name,
+		"# END " + s.Namespace + ":" + name
+}
+
+func (s Syncer) regionRe(f Format) *regexp.Regexp {
+	ns := regexp.QuoteMeta(s.Namespace)
+	if f == FormatMarkdown {
+		return regexp.MustCompile(
+			`(?m)^<!-- BEGIN ` + ns + `:([a-z0-9-]+) -->$\n([\s\S]*?)^<!-- END ` + ns + `:([a-z0-9-]+) -->$`)
+	}
+	return regexp.MustCompile(
+		`(?m)^# BEGIN ` + ns + `:([a-z0-9-]+)$\n([\s\S]*?)^# END ` + ns + `:([a-z0-9-]+)$`)
+}
+
+// SyncResult reports what one document contained and what it should contain.
+type SyncResult struct {
+	Doc        Doc
+	Seen       []string // fragment names found, sorted
+	Stale      []string // regions whose text differs from the generated fragment
+	Unknown    []string // regions naming a fragment the study does not generate
+	Unbalanced []string // regions whose BEGIN and END names disagree
+	Content    string   // the document with every region regenerated
+	Changed    bool     // whether Content differs from what was on disk
+}
+
+// SyncDoc regenerates every marked region in one document.  It never writes;
+// callers decide what to do with the result.
+func (s Syncer) SyncDoc(root string, d Doc) (SyncResult, error) {
+	res := SyncResult{Doc: d}
+
+	raw, err := os.ReadFile(filepath.Join(root, d.Path))
+	if err != nil {
+		return res, err
+	}
+
+	frag := s.Fragments(d.Format)
+	re := s.regionRe(d.Format)
+	seen := map[string]bool{}
+
+	res.Content = re.ReplaceAllStringFunc(string(raw), func(m string) string {
+		sub := re.FindStringSubmatch(m)
+		name, body, closing := sub[1], sub[2], sub[3]
+
+		if name != closing {
+			res.Unbalanced = append(res.Unbalanced, name+"/"+closing)
+			return m
+		}
+
+		want, ok := frag[name]
+		if !ok {
+			res.Unknown = append(res.Unknown, name)
+			return m
+		}
+
+		seen[name] = true
+		if body != want {
+			res.Stale = append(res.Stale, name)
+		}
+
+		begin, end := s.Markers(d.Format, name)
+		return begin + "\n" + want + end
+	})
+
+	for name := range seen {
+		res.Seen = append(res.Seen, name)
+	}
+	sort.Strings(res.Seen)
+	sort.Strings(res.Stale)
+	res.Changed = res.Content != string(raw)
+
+	return res, nil
+}
+
+// Sync regenerates every document.  With write set, stale documents are
+// rewritten in place.
+func (s Syncer) Sync(root string, write bool) ([]SyncResult, error) {
+	var out []SyncResult
+
+	for _, d := range s.Docs {
+		res, err := s.SyncDoc(root, d)
+		if err != nil {
+			return nil, err
+		}
+		if write && res.Changed {
+			path := filepath.Join(root, d.Path)
+			if err := os.WriteFile(path, []byte(res.Content), 0o644); err != nil {
+				return nil, err
+			}
+		}
+		out = append(out, res)
+	}
+
+	return out, nil
+}
+
+// UsedFragments reports which fragment names are embedded across all of the
+// study's documents, so a generated-but-unused fragment can be caught.
+func (s Syncer) UsedFragments(root string) (map[string]bool, error) {
+	used := map[string]bool{}
+
+	for _, d := range s.Docs {
+		raw, err := os.ReadFile(filepath.Join(root, d.Path))
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range s.regionRe(d.Format).FindAllStringSubmatch(string(raw), -1) {
+			used[m[1]] = true
+		}
+	}
+
+	return used, nil
+}
+
+// RepoRoot walks up from dir to the directory holding go.mod.
+func RepoRoot(dir string) (string, error) {
+	for range 10 {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("numericstudy: no go.mod above %s", dir)
+}

--- a/test/internal/numericstudy/golden_test.go
+++ b/test/internal/numericstudy/golden_test.go
@@ -4,9 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,35 +17,15 @@ import (
 var update = flag.Bool("update", false,
 	"rewrite generated table regions in the ADR and README")
 
-// generatedDoc is a document carrying machine-maintained table regions.
-type generatedDoc struct {
-	path   string // relative to the repository root
-	format Format
-}
-
-var generatedDocs = []generatedDoc{
-	{path: "docs/arch/adr-004-exact-numeric-representation.org", format: FormatOrg},
-	{path: "test/internal/numericstudy/README.md", format: FormatMarkdown},
-}
-
-// Marker syntax, in each format's comment form so the markers stay invisible
-// when the document is rendered:
-//
-//	org:      # BEGIN numericstudy:asset-matrix ... # END numericstudy:asset-matrix
-//	markdown: <!-- BEGIN numericstudy:asset-matrix --> ... <!-- END ... -->
-func markers(f Format, name string) (begin, end string) {
-	if f == FormatMarkdown {
-		return "<!-- BEGIN numericstudy:" + name + " -->",
-			"<!-- END numericstudy:" + name + " -->"
-	}
-	return "# BEGIN numericstudy:" + name, "# END numericstudy:" + name
-}
-
-var regionRe = map[Format]*regexp.Regexp{
-	FormatOrg: regexp.MustCompile(
-		`(?m)^# BEGIN numericstudy:([a-z0-9-]+)$\n([\s\S]*?)^# END numericstudy:([a-z0-9-]+)$`),
-	FormatMarkdown: regexp.MustCompile(
-		`(?m)^<!-- BEGIN numericstudy:([a-z0-9-]+) -->$\n([\s\S]*?)^<!-- END numericstudy:([a-z0-9-]+) -->$`),
+// syncer describes where this study's tables are embedded.  The machinery
+// itself lives in golden.go so sibling studies can reuse it.
+var syncer = Syncer{
+	Namespace: "numericstudy",
+	Docs: []Doc{
+		{Path: "docs/arch/adr-004-exact-numeric-representation.org", Format: FormatOrg},
+		{Path: "test/internal/numericstudy/README.md", Format: FormatMarkdown},
+	},
+	Fragments: Fragments,
 }
 
 // TestGeneratedTables is the guarantee behind the claim that the checked-in
@@ -58,57 +35,27 @@ var regionRe = map[Format]*regexp.Regexp{
 //
 // Run with -update to rewrite the regions in place.
 func TestGeneratedTables(t *testing.T) {
-	root := repoRoot(t)
+	root := testRepoRoot(t)
 
-	for _, doc := range generatedDocs {
-		t.Run(doc.path, func(t *testing.T) {
-			path := filepath.Join(root, doc.path)
-			raw, err := os.ReadFile(path)
-			require.NoError(t, err)
+	results, err := syncer.Sync(root, *update)
+	require.NoError(t, err)
+	require.Len(t, results, len(syncer.Docs))
 
-			frag := Fragments(doc.format)
-			re := regionRe[doc.format]
-
-			seen := map[string]bool{}
-			var mismatched []string
-
-			updated := re.ReplaceAllStringFunc(string(raw), func(m string) string {
-				sub := re.FindStringSubmatch(m)
-				name, body, closing := sub[1], sub[2], sub[3]
-
-				require.Equal(t, name, closing,
-					"mismatched BEGIN/END marker names in %s", doc.path)
-
-				want, ok := frag[name]
-				if !ok {
-					t.Errorf("%s: unknown fragment %q; known: %v",
-						doc.path, name, fragmentNames(frag))
-					return m
-				}
-				seen[name] = true
-
-				if body != want {
-					mismatched = append(mismatched, name)
-				}
-
-				begin, end := markers(doc.format, name)
-				return begin + "\n" + want + end
-			})
-
-			require.NotEmpty(t, seen,
-				"%s has no numericstudy markers; generated tables are unguarded",
-				doc.path)
+	for _, res := range results {
+		t.Run(res.Doc.Path, func(t *testing.T) {
+			assert.Empty(t, res.Unbalanced, "mismatched BEGIN/END marker names")
+			assert.Empty(t, res.Unknown, "regions naming a fragment nothing generates")
+			require.NotEmpty(t, res.Seen,
+				"no %s markers; generated tables are unguarded", syncer.Namespace)
 
 			if *update {
-				require.NoError(t, os.WriteFile(path, []byte(updated), 0o644))
-				t.Logf("updated %d region(s) in %s", len(seen), doc.path)
+				t.Logf("synced %d region(s)", len(res.Seen))
 				return
 			}
 
-			assert.Empty(t, mismatched,
-				"%s is stale in %v — regenerate with:\n"+
-					"  go test ./test/internal/numericstudy/ -run TestGeneratedTables -update",
-				doc.path, mismatched)
+			assert.Empty(t, res.Stale,
+				"stale regions — regenerate with:\n"+
+					"  go test ./test/internal/numericstudy/ -run TestGeneratedTables -update")
 		})
 	}
 }
@@ -116,16 +63,8 @@ func TestGeneratedTables(t *testing.T) {
 // TestEveryFragmentIsUsed keeps the generator honest in the other direction: a
 // fragment nobody embeds is dead code that will silently rot.
 func TestEveryFragmentIsUsed(t *testing.T) {
-	root := repoRoot(t)
-	used := map[string]bool{}
-
-	for _, doc := range generatedDocs {
-		raw, err := os.ReadFile(filepath.Join(root, doc.path))
-		require.NoError(t, err)
-		for _, m := range regionRe[doc.format].FindAllStringSubmatch(string(raw), -1) {
-			used[m[1]] = true
-		}
-	}
+	used, err := syncer.UsedFragments(testRepoRoot(t))
+	require.NoError(t, err)
 
 	for name := range Fragments(FormatOrg) {
 		assert.True(t, used[name],
@@ -139,51 +78,20 @@ func TestFragmentsRenderInBothFormats(t *testing.T) {
 	for _, f := range []Format{FormatOrg, FormatMarkdown} {
 		for name, body := range Fragments(f) {
 			t.Run(fmt.Sprintf("%d/%s", f, name), func(t *testing.T) {
-				lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
-				require.GreaterOrEqual(t, len(lines), 3,
-					"want header, rule, and at least one row")
-
-				// The org rule row separates columns with "+", so count both
-				// delimiters to compare column counts across formats.
-				delims := func(s string) int {
-					return strings.Count(s, "|") + strings.Count(s, "+")
-				}
-
-				want := delims(lines[0])
-				for i, ln := range lines {
-					assert.True(t, strings.HasPrefix(ln, "|"),
-						"line %d must start a table row: %q", i, ln)
-					assert.Equal(t, want, delims(ln),
-						"line %d has a different column count: %q", i, ln)
-				}
+				assert.NoError(t, ValidateTable(body))
 			})
 		}
 	}
 }
 
-func fragmentNames(frag map[string]string) []string {
-	out := make([]string, 0, len(frag))
-	for k := range frag {
-		out = append(out, k)
-	}
-	return out
-}
-
-// repoRoot walks up from the package directory to the module root.
-func repoRoot(t *testing.T) string {
+func testRepoRoot(t *testing.T) string {
 	t.Helper()
 
-	dir, err := os.Getwd()
+	wd, err := os.Getwd()
 	require.NoError(t, err)
 
-	for range 10 {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		require.NotEqual(t, dir, parent, "reached filesystem root without go.mod")
-		dir = parent
-	}
-	t.Fatal("could not locate repository root")
-	return ""
+	root, err := RepoRoot(wd)
+	require.NoError(t, err)
+
+	return root
 }

--- a/test/internal/numericstudy/nofloat.go
+++ b/test/internal/numericstudy/nofloat.go
@@ -1,0 +1,72 @@
+package numericstudy
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FloatUse is one binary-floating-point reference found in study source.
+type FloatUse struct {
+	File     string
+	Position string
+	What     string
+}
+
+// FindFloatUsage reports every float32/float64 identifier and floating-point
+// literal in the Go files directly under dir.
+//
+// The studies conclude that scaled int64 is the right representation; they
+// must not depend on binary floating point to reach that conclusion, including
+// in their reporting.  An earlier revision computed margins in float64, which
+// made a documented claim false in exactly the place a reader would check.
+//
+// Files are parsed rather than scanned as text, so identifiers appearing in
+// comments and string literals — including this package's own prose about
+// float64 — do not register.
+func FindFloatUsage(dir string) ([]FloatUse, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var found []FloatUse
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, filepath.Join(dir, e.Name()), nil, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch v := n.(type) {
+			case *ast.Ident:
+				if v.Name == "float64" || v.Name == "float32" {
+					found = append(found, FloatUse{
+						File:     e.Name(),
+						Position: fset.Position(v.Pos()).String(),
+						What:     v.Name,
+					})
+				}
+			case *ast.BasicLit:
+				if v.Kind == token.FLOAT || v.Kind == token.IMAG {
+					found = append(found, FloatUse{
+						File:     e.Name(),
+						Position: fset.Position(v.Pos()).String(),
+						What:     "literal " + v.Value,
+					})
+				}
+			}
+			return true
+		})
+	}
+
+	return found, nil
+}

--- a/test/internal/numericstudy/nofloat_test.go
+++ b/test/internal/numericstudy/nofloat_test.go
@@ -1,12 +1,7 @@
 package numericstudy
 
 import (
-	"go/ast"
-	"go/parser"
-	"go/token"
 	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,45 +16,15 @@ import (
 // "no float64" claim false in exactly the place a reader would care about — a
 // study arguing against binary floating point should not depend on it to
 // produce its evidence.  This test keeps that from coming back.
-//
-// It parses each file rather than grepping so identifiers in comments and
-// strings, including this comment, do not trip it.
 func TestNoFloatingPoint(t *testing.T) {
 	dir, err := os.Getwd()
 	require.NoError(t, err)
 
-	entries, err := os.ReadDir(dir)
+	found, err := FindFloatUsage(dir)
 	require.NoError(t, err)
 
-	checked := 0
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
-			continue
-		}
-		checked++
-
-		t.Run(e.Name(), func(t *testing.T) {
-			fset := token.NewFileSet()
-			file, err := parser.ParseFile(fset, filepath.Join(dir, e.Name()), nil, 0)
-			require.NoError(t, err)
-
-			ast.Inspect(file, func(n ast.Node) bool {
-				switch v := n.(type) {
-				case *ast.Ident:
-					if v.Name == "float64" || v.Name == "float32" {
-						t.Errorf("%s: %s used at %s",
-							e.Name(), v.Name, fset.Position(v.Pos()))
-					}
-				case *ast.BasicLit:
-					if v.Kind == token.FLOAT || v.Kind == token.IMAG {
-						t.Errorf("%s: floating-point literal %s at %s",
-							e.Name(), v.Value, fset.Position(v.Pos()))
-					}
-				}
-				return true
-			})
-		})
+	for _, u := range found {
+		assert.Fail(t, "binary floating point in study source",
+			"%s at %s", u.What, u.Position)
 	}
-
-	assert.Greater(t, checked, 1, "expected to scan the package's Go files")
 }

--- a/test/internal/numericstudy/tables.go
+++ b/test/internal/numericstudy/tables.go
@@ -15,35 +15,35 @@ const (
 	FormatMarkdown
 )
 
-// column is one rendered column: a header, an alignment, and its cells.
-type column struct {
-	header string
-	right  bool
-	cells  []string
+// Column is one rendered column: a header, an alignment, and its cells.
+type Column struct {
+	Header string
+	Right  bool
+	Cells  []string
 }
 
-// renderTable lays out columns as an aligned org or markdown table.  Alignment
+// RenderTable lays out columns as an aligned org or markdown table.  Alignment
 // is cosmetic in both formats, but keeps the checked-in docs readable and
 // makes regeneration diffs small.
-func renderTable(f Format, cols []column) string {
+func RenderTable(f Format, cols []Column) string {
 	rows := 0
 	for _, c := range cols {
-		rows = max(rows, len(c.cells))
+		rows = max(rows, len(c.Cells))
 	}
 
 	// Column widths are counted in runes, not bytes: the "—" used for
 	// unrepresentable values is three bytes wide but one column wide.
 	width := make([]int, len(cols))
 	for i, c := range cols {
-		width[i] = utf8.RuneCountInString(c.header)
-		for _, v := range c.cells {
+		width[i] = utf8.RuneCountInString(c.Header)
+		for _, v := range c.Cells {
 			width[i] = max(width[i], utf8.RuneCountInString(v))
 		}
 	}
 
 	pad := func(i int, s string) string {
 		gap := strings.Repeat(" ", width[i]-utf8.RuneCountInString(s))
-		if cols[i].right {
+		if cols[i].Right {
 			return gap + s
 		}
 		return s + gap
@@ -53,7 +53,7 @@ func renderTable(f Format, cols []column) string {
 
 	b.WriteString("|")
 	for i, c := range cols {
-		b.WriteString(" " + pad(i, c.header) + " |")
+		b.WriteString(" " + pad(i, c.Header) + " |")
 	}
 	b.WriteString("\n")
 
@@ -62,7 +62,7 @@ func renderTable(f Format, cols []column) string {
 	for i := range cols {
 		rule := strings.Repeat("-", width[i]+2)
 		if f == FormatMarkdown {
-			if cols[i].right {
+			if cols[i].Right {
 				rule = strings.Repeat("-", width[i]+1) + ":"
 			}
 			b.WriteString(rule + "|")
@@ -81,8 +81,8 @@ func renderTable(f Format, cols []column) string {
 		b.WriteString("|")
 		for i, c := range cols {
 			v := ""
-			if r < len(c.cells) {
-				v = c.cells[r]
+			if r < len(c.Cells) {
+				v = c.Cells[r]
 			}
 			b.WriteString(" " + pad(i, v) + " |")
 		}
@@ -90,6 +90,36 @@ func renderTable(f Format, cols []column) string {
 	}
 
 	return b.String()
+}
+
+// ValidateTable checks that rendered text really is a table: every line is a
+// row, and every row has the same column count.  Sibling studies apply it to
+// their own fragments, so it returns an error rather than taking a *testing.T.
+func ValidateTable(body string) error {
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	if len(lines) < 3 {
+		return fmt.Errorf("want header, rule, and at least one row, got %d lines",
+			len(lines))
+	}
+
+	// The org rule row separates columns with "+", so count both delimiters
+	// to compare column counts across formats.
+	delims := func(s string) int {
+		return strings.Count(s, "|") + strings.Count(s, "+")
+	}
+
+	want := delims(lines[0])
+	for i, ln := range lines {
+		if !strings.HasPrefix(ln, "|") {
+			return fmt.Errorf("line %d is not a table row: %q", i, ln)
+		}
+		if got := delims(ln); got != want {
+			return fmt.Errorf("line %d has %d columns, want %d: %q",
+				i, got, want, ln)
+		}
+	}
+
+	return nil
 }
 
 // code wraps an inline literal in the target format's verbatim markup.
@@ -100,8 +130,8 @@ func code(f Format, s string) string {
 	return "=" + s + "="
 }
 
-// commas groups an integer with thousands separators.
-func commas(v int64) string {
+// Commas groups an integer with thousands separators.
+func Commas(v int64) string {
 	s := fmt.Sprintf("%d", v)
 	neg := strings.HasPrefix(s, "-")
 	if neg {
@@ -146,41 +176,41 @@ func Fragments(f Format) map[string]string {
 	frag := map[string]string{}
 
 	// Asset representation matrix -------------------------------------------
-	cols := []column{
-		{header: "Class", cells: pluck(Assets, func(a Asset) string { return a.Class })},
-		{header: "Symbol", cells: pluck(Assets, func(a Asset) string { return a.Symbol })},
-		{header: "Price", right: true, cells: pluck(Assets, func(a Asset) string { return a.Price })},
-		{header: "Tick", right: true, cells: pluck(Assets, func(a Asset) string { return a.TickSize })},
-		{header: "Dec", right: true, cells: pluck(Assets, func(a Asset) string { return fmt.Sprint(a.Decimals) })},
+	cols := []Column{
+		{Header: "Class", Cells: pluck(Assets, func(a Asset) string { return a.Class })},
+		{Header: "Symbol", Cells: pluck(Assets, func(a Asset) string { return a.Symbol })},
+		{Header: "Price", Right: true, Cells: pluck(Assets, func(a Asset) string { return a.Price })},
+		{Header: "Tick", Right: true, Cells: pluck(Assets, func(a Asset) string { return a.TickSize })},
+		{Header: "Dec", Right: true, Cells: pluck(Assets, func(a Asset) string { return fmt.Sprint(a.Decimals) })},
 	}
 	for i, sc := range Candidates {
 		cells := make([]string, 0, len(Assets))
 		for _, a := range Assets {
 			cells = append(cells, scaledCells(a.Price)[i])
 		}
-		cols = append(cols, column{header: sc.Name, right: true, cells: cells})
+		cols = append(cols, Column{Header: sc.Name, Right: true, Cells: cells})
 	}
-	frag["asset-matrix"] = renderTable(f, cols)
+	frag["asset-matrix"] = RenderTable(f, cols)
 
 	// Range and headroom ----------------------------------------------------
 	var name, dec, maxp, unit, head []string
 	for _, sc := range Candidates {
 		name = append(name, sc.Name)
 		dec = append(dec, fmt.Sprint(sc.Decimals))
-		maxp = append(maxp, commas(MaxPrice(sc)))
+		maxp = append(maxp, Commas(MaxPrice(sc)))
 		unit = append(unit, FormatDecimal(1, sc))
 		if v, err := ParseDecimal("750000.00", sc); err == nil {
-			head = append(head, commas(Headroom(v, sc))+"x")
+			head = append(head, Commas(Headroom(v, sc))+"x")
 		} else {
 			head = append(head, "n/a")
 		}
 	}
-	frag["range-headroom"] = renderTable(f, []column{
-		{header: "Scale", cells: name},
-		{header: "Decimals", right: true, cells: dec},
-		{header: "Max price", right: true, cells: maxp},
-		{header: "Smallest unit", right: true, cells: unit},
-		{header: "Headroom over 750000.00", right: true, cells: head},
+	frag["range-headroom"] = RenderTable(f, []Column{
+		{Header: "Scale", Cells: name},
+		{Header: "Decimals", Right: true, Cells: dec},
+		{Header: "Max price", Right: true, Cells: maxp},
+		{Header: "Smallest unit", Right: true, Cells: unit},
+		{Header: "Headroom over 750000.00", Right: true, Cells: head},
 	})
 
 	// Price x Quantity margins ----------------------------------------------
@@ -197,18 +227,18 @@ func Fragments(f Format) map[string]string {
 			continue
 		}
 		rsScale = append(rsScale, sc.Name)
-		rsBars = append(rsBars, commas(MaxPriceCeil(v)))
+		rsBars = append(rsBars, Commas(MaxPriceCeil(v)))
 	}
-	frag["rolling-sum"] = renderTable(f, []column{
-		{header: "Scale", cells: rsScale},
-		{header: "Bars of 750000.00 before overflow", right: true, cells: rsBars},
+	frag["rolling-sum"] = RenderTable(f, []Column{
+		{Header: "Scale", Cells: rsScale},
+		{Header: "Bars of 750000.00 before overflow", Right: true, Cells: rsBars},
 	})
 
 	// Sub-quantum values ----------------------------------------------------
-	frag["subquantum"] = renderTable(f, []column{
-		{header: "Value", cells: pluckSub(func(i int) string { return code(f, SubQuantumValues[i].Value) })},
-		{header: "Digits", right: true, cells: pluckSub(func(i int) string { return fmt.Sprint(SubQuantumValues[i].Digits) })},
-		{header: "Note", cells: pluckSub(func(i int) string { return SubQuantumValues[i].Note })},
+	frag["subquantum"] = RenderTable(f, []Column{
+		{Header: "Value", Cells: pluckSub(func(i int) string { return code(f, SubQuantumValues[i].Value) })},
+		{Header: "Digits", Right: true, Cells: pluckSub(func(i int) string { return fmt.Sprint(SubQuantumValues[i].Digits) })},
+		{Header: "Note", Cells: pluckSub(func(i int) string { return SubQuantumValues[i].Note })},
 	})
 
 	// Unsupported quotation formats -----------------------------------------
@@ -219,20 +249,20 @@ func Fragments(f Format) map[string]string {
 		ud = append(ud, q.Decimal)
 		ur = append(ur, q.Reason)
 	}
-	frag["unsupported"] = renderTable(f, []column{
-		{header: "Format", cells: uf},
-		{header: "Example", cells: ue},
-		{header: "Normalizes to", right: true, cells: ud},
-		{header: "Reason", cells: ur},
+	frag["unsupported"] = RenderTable(f, []Column{
+		{Header: "Format", Cells: uf},
+		{Header: "Example", Cells: ue},
+		{Header: "Normalizes to", Right: true, Cells: ud},
+		{Header: "Reason", Cells: ur},
 	})
 
 	return frag
 }
 
 func notionalTable(f Format, scales []Scale) string {
-	cols := []column{
-		{header: "Case", cells: pluckNotional(func(n Notional) string { return n.Name })},
-		{header: "Quantity", right: true, cells: pluckNotional(func(n Notional) string { return commas(n.Quantity) })},
+	cols := []Column{
+		{Header: "Case", Cells: pluckNotional(func(n Notional) string { return n.Name })},
+		{Header: "Quantity", Right: true, Cells: pluckNotional(func(n Notional) string { return Commas(n.Quantity) })},
 	}
 	for _, sc := range scales {
 		cells := make([]string, 0, len(Notionals))
@@ -244,12 +274,12 @@ func notionalTable(f Format, scales []Scale) string {
 			case MulOverflows(p, n.Quantity):
 				cells = append(cells, "OVERFLOW")
 			default:
-				cells = append(cells, commas(MaxPriceCeil(p*n.Quantity))+"x")
+				cells = append(cells, Commas(MaxPriceCeil(p*n.Quantity))+"x")
 			}
 		}
-		cols = append(cols, column{header: sc.Name, right: true, cells: cells})
+		cols = append(cols, Column{Header: sc.Name, Right: true, Cells: cells})
 	}
-	return renderTable(f, cols)
+	return RenderTable(f, cols)
 }
 
 // MaxPriceCeil reports how many times v divides into the int64 ceiling — the

--- a/test/internal/quantitystudy/README.md
+++ b/test/internal/quantitystudy/README.md
@@ -1,0 +1,188 @@
+# quantitystudy
+
+A design-investigation spike for
+[#36 — Decide `Quantity` precision and asset constraints](https://github.com/rustyeddy/trader/issues/36),
+which feeds [ADR-004](../../../docs/arch/adr-004-exact-numeric-representation.org)
+under parent decision [#19](https://github.com/rustyeddy/trader/issues/19).
+
+**This is not the future `Quantity` type.** Like its sibling
+[`numericstudy`](../numericstudy/), it lives under `test/internal/` so the
+import path keeps it out of production code. Delete or supersede it when #44
+consolidates ADR-004.
+
+It reuses `numericstudy` for exact decimal parsing and formatting, table
+rendering, and the generated-documentation machinery, so both studies share one
+implementation of the "no binary floating point" guarantee and one
+implementation of the drift guard.
+
+## Running it
+
+```sh
+go test ./test/internal/quantitystudy/ -v                              # everything
+go test ./test/internal/quantitystudy/ -run TestGenerateReport -v      # the report
+go test ./test/internal/quantitystudy/ -run TestGeneratedTables -update # refresh docs
+```
+
+Tables in this file and in ADR-004 sit between `quantitystudy:` markers and are
+generated. `TestGeneratedTables` fails if any region drifts from what the code
+produces. Do not hand-edit inside the markers.
+
+## Recommendation: scale 1e8, with an explicitly bounded range
+
+`Quantity` uses a fixed Trader-wide scale of **1e8** — the same scale as
+`Price`. A decimal quantity `v` is stored as the `int64` `v * 100_000_000`.
+
+- smallest representable quantity: **0.00000001** (one satoshi)
+- maximum whole-unit quantity: **92,233,720,368** (~92.2 billion)
+- quantities above that bound are **rejected as out of range**, never truncated
+- extremely high-supply token positions above the bound are **outside the
+  initial supported domain**
+
+The recommendation rests on precision coverage plus an explicitly bounded
+range, not on holding every value in the pressure matrix. See the frontier
+below for why that distinction is forced rather than chosen.
+
+### Quantity representation matrix
+
+`PRECISION` marks a value needing more decimals than the scale holds;
+`RANGE` marks one exceeding `int64` at that scale. The two are reported
+separately because they lead to different conclusions — one narrows the asset
+classes a scale can serve, the other bounds the supported domain.
+
+<!-- BEGIN quantitystudy:quantity-matrix -->
+| Class    | Symbol  |      Quantity | Dec | Integral |                 1e6 |               1e7 |                1e8 |                 1e9 |
+|----------|---------|--------------:|----:|----------|--------------------:|------------------:|-------------------:|--------------------:|
+| FX       | EUR/USD |             1 |   0 | no       |             1000000 |          10000000 |          100000000 |          1000000000 |
+| FX       | EUR/USD |         10000 |   0 | no       |         10000000000 |      100000000000 |      1000000000000 |      10000000000000 |
+| FX       | EUR/USD |      10000000 |   0 | no       |      10000000000000 |   100000000000000 |   1000000000000000 |   10000000000000000 |
+| FX       | EUR/USD |    1000000000 |   0 | no       |    1000000000000000 | 10000000000000000 | 100000000000000000 | 1000000000000000000 |
+| Equity   | SPY     |             1 |   0 | no       |             1000000 |          10000000 |          100000000 |          1000000000 |
+| Equity   | SPY     |           0.5 |   1 | no       |              500000 |           5000000 |           50000000 |           500000000 |
+| Equity   | SPY     |      0.000001 |   6 | no       |                   1 |                10 |                100 |                1000 |
+| Futures  | ES      |             1 |   0 | yes      |             1000000 |          10000000 |          100000000 |          1000000000 |
+| Futures  | ES      |             3 |   0 | yes      |             3000000 |          30000000 |          300000000 |          3000000000 |
+| Futures  | ES      |         10000 |   0 | yes      |         10000000000 |      100000000000 |      1000000000000 |      10000000000000 |
+| Crypto   | BTC     |             1 |   0 | no       |             1000000 |          10000000 |          100000000 |          1000000000 |
+| Crypto   | BTC     |    0.00000001 |   8 | no       |           PRECISION |         PRECISION |                  1 |                  10 |
+| Token    | SHIB    | 1000000000000 |   0 | no       | 1000000000000000000 |             RANGE |              RANGE |               RANGE |
+| Boundary | ZERO    |             0 |   0 | no       |                   0 |                 0 |                  0 |                   0 |
+<!-- END quantitystudy:quantity-matrix -->
+
+### The precision/range frontier
+
+No scaled `int64` holds both extremes. One satoshi needs 8 fraction digits; a
+trillion whole units at 8 fraction digits needs 1e20, which is 67 bits against
+`int64`'s 63.
+
+<!-- BEGIN quantitystudy:frontier -->
+| Scale | Smallest unit |   Max whole units | Holds 1 satoshi | Holds 1e12 units |
+|-------|--------------:|------------------:|-----------------|------------------|
+| 1e6   |      0.000001 | 9,223,372,036,854 | no              | yes              |
+| 1e7   |     0.0000001 |   922,337,203,685 | no              | no               |
+| 1e8   |    0.00000001 |    92,233,720,368 | yes             | no               |
+| 1e9   |   0.000000001 |     9,223,372,036 | yes             | no               |
+<!-- END quantitystudy:frontier -->
+
+Only 1e6 holds a trillion units, and it cannot represent a satoshi. Only 1e8
+and 1e9 represent a satoshi, and neither reaches a trillion units. Trading
+range for precision is therefore not a free move — it swaps which asset class
+is excluded.
+
+Per [#36](https://github.com/rustyeddy/trader/issues/36), the trillion-unit row
+is a **range-pressure case, not a requirement**. It is retained in the evidence
+to mark the boundary rather than removed or quietly made to pass.
+`TestOutOfDomainQuantityIsRejected` asserts it fails with a range error
+specifically, so the boundary is visible in behaviour and not just in prose.
+
+### Why 1e8 rather than 1e9
+
+Both cover every intended asset class exactly. 1e9 spends a ninth decimal place
+that nothing in the matrix needs, and pays a factor of ten in supported range
+for it. 1e8 also matches the `Price` scale fixed by
+[#33](https://github.com/rustyeddy/trader/issues/33), which keeps the two
+scales in one mental model.
+
+Explicitly **not** adopted, per #36: per-asset-class scales, or a widened
+`Quantity`, solely for the pressure case. Either would add substantial
+complexity to all quantity arithmetic, serialization, and APIs for a
+requirement Trader does not currently have. If a concrete broker or instrument
+later needs positions above the bound, the representation decision reopens with
+real provider constraints — likely toward a widened backing representation or a
+specialised asset-unit model, not silent scale variation inside `Quantity`.
+
+## Representation scale is separate from instrument rules
+
+The scale says what can be **stored**; `QuantityRules` says what may be
+**traded**:
+
+```go
+type QuantityRules struct {
+    Increment    int64 // smallest tradable step
+    Minimum      int64 // smallest permitted order size
+    Maximum      int64 // largest permitted order size
+    IntegralOnly bool  // whole units only, e.g. futures contracts
+}
+```
+
+<!-- BEGIN quantitystudy:instrument-rules -->
+| Symbol  |  Increment |  Minimum |   Maximum | Integral only |
+|---------|-----------:|---------:|----------:|---------------|
+| EUR/USD |          1 |        1 | 100000000 | no            |
+| SPY     |   0.000001 | 0.000001 |         — | no            |
+| ES      |          1 |        1 |     10000 | yes           |
+| BTC     | 0.00000001 |   0.0001 |         — | no            |
+| SHIB    |          1 |     1000 |         — | no            |
+<!-- END quantitystudy:instrument-rules -->
+
+Holding quantity and increment in the same scale makes increment validation
+exact integer modulo — `q % increment == 0`, no tolerance, no rounding.
+`TestRulesAreIndependentOfScale` shows the same rule set behaving identically at
+every scale that can represent it.
+
+### Zero is representable; only orders reject it
+
+Zero is a perfectly good `Quantity` — a flat position, a fully closed lot — so
+the representation must hold it. `Validate` accepts it as instrument-conformant
+and `ValidateOrder` rejects it, keeping the two questions apart.
+
+### Direction is never encoded in the sign
+
+Public order quantities are non-negative. A negative quantity is a programming
+error, not a sell: side belongs to the order. `TestNonNegative` pins this,
+including that `math.MinInt64` is rejected as a quantity rather than mishandled.
+
+## Consequence for #38: scaled `Quantity` needs widened arithmetic
+
+With `Price` at 1e8 and `Quantity` scaled too, `Price × Quantity` is
+**double-scaled** — the same shape as `Price × Rate` in #33 — so the
+intermediate overflows `int64` before the descaling divide.
+
+<!-- BEGIN quantitystudy:notional -->
+| Case            |           Price |      Quantity |      1e6 |      1e7 |      1e8 |      1e9 |
+|-----------------|----------------:|--------------:|---------:|---------:|---------:|---------:|
+| BRK.A block     |       750000.00 |         10000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| FX 10M notional |         1.08473 |      10000000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| FX 1B notional  |         1.08473 |    1000000000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| BTC 1k coins    | 150000.12345678 |          1000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| SPY fractional  |          700.12 |           0.5 |     263x |      26x |       2x | OVERFLOW |
+| SHIB 1e12 units |      0.00000001 | 1000000000000 |       9x |      n/a |      n/a |      n/a |
+<!-- END quantitystudy:notional -->
+
+This confirms the caveat ADR-004 already recorded against #36 from the price
+study. `TestWholeUnitQuantityIsSafer` isolates the cost precisely: the same
+BRK.A-sized block is comfortable with a whole unscaled quantity and overflows
+with a scaled one. Scaling `Quantity` is what pushes the product past `int64`,
+so notional calculation must use the widened path that
+[#38](https://github.com/rustyeddy/trader/issues/38) owns.
+
+## How the code is organized
+
+| File                | Contents                                                                    |
+|---------------------|-----------------------------------------------------------------------------|
+| `quantity.go`       | `QuantityRules` and validation, `SelectedScale`, supported-range helpers    |
+| `assets.go`         | Quantity matrix, instrument rules, and notional cases — all as data         |
+| `tables.go`         | `Frontier` analysis and the generated table fragments                       |
+| `quantity_test.go`  | Checks 1–10 from #36                                                        |
+| `golden_test.go`    | Verifies (and with `-update`, rewrites) the generated regions               |
+| `nofloat_test.go`   | Fails if `float32`/`float64` or a float literal appears in the package      |
+| `report_test.go`    | Prints the full report for reading                                          |

--- a/test/internal/quantitystudy/assets.go
+++ b/test/internal/quantitystudy/assets.go
@@ -1,0 +1,154 @@
+package quantitystudy
+
+// AssetQuantity is one representative quantity requirement from #36.
+type AssetQuantity struct {
+	Class    string
+	Symbol   string
+	Quantity string // decimal text
+	Decimals int    // fraction digits the quantity actually requires
+	Integral bool   // instrument accepts whole units only
+	Note     string
+}
+
+// Quantities is the representative matrix.  It deliberately carries both
+// extremes — satoshi precision and trillion-unit token positions — because the
+// tension between them, not the ordinary cases, decides the scale.
+var Quantities = []AssetQuantity{
+	{
+		Class: "FX", Symbol: "EUR/USD", Quantity: "1", Decimals: 0,
+		Note: "single unit; the smallest sane FX ticket",
+	},
+	{
+		Class: "FX", Symbol: "EUR/USD", Quantity: "10000", Decimals: 0,
+		Note: "micro lot",
+	},
+	{
+		Class: "FX", Symbol: "EUR/USD", Quantity: "10000000", Decimals: 0,
+		Note: "institutional ticket",
+	},
+	{
+		Class: "FX", Symbol: "EUR/USD", Quantity: "1000000000", Decimals: 0,
+		Note: "extreme FX notional; upper bound on realistic size",
+	},
+	{
+		Class: "Equity", Symbol: "SPY", Quantity: "1", Decimals: 0,
+		Note: "whole share",
+	},
+	{
+		Class: "Equity", Symbol: "SPY", Quantity: "0.5", Decimals: 1,
+		Note: "fractional shares are widely supported",
+	},
+	{
+		Class: "Equity", Symbol: "SPY", Quantity: "0.000001", Decimals: 6,
+		Note: "finest fractional-share precision brokers quote",
+	},
+	{
+		Class: "Futures", Symbol: "ES", Quantity: "1", Decimals: 0, Integral: true,
+		Note: "contracts are integral only",
+	},
+	{
+		Class: "Futures", Symbol: "ES", Quantity: "3", Decimals: 0, Integral: true,
+	},
+	{
+		Class: "Futures", Symbol: "ES", Quantity: "10000", Decimals: 0, Integral: true,
+		Note: "large but realistic contract count",
+	},
+	{
+		Class: "Crypto", Symbol: "BTC", Quantity: "1", Decimals: 0,
+	},
+	{
+		Class: "Crypto", Symbol: "BTC", Quantity: "0.00000001", Decimals: 8,
+		Note: "one satoshi; the finest quantity Trader intends to support",
+	},
+	{
+		Class: "Token", Symbol: "SHIB", Quantity: "1000000000000", Decimals: 0,
+		Note: "trillion-unit position; upper-range pressure from #36",
+	},
+	{
+		Class: "Boundary", Symbol: "ZERO", Quantity: "0", Decimals: 0,
+		Note: "representable; only order construction rejects it",
+	},
+}
+
+// The two requirements that cannot coexist in a scaled int64.  Naming them
+// keeps the frontier analysis anchored to the matrix rather than to constants
+// buried in a test.
+const (
+	FinestQuantity  = "0.00000001"    // one satoshi: 8 decimals
+	LargestQuantity = "1000000000000" // one trillion whole units
+)
+
+// Increment is a representative instrument rule set, expressed in decimal text
+// so it can be scaled into whichever candidate is under test.
+type Increment struct {
+	Symbol       string
+	Increment    string // smallest tradable step
+	Minimum      string
+	Maximum      string // empty means unbounded
+	IntegralOnly bool
+	Note         string
+}
+
+// Increments exercise the separation between representation scale and
+// instrument rules: every one of these is an instrument property, none is a
+// property of how the number is stored.
+var Increments = []Increment{
+	{
+		Symbol: "EUR/USD", Increment: "1", Minimum: "1", Maximum: "100000000",
+		Note: "FX trades in whole units with a broker cap",
+	},
+	{
+		Symbol: "SPY", Increment: "0.000001", Minimum: "0.000001",
+		Note: "fractional shares down to six decimals",
+	},
+	{
+		Symbol: "ES", Increment: "1", Minimum: "1", Maximum: "10000",
+		IntegralOnly: true,
+		Note:         "contracts: integral only, and the increment agrees",
+	},
+	{
+		Symbol: "BTC", Increment: "0.00000001", Minimum: "0.0001",
+		Note: "satoshi increment, but a larger exchange minimum",
+	},
+	{
+		Symbol: "SHIB", Increment: "1", Minimum: "1000",
+		Note: "whole tokens, large minimum",
+	},
+}
+
+// NotionalCase pairs a price with a quantity to measure the double-scaled
+// Price x Quantity intermediate.
+type NotionalCase struct {
+	Name     string
+	Price    string // decimal text, at PriceScale
+	Quantity string // decimal text, at the candidate Quantity scale
+	Why      string
+}
+
+// NotionalCases are the multiplication cases for check 10 of #36.
+var NotionalCases = []NotionalCase{
+	{
+		Name: "BRK.A block", Price: "750000.00", Quantity: "10000",
+		Why: "highest price x an institutional block",
+	},
+	{
+		Name: "FX 10M notional", Price: "1.08473", Quantity: "10000000",
+		Why: "typical institutional FX ticket",
+	},
+	{
+		Name: "FX 1B notional", Price: "1.08473", Quantity: "1000000000",
+		Why: "extreme FX notional",
+	},
+	{
+		Name: "BTC 1k coins", Price: "150000.12345678", Quantity: "1000",
+		Why: "widest price precision x a large position",
+	},
+	{
+		Name: "SPY fractional", Price: "700.12", Quantity: "0.5",
+		Why: "fractional quantity, ordinary price",
+	},
+	{
+		Name: "SHIB 1e12 units", Price: "0.00000001", Quantity: "1000000000000",
+		Why: "smallest price x the largest unit count",
+	},
+}

--- a/test/internal/quantitystudy/doc.go
+++ b/test/internal/quantitystudy/doc.go
@@ -1,0 +1,19 @@
+// Package quantitystudy is a design-investigation spike for
+// https://github.com/rustyeddy/trader/issues/36 — "Decide Quantity precision
+// and asset constraints".
+//
+// It is NOT the future public Quantity type.  Like its sibling
+// test/internal/numericstudy, it lives under test/internal so the import path
+// keeps it out of production code, and it should be deleted or superseded when
+// #44 consolidates ADR-004.
+//
+// It reuses numericstudy for exact decimal parsing and formatting, table
+// rendering, and the generated-documentation machinery, so both studies share
+// one implementation of "no binary floating point" and one implementation of
+// the guarantee that checked-in tables match the code.
+//
+// The central question is whether one fixed Trader-wide Quantity scale can
+// serve every intended asset class.  The evidence says no: satoshi precision
+// and trillion-unit token positions cannot coexist in a scaled int64.  See
+// Frontier and the report for the range arithmetic behind that.
+package quantitystudy

--- a/test/internal/quantitystudy/golden_test.go
+++ b/test/internal/quantitystudy/golden_test.go
@@ -1,0 +1,108 @@
+package quantitystudy
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	ns "github.com/rustyeddy/trader/test/internal/numericstudy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// update rewrites the generated regions instead of asserting on them:
+//
+//	go test ./test/internal/quantitystudy/ -run TestGeneratedTables -update
+var update = flag.Bool("update", false,
+	"rewrite generated table regions in the ADR and README")
+
+// syncer describes where this study's tables are embedded.  The "quantitystudy"
+// namespace keeps its markers distinct from numericstudy's in the same ADR.
+var syncer = ns.Syncer{
+	Namespace: "quantitystudy",
+	Docs: []ns.Doc{
+		{Path: "docs/arch/adr-004-exact-numeric-representation.org", Format: ns.FormatOrg},
+		{Path: "test/internal/quantitystudy/README.md", Format: ns.FormatMarkdown},
+	},
+	Fragments: Fragments,
+}
+
+// TestGeneratedTables holds the checked-in tables to the evidence: every marked
+// region must equal what this package generates.  Run with -update to rewrite.
+func TestGeneratedTables(t *testing.T) {
+	root := testRepoRoot(t)
+
+	results, err := syncer.Sync(root, *update)
+	require.NoError(t, err)
+	require.Len(t, results, len(syncer.Docs))
+
+	for _, res := range results {
+		t.Run(res.Doc.Path, func(t *testing.T) {
+			assert.Empty(t, res.Unbalanced, "mismatched BEGIN/END marker names")
+			assert.Empty(t, res.Unknown, "regions naming a fragment nothing generates")
+			require.NotEmpty(t, res.Seen,
+				"no %s markers; generated tables are unguarded", syncer.Namespace)
+
+			if *update {
+				t.Logf("synced %d region(s)", len(res.Seen))
+				return
+			}
+
+			assert.Empty(t, res.Stale,
+				"stale regions — regenerate with:\n"+
+					"  go test ./test/internal/quantitystudy/ -run TestGeneratedTables -update")
+		})
+	}
+}
+
+// TestEveryFragmentIsUsed catches a generated table that no document embeds.
+func TestEveryFragmentIsUsed(t *testing.T) {
+	used, err := syncer.UsedFragments(testRepoRoot(t))
+	require.NoError(t, err)
+
+	for name := range Fragments(ns.FormatOrg) {
+		assert.True(t, used[name],
+			"fragment %q is generated but embedded in no document", name)
+	}
+}
+
+// TestMarkersDoNotCollide checks that this study's markers never match
+// numericstudy's, so the two can share ADR-004 safely.
+func TestMarkersDoNotCollide(t *testing.T) {
+	other := ns.Syncer{Namespace: "numericstudy"}
+
+	for _, f := range []ns.Format{ns.FormatOrg, ns.FormatMarkdown} {
+		mine, _ := syncer.Markers(f, "frontier")
+		theirs, _ := other.Markers(f, "frontier")
+
+		assert.NotEqual(t, mine, theirs)
+		assert.Contains(t, mine, "quantitystudy:")
+		assert.False(t, strings.Contains(mine, "numericstudy:"),
+			"quantitystudy markers must not be a substring match for numericstudy")
+	}
+}
+
+// TestFragmentsRenderInBothFormats guards the renderer for this study's data.
+func TestFragmentsRenderInBothFormats(t *testing.T) {
+	for _, f := range []ns.Format{ns.FormatOrg, ns.FormatMarkdown} {
+		for name, body := range Fragments(f) {
+			t.Run(fmt.Sprintf("%d/%s", f, name), func(t *testing.T) {
+				assert.NoError(t, ns.ValidateTable(body))
+			})
+		}
+	}
+}
+
+func testRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	root, err := ns.RepoRoot(wd)
+	require.NoError(t, err)
+
+	return root
+}

--- a/test/internal/quantitystudy/nofloat_test.go
+++ b/test/internal/quantitystudy/nofloat_test.go
@@ -1,0 +1,27 @@
+package quantitystudy
+
+import (
+	"os"
+	"testing"
+
+	ns "github.com/rustyeddy/trader/test/internal/numericstudy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoFloatingPoint holds this study to the same rule as numericstudy: it
+// concludes that scaled int64 is the right representation, so it must not
+// depend on binary floating point to reach that conclusion — including in its
+// reporting and margin arithmetic.
+func TestNoFloatingPoint(t *testing.T) {
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	found, err := ns.FindFloatUsage(dir)
+	require.NoError(t, err)
+
+	for _, u := range found {
+		assert.Fail(t, "binary floating point in study source",
+			"%s at %s", u.What, u.Position)
+	}
+}

--- a/test/internal/quantitystudy/quantity.go
+++ b/test/internal/quantitystudy/quantity.go
@@ -1,0 +1,130 @@
+package quantitystudy
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rustyeddy/trader/test/internal/numericstudy"
+)
+
+// Candidates are the internal Quantity scales evaluated by this study.
+//
+// #36 asks for 1e6 and 1e8; 1e7 and 1e9 are included so the range/precision
+// frontier is visible as a curve rather than asserted from two points.
+var Candidates = []numericstudy.Scale{
+	{Name: "1e6", Decimals: 6, Factor: 1_000_000},
+	{Name: "1e7", Decimals: 7, Factor: 10_000_000},
+	{Name: "1e8", Decimals: 8, Factor: 100_000_000},
+	{Name: "1e9", Decimals: 9, Factor: 1_000_000_000},
+}
+
+// PriceScale is the internal Price scale fixed by #33.  Quantity arithmetic is
+// evaluated against it, because Price x Quantity is where the two scales meet.
+var PriceScale = numericstudy.Scale{Name: "1e8", Decimals: 8, Factor: 100_000_000}
+
+// SelectedScale is the recommended Trader-wide Quantity scale: 1e8, matching
+// Price.
+//
+// It is chosen on precision coverage plus an explicitly bounded supported
+// range, not on holding every quantity the pressure matrix contains.  1e8
+// represents every intended asset class exactly — FX units, whole and
+// fractional equities, futures contracts, and crypto down to one satoshi — and
+// supports whole-unit quantities from 0 through MaxSupportedWholeUnits.
+//
+// Quantities above that bound are rejected as out of range rather than
+// silently truncated.  Positions in extremely high-supply tokens above the
+// bound are outside the initial supported domain; see the 1e12 row in the
+// evidence, which is retained precisely to mark that boundary.
+var SelectedScale = numericstudy.Scale{Name: "1e8", Decimals: 8, Factor: 100_000_000}
+
+// MaxSupportedWholeUnits is the largest whole-unit quantity representable at
+// SelectedScale: 92,233,720,368, or roughly 92.2 billion units.
+var MaxSupportedWholeUnits = numericstudy.MaxPrice(SelectedScale)
+
+// QuantityRules are the instrument and broker constraints on an order
+// quantity.  They are deliberately separate from the representation scale: the
+// scale says what can be stored, these say what may be traded.
+type QuantityRules struct {
+	Increment    int64 // smallest tradable step, in scale units; 0 means unconstrained
+	Minimum      int64 // smallest permitted order size, in scale units
+	Maximum      int64 // largest permitted order size, in scale units; 0 means unbounded
+	IntegralOnly bool  // whole units only, e.g. futures contracts
+}
+
+// Validation failures.  They are distinct because they carry different
+// remedies: a rounding adjustment, a size change, or an outright rejection.
+var (
+	ErrNegative     = errors.New("quantitystudy: order quantity must not be negative")
+	ErrZero         = errors.New("quantitystudy: order quantity must not be zero")
+	ErrIncrement    = errors.New("quantitystudy: quantity is not a multiple of the increment")
+	ErrNotIntegral  = errors.New("quantitystudy: instrument accepts whole units only")
+	ErrBelowMinimum = errors.New("quantitystudy: quantity is below the instrument minimum")
+	ErrAboveMaximum = errors.New("quantitystudy: quantity is above the instrument maximum")
+)
+
+// Validate checks a scaled quantity against the instrument rules.
+//
+// Zero is representable and is not rejected here: whether an order may have
+// zero quantity is an order-construction question, and Validate is about
+// instrument conformance.  ValidateOrder layers the order-level rule on top.
+func (r QuantityRules) Validate(q int64, sc numericstudy.Scale) error {
+	// Direction is never encoded in the quantity sign; a negative quantity is
+	// a programming error, not a sell.
+	if q < 0 {
+		return fmt.Errorf("%w: %s", ErrNegative, numericstudy.FormatDecimal(q, sc))
+	}
+
+	if r.IntegralOnly && q%sc.Factor != 0 {
+		return fmt.Errorf("%w: %s", ErrNotIntegral, numericstudy.FormatDecimal(q, sc))
+	}
+
+	// Exact integer modulo — no tolerance, no rounding.  This is the whole
+	// reason for holding quantity and increment in the same scale.
+	if r.Increment > 0 && q%r.Increment != 0 {
+		return fmt.Errorf("%w: %s is not a multiple of %s", ErrIncrement,
+			numericstudy.FormatDecimal(q, sc), numericstudy.FormatDecimal(r.Increment, sc))
+	}
+
+	if r.Minimum > 0 && q < r.Minimum {
+		return fmt.Errorf("%w: %s < %s", ErrBelowMinimum,
+			numericstudy.FormatDecimal(q, sc), numericstudy.FormatDecimal(r.Minimum, sc))
+	}
+
+	if r.Maximum > 0 && q > r.Maximum {
+		return fmt.Errorf("%w: %s > %s", ErrAboveMaximum,
+			numericstudy.FormatDecimal(q, sc), numericstudy.FormatDecimal(r.Maximum, sc))
+	}
+
+	return nil
+}
+
+// ValidateOrder adds the order-level rule that a tradable quantity must be
+// non-zero.  Keeping it separate from Validate is the point: zero is a
+// perfectly representable Quantity — a flat position, a closed lot — and only
+// order construction rejects it.
+func (r QuantityRules) ValidateOrder(q int64, sc numericstudy.Scale) error {
+	if q == 0 {
+		return ErrZero
+	}
+	return r.Validate(q, sc)
+}
+
+// MaxWholeUnits reports the largest whole-unit quantity representable at sc.
+func MaxWholeUnits(sc numericstudy.Scale) int64 {
+	return numericstudy.MaxPrice(sc)
+}
+
+// Representable reports whether decimal text is exactly representable at sc.
+func Representable(text string, sc numericstudy.Scale) bool {
+	_, err := numericstudy.ParseDecimal(text, sc)
+	return err == nil
+}
+
+// NotionalOverflows reports whether a scaled price times a scaled quantity
+// overflows int64 before the descaling divide.
+//
+// Both operands carry a scale, so the product is double-scaled — the same
+// shape as Price x Rate in #33, and the reason #36 feeds back into #38.
+func NotionalOverflows(price, qty int64) bool {
+	return numericstudy.MulOverflows(price, qty)
+}

--- a/test/internal/quantitystudy/quantity_test.go
+++ b/test/internal/quantitystudy/quantity_test.go
@@ -1,0 +1,440 @@
+package quantitystudy
+
+import (
+	"math"
+	"testing"
+
+	ns "github.com/rustyeddy/trader/test/internal/numericstudy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Checks 1 and 2: exact parse and format round trips ---------------------
+
+// TestRoundTrip is the core evidence: every representative quantity, at every
+// candidate scale, either round-trips exactly or fails for a documented
+// reason.  Parsing goes straight from decimal text to scaled int64 with no
+// float64 anywhere; TestNoFloatingPoint enforces that across the package.
+func TestRoundTrip(t *testing.T) {
+	for _, sc := range Candidates {
+		for _, q := range Quantities {
+			t.Run(sc.Name+"/"+q.Symbol+"/"+q.Quantity, func(t *testing.T) {
+				v, err := ns.ParseDecimal(q.Quantity, sc)
+
+				if q.Decimals > sc.Decimals {
+					require.ErrorIs(t, err, ns.ErrTooManyDecimals,
+						"%s needs %d decimals; scale %s holds %d",
+						q.Quantity, q.Decimals, sc.Name, sc.Decimals)
+					return
+				}
+				if err != nil {
+					require.ErrorIs(t, err, ns.ErrOverflow,
+						"the only other permitted failure is range")
+					return
+				}
+
+				assert.Equal(t, ns.Canonical(q.Quantity), ns.FormatDecimal(v, sc),
+					"round trip must be exact")
+			})
+		}
+	}
+}
+
+// --- Check 3: maximum whole-unit quantity -----------------------------------
+
+func TestMaxWholeUnits(t *testing.T) {
+	want := map[string]int64{
+		"1e6": 9_223_372_036_854,
+		"1e7": 922_337_203_685,
+		"1e8": 92_233_720_368,
+		"1e9": 9_223_372_036,
+	}
+
+	for _, sc := range Candidates {
+		t.Run(sc.Name, func(t *testing.T) {
+			got := MaxWholeUnits(sc)
+			require.Equal(t, want[sc.Name], got)
+
+			// The stated maximum is representable and one more is not.
+			_, err := ns.ParseDecimal(ns.MaxPriceText(sc), sc)
+			assert.NoError(t, err)
+
+			_, err = ns.ParseDecimal(wholeUnits(got+1), sc)
+			assert.ErrorIs(t, err, ns.ErrOverflow)
+		})
+	}
+}
+
+// --- Check 4 and the central finding: the precision/range frontier ----------
+
+// TestFrontier is this study's most consequential result.  #36 asks for one
+// fixed Trader-wide Quantity scale that holds both satoshi precision and
+// trillion-unit token positions.  No scaled int64 can do both, so the "single
+// scale" premise cannot survive the matrix as written.
+func TestFrontier(t *testing.T) {
+	for _, f := range Frontiers() {
+		t.Run(f.Scale.Name, func(t *testing.T) {
+			t.Logf("smallest=%s maxWhole=%d finest=%v largest=%v",
+				f.SmallestUnit, f.MaxWholeUnits, f.HoldsFinest, f.HoldsLargest)
+
+			assert.False(t, f.HoldsFinest && f.HoldsLargest,
+				"no int64 scale should hold both extremes")
+		})
+	}
+
+	assert.False(t, SatisfiesBoth(),
+		"if this ever passes, int64 gained bits and the #36 conclusion changes")
+
+	// Name the two ends explicitly so the frontier is not an accident of which
+	// candidates happen to be listed.
+	finest := mustScaleHolding(t, FinestQuantity)
+	largest := mustScaleHolding(t, LargestQuantity)
+	assert.NotEqual(t, finest.Name, largest.Name,
+		"the two requirements must be satisfied by different scales")
+
+	// The arithmetic behind the impossibility, stated as a check rather than
+	// as prose: satoshi precision needs 8 fraction digits, and a trillion
+	// whole units at 8 digits needs more than int64 has.
+	const trillion = int64(1_000_000_000_000)
+	satoshiScale := ns.Scale{Name: "1e8", Decimals: 8, Factor: 100_000_000}
+	assert.True(t, ns.MulOverflows(trillion, satoshiScale.Factor),
+		"1e12 units at satoshi precision must exceed int64")
+}
+
+// TestSelectedScale pins the #36 recommendation and the bound that comes with
+// it: 1e8 Trader-wide, chosen on precision coverage plus an explicitly bounded
+// supported range rather than on holding every quantity in the pressure matrix.
+func TestSelectedScale(t *testing.T) {
+	sc := SelectedScale
+
+	require.Equal(t, PriceScale.Factor, sc.Factor,
+		"Quantity should share Price's scale unless there is a reason not to")
+	assert.Equal(t, int64(92_233_720_368), MaxSupportedWholeUnits)
+	assert.Equal(t, "0.00000001", ns.FormatDecimal(1, sc))
+
+	// Every intended asset class is representable at the selected scale.
+	for _, q := range Quantities {
+		if q.Quantity == LargestQuantity {
+			continue // the out-of-domain pressure case, asserted below
+		}
+		t.Run(q.Symbol+"/"+q.Quantity, func(t *testing.T) {
+			v, err := ns.ParseDecimal(q.Quantity, sc)
+			require.NoError(t, err, "%s must be representable at the selected scale", q.Quantity)
+			assert.Equal(t, ns.Canonical(q.Quantity), ns.FormatDecimal(v, sc))
+		})
+	}
+
+	// The bound is exact: the maximum holds, one more unit does not.
+	_, err := ns.ParseDecimal(wholeUnits(MaxSupportedWholeUnits), sc)
+	assert.NoError(t, err)
+
+	_, err = ns.ParseDecimal(wholeUnits(MaxSupportedWholeUnits+1), sc)
+	assert.ErrorIs(t, err, ns.ErrOverflow)
+}
+
+// TestOutOfDomainQuantityIsRejected covers the retained pressure case.  A
+// trillion-unit token position is outside the initial supported domain, and
+// the important property is that it is rejected as out of range rather than
+// silently truncated or wrapped into a plausible-looking small number.
+func TestOutOfDomainQuantityIsRejected(t *testing.T) {
+	sc := SelectedScale
+
+	_, err := ns.ParseDecimal(LargestQuantity, sc)
+	require.ErrorIs(t, err, ns.ErrOverflow,
+		"the failure must be a range error, not a precision error")
+	assert.NotErrorIs(t, err, ns.ErrTooManyDecimals)
+
+	// It is a range problem, not a precision problem: the same value is
+	// representable at a coarser scale.
+	v, err := ns.ParseDecimal(LargestQuantity, scaleByName(t, "1e6"))
+	require.NoError(t, err)
+	assert.Equal(t, LargestQuantity, ns.FormatDecimal(v, scaleByName(t, "1e6")))
+
+	// And the coarser scale that holds it cannot hold a satoshi, which is why
+	// trading range for precision is not a free move.
+	assert.False(t, Representable(FinestQuantity, scaleByName(t, "1e6")))
+}
+
+// TestSelectedScaleBeatsFinerCandidates records why 1e8 rather than 1e9: both
+// cover every intended asset class, but 1e9 spends an unused decimal place on
+// a tenfold smaller supported range.
+func TestSelectedScaleBeatsFinerCandidates(t *testing.T) {
+	fine := scaleByName(t, "1e9")
+
+	assert.True(t, Representable(FinestQuantity, SelectedScale))
+	assert.True(t, Representable(FinestQuantity, fine),
+		"1e9 also covers satoshi precision")
+
+	// Integer division truncates, so compare in the direction that stays
+	// exact: the finer scale's range is the selected scale's, divided by ten.
+	assert.Equal(t, MaxWholeUnits(SelectedScale)/10, MaxWholeUnits(fine),
+		"1e9 costs a factor of ten in supported range")
+
+	// Nothing in the matrix needs the ninth decimal place.
+	for _, q := range Quantities {
+		assert.LessOrEqual(t, q.Decimals, SelectedScale.Decimals,
+			"%s would justify a finer scale", q.Quantity)
+	}
+}
+
+// TestRepresentabilityIsMonotonic pins the shape of the trade-off: finer
+// scales hold smaller quantities and fewer whole units, strictly.
+func TestRepresentabilityIsMonotonic(t *testing.T) {
+	frontiers := Frontiers()
+
+	for i := 1; i < len(frontiers); i++ {
+		prev, cur := frontiers[i-1], frontiers[i]
+		require.Greater(t, cur.Scale.Decimals, prev.Scale.Decimals,
+			"candidates must be ordered coarsest first")
+
+		assert.Less(t, cur.MaxWholeUnits, prev.MaxWholeUnits,
+			"a finer scale must hold fewer whole units")
+	}
+}
+
+// --- Check 5: representation scale is independent of instrument rules -------
+
+// TestRulesAreIndependentOfScale shows the same instrument rule set behaves
+// identically at every scale that can represent it.  The scale says what can
+// be stored; the rules say what may be traded.
+func TestRulesAreIndependentOfScale(t *testing.T) {
+	for _, inc := range Increments {
+		for _, sc := range Candidates {
+			rules, ok := scaleRules(inc, sc)
+			if !ok {
+				continue // rule not representable at this scale
+			}
+
+			t.Run(inc.Symbol+"/"+sc.Name, func(t *testing.T) {
+				// A quantity of exactly one increment above the minimum is
+				// valid at every scale that can express both.
+				q := rules.Minimum
+				if rules.Increment > 0 && q%rules.Increment != 0 {
+					q = ((q / rules.Increment) + 1) * rules.Increment
+				}
+				assert.NoError(t, rules.Validate(q, sc))
+
+				// Half an increment never is.  An integral-only instrument
+				// rejects it as non-integral first, which is the same
+				// judgement reached by the stricter of two applicable rules.
+				if rules.Increment > 1 {
+					err := rules.Validate(q+rules.Increment/2, sc)
+					if rules.IntegralOnly {
+						assert.ErrorIs(t, err, ErrNotIntegral)
+					} else {
+						assert.ErrorIs(t, err, ErrIncrement)
+					}
+				}
+			})
+		}
+	}
+}
+
+// --- Check 6: exact increment validation by integer modulo ------------------
+
+func TestIncrementValidation(t *testing.T) {
+	sc := scaleByName(t, "1e8")
+
+	rules := QuantityRules{
+		Increment: mustParse(t, "0.00000001", sc),
+		Minimum:   mustParse(t, "0.0001", sc),
+	}
+
+	assert.NoError(t, rules.Validate(mustParse(t, "0.0001", sc), sc))
+	assert.NoError(t, rules.Validate(mustParse(t, "1.23456789", sc), sc))
+	assert.ErrorIs(t, rules.Validate(mustParse(t, "0.00001", sc), sc), ErrBelowMinimum)
+
+	// A coarser increment rejects anything off the step, exactly.
+	coarse := QuantityRules{Increment: mustParse(t, "0.25", sc)}
+	assert.NoError(t, coarse.Validate(mustParse(t, "0.75", sc), sc))
+	assert.ErrorIs(t, coarse.Validate(mustParse(t, "0.8", sc), sc), ErrIncrement)
+	assert.ErrorIs(t, coarse.Validate(mustParse(t, "0.7499999", sc), sc), ErrIncrement)
+}
+
+// --- Check 7: integral-only instruments -------------------------------------
+
+func TestIntegralOnly(t *testing.T) {
+	for _, sc := range Candidates {
+		t.Run(sc.Name, func(t *testing.T) {
+			rules := QuantityRules{IntegralOnly: true, Increment: sc.Factor}
+
+			for _, whole := range []string{"1", "3", "10000"} {
+				assert.NoError(t, rules.Validate(mustParse(t, whole, sc), sc),
+					"%s contracts must validate", whole)
+			}
+
+			for _, frac := range []string{"0.5", "1.5", "2.000001"} {
+				v, err := ns.ParseDecimal(frac, sc)
+				if err != nil {
+					continue
+				}
+				assert.ErrorIs(t, rules.Validate(v, sc), ErrNotIntegral,
+					"%s must be rejected as non-integral", frac)
+			}
+		})
+	}
+}
+
+// --- Check 8: zero is representable but not orderable -----------------------
+
+// TestZeroPolicy separates two questions that are easy to conflate.  Zero is a
+// perfectly good Quantity — a flat position, a fully closed lot — so the
+// representation must hold it.  Only order construction rejects it.
+func TestZeroPolicy(t *testing.T) {
+	for _, sc := range Candidates {
+		t.Run(sc.Name, func(t *testing.T) {
+			v, err := ns.ParseDecimal("0", sc)
+			require.NoError(t, err, "zero must be representable")
+			assert.Zero(t, v)
+			assert.Equal(t, "0", ns.FormatDecimal(v, sc))
+
+			rules := QuantityRules{Increment: sc.Factor, Minimum: sc.Factor}
+
+			// Instrument conformance does not reject zero...
+			assert.NotErrorIs(t, rules.Validate(0, sc), ErrZero)
+
+			// ...but constructing an order from it does.
+			assert.ErrorIs(t, rules.ValidateOrder(0, sc), ErrZero)
+		})
+	}
+}
+
+// --- Check 9: public quantities are non-negative ----------------------------
+
+// TestNonNegative pins the rule that direction is never encoded in the
+// quantity sign.  A negative quantity is a programming error, not a sell: side
+// belongs to the order, and conflating them makes every downstream sum
+// silently wrong.
+func TestNonNegative(t *testing.T) {
+	for _, sc := range Candidates {
+		t.Run(sc.Name, func(t *testing.T) {
+			rules := QuantityRules{Increment: sc.Factor}
+
+			for _, neg := range []string{"-1", "-0.5", "-10000"} {
+				v, err := ns.ParseDecimal(neg, sc)
+				if err != nil {
+					continue
+				}
+				assert.ErrorIs(t, rules.Validate(v, sc), ErrNegative)
+				assert.ErrorIs(t, rules.ValidateOrder(v, sc), ErrNegative)
+			}
+
+			// The negative bound is rejected as a quantity, not mishandled.
+			assert.ErrorIs(t, rules.Validate(math.MinInt64, sc), ErrNegative)
+		})
+	}
+}
+
+// --- Check 10: Price x Quantity intermediates -------------------------------
+
+// TestNotionalNeedsWidening is the arithmetic consequence #36 owes #38.  With
+// Price fixed at 1e8 by #33 and Quantity scaled too, the product is
+// double-scaled — the same shape as Price x Rate — so realistic notionals
+// overflow int64 before the descaling divide.
+func TestNotionalNeedsWidening(t *testing.T) {
+	overflowed := map[string]bool{}
+
+	for _, sc := range Candidates {
+		for _, n := range NotionalCases {
+			p, perr := ns.ParseDecimal(n.Price, PriceScale)
+			q, qerr := ns.ParseDecimal(n.Quantity, sc)
+			if perr != nil || qerr != nil {
+				continue
+			}
+			if NotionalOverflows(p, q) {
+				overflowed[sc.Name] = true
+				t.Logf("%s: %s overflows the double-scaled intermediate", sc.Name, n.Name)
+			}
+		}
+	}
+
+	for _, sc := range Candidates {
+		assert.True(t, overflowed[sc.Name],
+			"scale %s: scaled Quantity must be shown to require widened "+
+				"arithmetic for notional, per #38", sc.Name)
+	}
+}
+
+// TestWholeUnitQuantityIsSafer contrasts the scaled case with the unscaled one
+// #33 measured, showing precisely what scaling Quantity costs.
+func TestWholeUnitQuantityIsSafer(t *testing.T) {
+	sc := scaleByName(t, "1e8")
+
+	price := mustParse(t, "750000.00", PriceScale)
+	const blockSize = int64(10_000)
+
+	// Whole unscaled quantity: single-scaled, comfortable.
+	assert.False(t, ns.MulOverflows(price, blockSize),
+		"unscaled quantity keeps the #33 margin")
+
+	// The same position with a scaled quantity: double-scaled, overflows.
+	scaled := mustParse(t, "10000", sc)
+	assert.True(t, ns.MulOverflows(price, scaled),
+		"scaling Quantity is what pushes this product past int64")
+}
+
+// --- helpers ----------------------------------------------------------------
+
+func scaleByName(t *testing.T, name string) ns.Scale {
+	t.Helper()
+	for _, sc := range Candidates {
+		if sc.Name == name {
+			return sc
+		}
+	}
+	t.Fatalf("unknown scale %q", name)
+	return ns.Scale{}
+}
+
+func mustParse(t *testing.T, text string, sc ns.Scale) int64 {
+	t.Helper()
+	v, err := ns.ParseDecimal(text, sc)
+	require.NoError(t, err, "%s at scale %s", text, sc.Name)
+	return v
+}
+
+// mustScaleHolding returns the first candidate that can represent text.
+func mustScaleHolding(t *testing.T, text string) ns.Scale {
+	t.Helper()
+	for _, sc := range Candidates {
+		if Representable(text, sc) {
+			return sc
+		}
+	}
+	t.Fatalf("no candidate represents %s", text)
+	return ns.Scale{}
+}
+
+// scaleRules converts an Increment's decimal text into scaled rules, reporting
+// false when the scale cannot represent them.
+func scaleRules(inc Increment, sc ns.Scale) (QuantityRules, bool) {
+	step, err := ns.ParseDecimal(inc.Increment, sc)
+	if err != nil {
+		return QuantityRules{}, false
+	}
+
+	min, err := ns.ParseDecimal(inc.Minimum, sc)
+	if err != nil {
+		return QuantityRules{}, false
+	}
+
+	var max int64
+	if inc.Maximum != "" {
+		max, err = ns.ParseDecimal(inc.Maximum, sc)
+		if err != nil {
+			return QuantityRules{}, false
+		}
+	}
+
+	return QuantityRules{
+		Increment:    step,
+		Minimum:      min,
+		Maximum:      max,
+		IntegralOnly: inc.IntegralOnly,
+	}, true
+}
+
+// wholeUnits renders an int64 as plain digits for feeding back into the parser.
+func wholeUnits(v int64) string {
+	return ns.FormatDecimal(v, ns.Scale{Name: "1e0", Decimals: 0, Factor: 1})
+}

--- a/test/internal/quantitystudy/report_test.go
+++ b/test/internal/quantitystudy/report_test.go
@@ -1,0 +1,56 @@
+package quantitystudy
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	ns "github.com/rustyeddy/trader/test/internal/numericstudy"
+	"github.com/stretchr/testify/require"
+)
+
+// reportSections is the order the report prints its tables in.  The names match
+// the fragments embedded in the ADR and README, so the printed report and the
+// documents are one source rendered once.
+var reportSections = []struct{ name, heading string }{
+	{"quantity-matrix", "Quantity representation matrix"},
+	{"frontier", "Precision and range frontier"},
+	{"instrument-rules", "Instrument rules (separate from representation scale)"},
+	{"notional", "Price(1e8) x Quantity headroom, both operands scaled"},
+}
+
+// TestGenerateReport prints the validation tables in org-mode syntax.
+//
+// The checked-in tables are the same fragments, verified by
+// TestGeneratedTables — so this is for reading, not for pasting.  To refresh
+// the documents, run that test with -update.
+//
+//	go test ./test/internal/quantitystudy/ -run TestGenerateReport -v
+//	NUMERICSTUDY_REPORT=q.org go test ./test/internal/quantitystudy/ -run TestGenerateReport
+func TestGenerateReport(t *testing.T) {
+	frag := Fragments(ns.FormatOrg)
+
+	var b strings.Builder
+	for _, s := range reportSections {
+		body, ok := frag[s.name]
+		require.True(t, ok, "report references unknown fragment %q", s.name)
+		fmt.Fprintf(&b, "\n** %s\n\n%s", s.heading, body)
+	}
+
+	fmt.Fprintf(&b, "\nPRECISION = needs more decimals than the scale holds.\n"+
+		"RANGE     = exceeds int64 at that scale.\n\n"+
+		"Selected scale: %s.  Smallest quantity %s, maximum whole units %s.\n",
+		SelectedScale.Name, ns.FormatDecimal(1, SelectedScale),
+		ns.Commas(MaxSupportedWholeUnits))
+
+	if path := os.Getenv("NUMERICSTUDY_REPORT"); path != "" {
+		require.NoError(t, os.WriteFile(path, []byte(b.String()), 0o644))
+		t.Logf("report written to %s", path)
+		return
+	}
+
+	if testing.Verbose() {
+		fmt.Print(b.String())
+	}
+}

--- a/test/internal/quantitystudy/tables.go
+++ b/test/internal/quantitystudy/tables.go
@@ -1,0 +1,180 @@
+package quantitystudy
+
+import (
+	"errors"
+	"fmt"
+
+	ns "github.com/rustyeddy/trader/test/internal/numericstudy"
+)
+
+// Frontier reports, for one candidate scale, whether it can hold the finest
+// and the largest quantity in the pressure matrix.
+//
+// No scaled int64 satisfies both.  One satoshi requires 8 fraction digits, and
+// a trillion whole units at 8 fraction digits requires 1e20 — 67 bits against
+// int64's 63.  This type exists so that fact is computed rather than asserted
+// in prose.
+//
+// The trillion-unit row is a deliberate range-pressure case, not a
+// requirement: per #36 it is retained in the evidence to mark the boundary of
+// the supported domain, and the recommendation is made on precision coverage
+// plus an explicitly bounded range.  See SelectedScale.
+type Frontier struct {
+	Scale         ns.Scale
+	MaxWholeUnits int64
+	SmallestUnit  string
+	HoldsFinest   bool
+	HoldsLargest  bool
+}
+
+// Frontiers evaluates every candidate.
+func Frontiers() []Frontier {
+	out := make([]Frontier, 0, len(Candidates))
+	for _, sc := range Candidates {
+		out = append(out, Frontier{
+			Scale:         sc,
+			MaxWholeUnits: MaxWholeUnits(sc),
+			SmallestUnit:  ns.FormatDecimal(1, sc),
+			HoldsFinest:   Representable(FinestQuantity, sc),
+			HoldsLargest:  Representable(LargestQuantity, sc),
+		})
+	}
+	return out
+}
+
+// SatisfiesBoth reports whether any candidate holds both extremes.
+func SatisfiesBoth() bool {
+	for _, f := range Frontiers() {
+		if f.HoldsFinest && f.HoldsLargest {
+			return true
+		}
+	}
+	return false
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+// Fragments renders every generated table for this study, keyed by the name
+// used in the document markers.
+func Fragments(f ns.Format) map[string]string {
+	frag := map[string]string{}
+
+	// Quantity representation matrix -----------------------------------------
+	var class, symbol, qty, dec, integral []string
+	for _, q := range Quantities {
+		class = append(class, q.Class)
+		symbol = append(symbol, q.Symbol)
+		qty = append(qty, q.Quantity)
+		dec = append(dec, fmt.Sprint(q.Decimals))
+		integral = append(integral, yesNo(q.Integral))
+	}
+
+	cols := []ns.Column{
+		{Header: "Class", Cells: class},
+		{Header: "Symbol", Cells: symbol},
+		{Header: "Quantity", Right: true, Cells: qty},
+		{Header: "Dec", Right: true, Cells: dec},
+		{Header: "Integral", Cells: integral},
+	}
+	for _, sc := range Candidates {
+		cells := make([]string, 0, len(Quantities))
+		for _, q := range Quantities {
+			// Precision failures and range failures lead to different
+			// conclusions — one narrows the asset classes a scale can serve,
+			// the other bounds the supported domain — so they are reported
+			// distinctly rather than both as a blank cell.
+			v, err := ns.ParseDecimal(q.Quantity, sc)
+			switch {
+			case errors.Is(err, ns.ErrTooManyDecimals):
+				cells = append(cells, "PRECISION")
+			case errors.Is(err, ns.ErrOverflow):
+				cells = append(cells, "RANGE")
+			case err != nil:
+				cells = append(cells, "—")
+			case ns.FormatDecimal(v, sc) != ns.Canonical(q.Quantity):
+				cells = append(cells, "INEXACT")
+			default:
+				cells = append(cells, fmt.Sprintf("%d", v))
+			}
+		}
+		cols = append(cols, ns.Column{Header: sc.Name, Right: true, Cells: cells})
+	}
+	frag["quantity-matrix"] = ns.RenderTable(f, cols)
+
+	// Range and precision frontier -------------------------------------------
+	var fs, fu, fm, ff, fl []string
+	for _, fr := range Frontiers() {
+		fs = append(fs, fr.Scale.Name)
+		fu = append(fu, fr.SmallestUnit)
+		fm = append(fm, ns.Commas(fr.MaxWholeUnits))
+		ff = append(ff, yesNo(fr.HoldsFinest))
+		fl = append(fl, yesNo(fr.HoldsLargest))
+	}
+	frag["frontier"] = ns.RenderTable(f, []ns.Column{
+		{Header: "Scale", Cells: fs},
+		{Header: "Smallest unit", Right: true, Cells: fu},
+		{Header: "Max whole units", Right: true, Cells: fm},
+		{Header: "Holds 1 satoshi", Cells: ff},
+		{Header: "Holds 1e12 units", Cells: fl},
+	})
+
+	// Instrument rules -------------------------------------------------------
+	var is, ii, im, ix, ig []string
+	for _, inc := range Increments {
+		is = append(is, inc.Symbol)
+		ii = append(ii, inc.Increment)
+		im = append(im, inc.Minimum)
+		if inc.Maximum == "" {
+			ix = append(ix, "—")
+		} else {
+			ix = append(ix, inc.Maximum)
+		}
+		ig = append(ig, yesNo(inc.IntegralOnly))
+	}
+	frag["instrument-rules"] = ns.RenderTable(f, []ns.Column{
+		{Header: "Symbol", Cells: is},
+		{Header: "Increment", Right: true, Cells: ii},
+		{Header: "Minimum", Right: true, Cells: im},
+		{Header: "Maximum", Right: true, Cells: ix},
+		{Header: "Integral only", Cells: ig},
+	})
+
+	// Price x Quantity intermediates -----------------------------------------
+	ncols := []ns.Column{
+		{Header: "Case", Cells: pluckNotional(func(n NotionalCase) string { return n.Name })},
+		{Header: "Price", Right: true, Cells: pluckNotional(func(n NotionalCase) string { return n.Price })},
+		{Header: "Quantity", Right: true, Cells: pluckNotional(func(n NotionalCase) string { return n.Quantity })},
+	}
+	for _, sc := range Candidates {
+		cells := make([]string, 0, len(NotionalCases))
+		for _, n := range NotionalCases {
+			p, perr := ns.ParseDecimal(n.Price, PriceScale)
+			q, qerr := ns.ParseDecimal(n.Quantity, sc)
+			switch {
+			case perr != nil || qerr != nil:
+				cells = append(cells, "n/a")
+			case NotionalOverflows(p, q):
+				cells = append(cells, "OVERFLOW")
+			default:
+				cells = append(cells, ns.Commas(ns.MaxPriceCeil(p*q))+"x")
+			}
+		}
+		ncols = append(ncols, ns.Column{Header: sc.Name, Right: true, Cells: cells})
+	}
+	frag["notional"] = ns.RenderTable(f, ncols)
+
+	return frag
+}
+
+func pluckNotional(fn func(NotionalCase) string) []string {
+	out := make([]string, 0, len(NotionalCases))
+	for _, n := range NotionalCases {
+		out = append(out, fn(n))
+	}
+	return out
+}


### PR DESCRIPTION
Resolves #36. Feeds ADR-004 under parent decision #19.

A code-backed design investigation covering the ten checks in #36, built as a sibling to `numericstudy` from #33.

## Recommendation: one Trader-wide `Quantity` scale of 1e8

Matching `Price`. A decimal quantity `v` is stored as the `int64` `v * 100_000_000`.

- smallest representable quantity: **0.00000001** (one satoshi)
- maximum whole-unit quantity: **92,233,720,368** (~92.2 billion)
- quantities above that bound are **rejected as out of range**, never truncated
- positions in extremely high-supply tokens above the bound are **outside the initial supported domain**

Per the direction on #36, the recommendation rests on precision coverage plus an explicitly bounded range rather than on holding every value in the pressure matrix.

## Why the bound is forced, not chosen

No scaled `int64` holds both ends of the matrix. One satoshi needs 8 fraction digits; a trillion whole units at 8 fraction digits needs 1e20 — 67 bits against `int64`'s 63.

| Scale | Smallest unit | Max whole units | Holds 1 satoshi | Holds 1e12 units |
|---|---:|---:|---|---|
| 1e6 | 0.000001 | 9,223,372,036,854 | no | yes |
| 1e7 | 0.0000001 | 922,337,203,685 | no | no |
| 1e8 | 0.00000001 | 92,233,720,368 | **yes** | no |
| 1e9 | 0.000000001 | 9,223,372,036 | yes | no |

Only 1e6 holds a trillion units and it cannot represent a satoshi; only 1e8 and 1e9 represent a satoshi and neither reaches a trillion units. Trading range for precision swaps which asset class is excluded rather than solving anything.

The trillion-unit row is **retained as an explicit unsupported-range case**, not removed or quietly made to pass. `TestOutOfDomainQuantityIsRejected` asserts it fails with a *range* error specifically — and that the same value parses at 1e6 — so the boundary is visible in behaviour, not only in prose. The generated matrix reports `PRECISION` and `RANGE` as distinct cells for the same reason.

Per-asset-class scales and a widened `Quantity` were both considered and rejected per #36.

**1e8 over 1e9:** both cover every intended asset class; 1e9 spends a ninth decimal place nothing in the matrix needs and pays a factor of ten in supported range for it.

## Consequence for #38

Scaling `Quantity` makes `Price × Quantity` **double-scaled** — the same shape as `Price × Rate` — so realistic notionals overflow `int64` before the descaling divide. This confirms the caveat ADR-004 already carried from #33.

`TestWholeUnitQuantityIsSafer` isolates the cost exactly: the same BRK.A-sized block is comfortable with a whole unscaled quantity and overflows with a scaled one. Notional calculation must use the widened path #38 owns.

## Also covered

- **Increment validation** by exact integer modulo — no tolerance, no rounding — which is the payoff for holding quantity and increment in one scale.
- **Integral-only instruments** (futures contracts) validated against the scale factor.
- **Representation scale separate from instrument rules.** `QuantityRules{Increment, Minimum, Maximum, IntegralOnly}`; `TestRulesAreIndependentOfScale` shows one rule set behaving identically at every scale that can represent it.
- **Zero representable, orders reject it.** `Validate` accepts zero as instrument-conformant; `ValidateOrder` rejects it. A flat position is a legitimate `Quantity`.
- **Non-negative public quantities.** Direction is never encoded in the sign; `math.MinInt64` is rejected as a quantity rather than mishandled.

## Refactor to `numericstudy`

To let the new package reuse the drift guard and the float ban, that machinery moved out of `_test.go` files into `golden.go` and `nofloat.go` — Go does not export test files across packages. `Syncer` gained a `Namespace` so both studies write into ADR-004 without colliding, and the table-rendering primitives are exported.

Verified in **both directions** that one study's `-update` leaves the other's regions untouched; `TestMarkersDoNotCollide` pins it.

No behaviour change to the #33 evidence — its generated tables are byte-identical.

## Verification

`make check` passes (`fmt-check`, `vet`, `test`, `race`). Coverage: quantitystudy 95.5%, numericstudy 91.2% — the latter down from 96.0% because the promoted `golden.go`/`nofloat.go` have I/O error paths this suite does not manufacture.

```sh
go test ./test/internal/quantitystudy/ -run TestGenerateReport -v
go test ./test/internal/quantitystudy/ -run TestGeneratedTables -update
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsfxQH4YBP5DA1LpAafWyt
