### PR TITLE
num: implement exact foundational value types (ADR-004, #22)

### DIFF
--- a/num/arch_test.go
+++ b/num/arch_test.go
@@ -1,0 +1,147 @@
+package num
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file enforces, mechanically, the two structural rules ADR-004 and the
+// package boundary depend on:
+//
+//   - no float32/float64 anywhere in num or num/internal/fixed;
+//   - no package outside num importing num/internal/fixed.
+//
+// The import rule is already guaranteed by Go's internal/ package visibility
+// rule — the compiler will not build a package outside the num tree that
+// imports num/internal/fixed. The test below is a second, independent check
+// of the same property: it documents the rule in a place a reviewer will
+// find, and it keeps failing loudly if the package is ever moved out from
+// under internal/ and loses that compiler guarantee.
+
+// fixedImportPath is the import path packages outside num must never use.
+const fixedImportPath = "github.com/rustyeddy/trader/num/internal/fixed"
+
+// TestNoFloatingPoint enforces the ADR-004 float containment policy within
+// num's own implementation: no float32 or float64 identifier or literal may
+// appear anywhere under num, including num/internal/fixed.
+//
+// Source is parsed rather than scanned as text, so identifiers and literals
+// appearing only in comments or string literals do not register.
+func TestNoFloatingPoint(t *testing.T) {
+	root, err := os.Getwd()
+	require.NoError(t, err)
+
+	found := findFloatUsage(t, root)
+	for _, u := range found {
+		assert.Fail(t, "binary floating point in num source", "%s at %s", u.what, u.pos)
+	}
+}
+
+type floatUse struct {
+	pos  string
+	what string
+}
+
+func findFloatUsage(t *testing.T, root string) []floatUse {
+	t.Helper()
+
+	var found []floatUse
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".go") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch v := n.(type) {
+			case *ast.Ident:
+				if v.Name == "float64" || v.Name == "float32" {
+					found = append(found, floatUse{
+						pos:  fset.Position(v.Pos()).String(),
+						what: v.Name,
+					})
+				}
+			case *ast.BasicLit:
+				if v.Kind == token.FLOAT || v.Kind == token.IMAG {
+					found = append(found, floatUse{
+						pos:  fset.Position(v.Pos()).String(),
+						what: v.Value,
+					})
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	require.NoError(t, err)
+	return found
+}
+
+// TestFixedIsNotImportedOutsideNum walks the whole repository module and
+// fails if any package outside the num tree imports num/internal/fixed. See
+// the file comment for why this duplicates a guarantee the Go compiler
+// already provides.
+func TestFixedIsNotImportedOutsideNum(t *testing.T) {
+	numDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	repoRoot := filepath.Dir(numDir) // num's parent is the module root
+
+	var violations []string
+	err = filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".go") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return err
+		}
+		if rel == "num" || strings.HasPrefix(rel, "num"+string(filepath.Separator)) {
+			return nil // inside the num tree; the rule does not apply here
+		}
+
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		for _, imp := range file.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			if importPath == fixedImportPath {
+				violations = append(violations, rel+": imports "+fixedImportPath)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	for _, v := range violations {
+		assert.Fail(t, "package outside num imports num/internal/fixed", v)
+	}
+}

--- a/num/currency.go
+++ b/num/currency.go
@@ -1,0 +1,72 @@
+package num
+
+// Currency identifies the denomination of a Money value.
+//
+// Currency validation is structural only: 3 to 5 uppercase ASCII letters.
+// This is deliberate — num does not embed an ISO-4217 table, a crypto asset
+// registry, or any other authoritative list of supported currencies.
+// Instrument and venue packages own that authority; num only guarantees that
+// whatever code is stored here is a well-formed identifier, not that it is a
+// currency Trader actually supports or trades.
+//
+// Currency carries no minor-unit count, display precision, tick size, or
+// other presentation convention. Those are presentation and instrument
+// concerns, not properties of the identifier itself.
+//
+// The Go zero value of Currency is invalid: it has no code and fails
+// validation. A valid Currency must be constructed with ParseCurrency or
+// MustParseCurrency.
+type Currency struct {
+	code string
+}
+
+// ParseCurrency validates code as a currency identifier: 3 to 5 uppercase
+// ASCII letters, nothing else. Empty input, lowercase letters, digits,
+// punctuation, separators, and whitespace are all rejected.
+func ParseCurrency(code string) (Currency, error) {
+	if !isValidCurrencyCode(code) {
+		return Currency{}, ErrInvalidCurrency
+	}
+	return Currency{code: code}, nil
+}
+
+// MustParseCurrency is like ParseCurrency but panics on error.
+//
+// It is intended for programmer-controlled constants, fixtures, and tests,
+// not for parsing external or market input.
+func MustParseCurrency(code string) Currency {
+	c, err := ParseCurrency(code)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+// IsValid reports whether c holds a structurally valid currency code.
+//
+// The Go zero value of Currency reports false.
+func (c Currency) IsValid() bool {
+	return isValidCurrencyCode(c.code)
+}
+
+// String returns the currency code, or the empty string for the zero value.
+func (c Currency) String() string {
+	return c.code
+}
+
+// Equal reports whether c and o hold the identical currency code.
+func (c Currency) Equal(o Currency) bool {
+	return c.code == o.code
+}
+
+func isValidCurrencyCode(code string) bool {
+	if len(code) < 3 || len(code) > 5 {
+		return false
+	}
+	for i := 0; i < len(code); i++ {
+		if code[i] < 'A' || code[i] > 'Z' {
+			return false
+		}
+	}
+	return true
+}

--- a/num/currency_test.go
+++ b/num/currency_test.go
@@ -1,0 +1,77 @@
+package num
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCurrencyValid(t *testing.T) {
+	tests := []string{
+		"USD", "EUR", "GBP", "JPY", // 3-letter FX/ISO-shaped
+		"USDT", "USDC", // 4-letter crypto
+		"WAVES", // 5-letter, upper bound
+	}
+
+	for _, code := range tests {
+		t.Run(code, func(t *testing.T) {
+			c, err := ParseCurrency(code)
+			require.NoError(t, err)
+			assert.Equal(t, code, c.String())
+			assert.True(t, c.IsValid())
+		})
+	}
+}
+
+func TestParseCurrencyInvalid(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+	}{
+		{name: "empty", code: ""},
+		{name: "too short", code: "US"},
+		{name: "too long", code: "TOOLONG"},
+		{name: "lowercase", code: "usd"},
+		{name: "mixed case", code: "Usd"},
+		{name: "contains digits", code: "US1"},
+		{name: "contains punctuation", code: "US-D"},
+		{name: "contains underscore", code: "US_D"},
+		{name: "contains whitespace", code: "US D"},
+		{name: "leading whitespace", code: " USD"},
+		{name: "trailing whitespace", code: "USD "},
+		{name: "currency symbol", code: "$UD"},
+		{name: "non-ascii letters", code: "USÐ"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseCurrency(tt.code)
+			require.ErrorIs(t, err, ErrInvalidCurrency)
+		})
+	}
+}
+
+func TestMustParseCurrency(t *testing.T) {
+	assert.Equal(t, "USD", MustParseCurrency("USD").String())
+	assert.Panics(t, func() { MustParseCurrency("usd") })
+}
+
+func TestCurrencyZeroValueIsInvalid(t *testing.T) {
+	var c Currency
+	assert.False(t, c.IsValid())
+	assert.Equal(t, "", c.String())
+}
+
+func TestCurrencyEqual(t *testing.T) {
+	usd1 := MustParseCurrency("USD")
+	usd2 := MustParseCurrency("USD")
+	eur := MustParseCurrency("EUR")
+
+	assert.True(t, usd1.Equal(usd2))
+	assert.False(t, usd1.Equal(eur))
+
+	var zero Currency
+	assert.False(t, usd1.Equal(zero))
+	assert.True(t, zero.Equal(Currency{}))
+}

--- a/num/doc.go
+++ b/num/doc.go
@@ -1,0 +1,54 @@
+// Package num implements Trader's exact foundational numeric value types, as
+// decided by ADR-004 (docs/arch/adr-004-exact-numeric-representation.org):
+//
+//	Price
+//	Quantity
+//	Rate
+//	Currency
+//	Money
+//
+// # Architectural boundary
+//
+// num expresses financial semantics: what a Price is, that a Quantity cannot
+// be negative, that Money requires a currency.  The private package
+// num/internal/fixed implements exact scaled-integer representation
+// mechanics: the common scale, checked arithmetic, widened multiplication and
+// division, rounding, and decimal parsing and formatting.
+//
+// Packages outside num must never import num/internal/fixed.  Code outside
+// num expresses financial intent using the semantic types exported here; it
+// does not know the raw scale, does not manipulate raw scaled integers, and
+// does not call generic fixed-point primitives directly.
+//
+// # Context-free versus context-dependent arithmetic
+//
+// Only universally valid operations are exported here, for example
+// Price.MulRate, Quantity.MulRate, Money.Add, and Money.DivRate.
+// Context-dependent calculations that need instrument metadata, contract
+// multipliers, or lot conventions — such as deriving Money from Price and
+// Quantity — belong in their eventual domain packages, not in num.
+//
+// # Percent and Ratio
+//
+// Rate is the foundational exact dimensionless type.  Percent and Ratio are
+// intentionally deferred: introducing them now, before a concrete domain
+// operation needs direction, bounds, or interpretation that Rate does not
+// already provide, would just be a naming exercise.  When a real constraint
+// materially differs from Rate's, add a semantic wrapper around Rate rather
+// than a competing base type.
+//
+// # Floating point
+//
+// float32 and float64 are prohibited from this package's implementation and
+// from its public API: no field, parameter, return value, or internal
+// arithmetic may use them.  An architecture test enforces this by parsing
+// package source.
+//
+// # Construction
+//
+// Ordinary callers construct values from exact decimal text (ParsePrice,
+// ParseQuantity, ...) or from the text/JSON unmarshalers.  Raw scaled int64
+// construction (PriceFromScaled, ...) is reserved for trusted internal code,
+// persistence reconstruction, and tests that exercise representation
+// boundaries directly; it is not the ordinary public API.
+package num

--- a/num/doc.go
+++ b/num/doc.go
@@ -46,9 +46,14 @@
 //
 // # Construction
 //
-// Ordinary callers construct values from exact decimal text (ParsePrice,
-// ParseQuantity, ...) or from the text/JSON unmarshalers.  Raw scaled int64
-// construction (PriceFromScaled, ...) is reserved for trusted internal code,
-// persistence reconstruction, and tests that exercise representation
-// boundaries directly; it is not the ordinary public API.
+// Callers construct values from exact decimal text (ParsePrice,
+// ParseQuantity, ...) or from the text/JSON unmarshalers.  There is no public
+// raw-scaled-int64 constructor or accessor: ADR-004 reserves that
+// representation detail for trusted internal code, persistence
+// reconstruction, and representation-boundary tests, and a public
+// FromScaled/Scaled pair on every semantic type would leak the 1e8 scale to
+// every importer of num rather than keep it narrowly scoped. A future
+// persistence adapter that needs exact scaled BIGINT reconstruction should
+// introduce its own narrowly scoped boundary for that purpose rather than
+// reuse a general-purpose escape hatch here.
 package num

--- a/num/encoding.go
+++ b/num/encoding.go
@@ -115,7 +115,13 @@ func (r *Rate) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalText implements encoding.TextMarshaler.
+//
+// MarshalText reports ErrInvalidCurrency for an invalid Currency, including
+// the zero value, rather than silently writing an empty or malformed code.
 func (c Currency) MarshalText() ([]byte, error) {
+	if !c.IsValid() {
+		return nil, ErrInvalidCurrency
+	}
 	return []byte(c.code), nil
 }
 
@@ -131,7 +137,13 @@ func (c *Currency) UnmarshalText(text []byte) error {
 
 // MarshalJSON implements json.Marshaler, encoding c as a JSON string holding
 // the currency code.
+//
+// MarshalJSON reports ErrInvalidCurrency for an invalid Currency, including
+// the zero value, rather than silently writing "".
 func (c Currency) MarshalJSON() ([]byte, error) {
+	if !c.IsValid() {
+		return nil, ErrInvalidCurrency
+	}
 	return json.Marshal(c.code)
 }
 

--- a/num/encoding.go
+++ b/num/encoding.go
@@ -1,0 +1,238 @@
+package num
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rustyeddy/trader/num/internal/fixed"
+)
+
+// Text and JSON encoding for num's semantic types (ADR-004).
+//
+// Price, Quantity, and Rate serialize as canonical decimal strings, both as
+// text and as JSON strings. Money serializes as a structured JSON value
+// carrying an explicit amount and currency; its text form is the single
+// canonical string "<amount> <currency>" (one ASCII space), which is a
+// distinct, narrower contract used for CSV cells, map keys, and log lines —
+// not a substitute for the JSON form.
+//
+// Writers here always emit canonical text. Readers accept any input the
+// underlying exact parser accepts, which includes non-canonical but exactly
+// equivalent forms such as trailing zeros; they never round. Nothing in this
+// file uses float64.
+
+// MarshalText implements encoding.TextMarshaler.
+func (p Price) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (p *Price) UnmarshalText(text []byte) error {
+	v, err := ParsePrice(string(text))
+	if err != nil {
+		return err
+	}
+	*p = v
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler, encoding p as a canonical decimal
+// string.
+func (p Price) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
+}
+
+// UnmarshalJSON implements json.Unmarshaler, decoding a JSON string holding
+// exact decimal text.
+func (p *Price) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	return p.UnmarshalText([]byte(s))
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (q Quantity) MarshalText() ([]byte, error) {
+	return []byte(q.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (q *Quantity) UnmarshalText(text []byte) error {
+	v, err := ParseQuantity(string(text))
+	if err != nil {
+		return err
+	}
+	*q = v
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler, encoding q as a canonical decimal
+// string.
+func (q Quantity) MarshalJSON() ([]byte, error) {
+	return json.Marshal(q.String())
+}
+
+// UnmarshalJSON implements json.Unmarshaler, decoding a JSON string holding
+// exact decimal text.
+func (q *Quantity) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	return q.UnmarshalText([]byte(s))
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (r Rate) MarshalText() ([]byte, error) {
+	return []byte(r.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (r *Rate) UnmarshalText(text []byte) error {
+	v, err := ParseRate(string(text))
+	if err != nil {
+		return err
+	}
+	*r = v
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler, encoding r as a canonical decimal
+// string.
+func (r Rate) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.String())
+}
+
+// UnmarshalJSON implements json.Unmarshaler, decoding a JSON string holding
+// exact decimal text.
+func (r *Rate) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	return r.UnmarshalText([]byte(s))
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (c Currency) MarshalText() ([]byte, error) {
+	return []byte(c.code), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (c *Currency) UnmarshalText(text []byte) error {
+	v, err := ParseCurrency(string(text))
+	if err != nil {
+		return err
+	}
+	*c = v
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler, encoding c as a JSON string holding
+// the currency code.
+func (c Currency) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.code)
+}
+
+// UnmarshalJSON implements json.Unmarshaler, decoding a JSON string holding a
+// currency code.
+func (c *Currency) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	return c.UnmarshalText([]byte(s))
+}
+
+// MarshalText implements encoding.TextMarshaler, encoding m as
+// "<canonical amount> <currency>", for example "123.45 USD".
+//
+// MarshalText reports ErrMissingCurrency for invalid Money, since there is no
+// canonical text for money that is not self-describing.
+func (m Money) MarshalText() ([]byte, error) {
+	if !m.IsValid() {
+		return nil, ErrMissingCurrency
+	}
+	return []byte(m.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler, decoding the
+// "<amount> <currency>" form produced by MarshalText. Exactly one ASCII space
+// separates the two fields.
+func (m *Money) UnmarshalText(text []byte) error {
+	s := string(text)
+	i := indexByte(s, ' ')
+	if i < 0 {
+		return fmt.Errorf("%w: missing currency separator", ErrSyntax)
+	}
+	if indexByte(s[i+1:], ' ') >= 0 {
+		return fmt.Errorf("%w: too many fields", ErrSyntax)
+	}
+
+	amount, currencyCode := s[:i], s[i+1:]
+
+	var currency Currency
+	if err := currency.UnmarshalText([]byte(currencyCode)); err != nil {
+		return err
+	}
+
+	v, err := ParseMoney(amount, currency)
+	if err != nil {
+		return err
+	}
+	*m = v
+	return nil
+}
+
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// moneyJSON is Money's structured JSON wire form (ADR-004): an explicit
+// canonical decimal amount alongside an explicit currency, never a bare
+// number and never a raw scaled integer.
+type moneyJSON struct {
+	Amount   string `json:"amount"`
+	Currency string `json:"currency"`
+}
+
+// MarshalJSON implements json.Marshaler, encoding m as
+// {"amount":"123.45","currency":"USD"}.
+//
+// MarshalJSON reports ErrMissingCurrency for invalid Money.
+func (m Money) MarshalJSON() ([]byte, error) {
+	if !m.IsValid() {
+		return nil, ErrMissingCurrency
+	}
+	return json.Marshal(moneyJSON{
+		Amount:   fixed.Format(m.amount),
+		Currency: m.currency.String(),
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler, decoding the structured
+// {"amount":"...","currency":"..."} form.
+func (m *Money) UnmarshalJSON(data []byte) error {
+	var wire moneyJSON
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+
+	var currency Currency
+	if err := currency.UnmarshalText([]byte(wire.Currency)); err != nil {
+		return err
+	}
+
+	v, err := ParseMoney(wire.Amount, currency)
+	if err != nil {
+		return err
+	}
+	*m = v
+	return nil
+}

--- a/num/encoding_fuzz_test.go
+++ b/num/encoding_fuzz_test.go
@@ -1,0 +1,68 @@
+package num
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// FuzzPriceJSONRoundTrip checks that every Price JSON encoding decodes back
+// to the identical value, for the full range Parse accepts.
+func FuzzPriceJSONRoundTrip(f *testing.F) {
+	seeds := []string{"0", "1", "123.45", "0.00000001", "92233720368.54775807"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		want, err := ParsePrice(s)
+		if err != nil {
+			return
+		}
+
+		data, err := json.Marshal(want)
+		if err != nil {
+			t.Fatalf("Marshal(%v) failed: %v", want, err)
+		}
+
+		var got Price
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("Unmarshal(%q) failed: %v", data, err)
+		}
+		if !want.Equal(got) {
+			t.Fatalf("round trip changed value: %v -> %q -> %v", want, data, got)
+		}
+	})
+}
+
+// FuzzMoneyTextRoundTrip checks the "<amount> <currency>" text form round
+// trips for every amount/currency pair ParseMoney accepts.
+func FuzzMoneyTextRoundTrip(f *testing.F) {
+	f.Add("123.45", "USD")
+	f.Add("-15", "EUR")
+	f.Add("0", "BTC")
+	f.Add("0.00000001", "USDT")
+
+	f.Fuzz(func(t *testing.T, amount, currencyCode string) {
+		currency, err := ParseCurrency(currencyCode)
+		if err != nil {
+			return
+		}
+		want, err := ParseMoney(amount, currency)
+		if err != nil {
+			return
+		}
+
+		text, err := want.MarshalText()
+		if err != nil {
+			t.Fatalf("MarshalText(%v) failed: %v", want, err)
+		}
+
+		var got Money
+		if err := got.UnmarshalText(text); err != nil {
+			t.Fatalf("UnmarshalText(%q) failed: %v", text, err)
+		}
+		if !want.Equal(got) {
+			t.Fatalf("round trip changed value: %v -> %q -> %v", want, text, got)
+		}
+	})
+}

--- a/num/encoding_test.go
+++ b/num/encoding_test.go
@@ -1,0 +1,234 @@
+package num
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPriceTextRoundTrip(t *testing.T) {
+	want := MustParsePrice("123.45")
+
+	text, err := want.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "123.45", string(text))
+
+	var got Price
+	require.NoError(t, got.UnmarshalText(text))
+	assert.True(t, want.Equal(got))
+}
+
+func TestPriceTextUnmarshalAcceptsEquivalentForm(t *testing.T) {
+	var got Price
+	require.NoError(t, got.UnmarshalText([]byte("123.45000000")))
+	assert.Equal(t, "123.45", got.String())
+}
+
+func TestPriceTextUnmarshalRejectsNegative(t *testing.T) {
+	var got Price
+	err := got.UnmarshalText([]byte("-1"))
+	require.ErrorIs(t, err, ErrNegative)
+}
+
+func TestPriceJSONRoundTrip(t *testing.T) {
+	want := MustParsePrice("1.08473")
+
+	data, err := json.Marshal(want)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"1.08473"`, string(data))
+
+	var got Price
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.True(t, want.Equal(got))
+}
+
+func TestPriceJSONRejectsNumber(t *testing.T) {
+	var got Price
+	err := json.Unmarshal([]byte(`1.08473`), &got)
+	require.Error(t, err, "Price must not accept a bare JSON number")
+}
+
+func TestQuantityTextAndJSONRoundTrip(t *testing.T) {
+	want := MustParseQuantity("1000.5")
+
+	text, err := want.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "1000.5", string(text))
+
+	var gotText Quantity
+	require.NoError(t, gotText.UnmarshalText(text))
+	assert.True(t, want.Equal(gotText))
+
+	data, err := json.Marshal(want)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"1000.5"`, string(data))
+
+	var gotJSON Quantity
+	require.NoError(t, json.Unmarshal(data, &gotJSON))
+	assert.True(t, want.Equal(gotJSON))
+}
+
+func TestQuantityUnmarshalRejectsNegative(t *testing.T) {
+	var got Quantity
+	err := got.UnmarshalText([]byte("-1"))
+	require.ErrorIs(t, err, ErrNegative)
+}
+
+func TestRateTextAndJSONRoundTrip(t *testing.T) {
+	want := MustParseRate("-0.005")
+
+	text, err := want.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "-0.005", string(text))
+
+	var gotText Rate
+	require.NoError(t, gotText.UnmarshalText(text))
+	assert.True(t, want.Equal(gotText))
+
+	data, err := json.Marshal(want)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"-0.005"`, string(data))
+
+	var gotJSON Rate
+	require.NoError(t, json.Unmarshal(data, &gotJSON))
+	assert.True(t, want.Equal(gotJSON))
+}
+
+func TestCurrencyTextAndJSONRoundTrip(t *testing.T) {
+	want := MustParseCurrency("USD")
+
+	text, err := want.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "USD", string(text))
+
+	var gotText Currency
+	require.NoError(t, gotText.UnmarshalText(text))
+	assert.True(t, want.Equal(gotText))
+
+	data, err := json.Marshal(want)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"USD"`, string(data))
+
+	var gotJSON Currency
+	require.NoError(t, json.Unmarshal(data, &gotJSON))
+	assert.True(t, want.Equal(gotJSON))
+}
+
+func TestCurrencyUnmarshalRejectsMalformed(t *testing.T) {
+	var got Currency
+	err := got.UnmarshalText([]byte("usd"))
+	require.ErrorIs(t, err, ErrInvalidCurrency)
+}
+
+func TestMoneyTextRoundTrip(t *testing.T) {
+	want := usd("123.45")
+
+	text, err := want.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "123.45 USD", string(text))
+
+	var got Money
+	require.NoError(t, got.UnmarshalText(text))
+	assert.True(t, want.Equal(got))
+}
+
+func TestMoneyTextRoundTripNegative(t *testing.T) {
+	want := usd("-15.00")
+
+	text, err := want.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "-15 USD", string(text))
+
+	var got Money
+	require.NoError(t, got.UnmarshalText(text))
+	assert.True(t, want.Equal(got))
+}
+
+func TestMoneyTextMarshalRejectsInvalid(t *testing.T) {
+	var m Money
+	_, err := m.MarshalText()
+	require.ErrorIs(t, err, ErrMissingCurrency)
+}
+
+func TestMoneyTextUnmarshalRejectsMalformed(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{name: "missing currency", in: "123.45"},
+		{name: "too many fields", in: "123.45 USD extra"},
+		{name: "invalid currency", in: "123.45 usd"},
+		{name: "invalid amount", in: "abc USD"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m Money
+			err := m.UnmarshalText([]byte(tt.in))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestMoneyJSONRoundTrip(t *testing.T) {
+	want := usd("123.45")
+
+	data, err := json.Marshal(want)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"amount":"123.45","currency":"USD"}`, string(data))
+
+	var got Money
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.True(t, want.Equal(got))
+}
+
+func TestMoneyJSONRoundTripNegativeAndZero(t *testing.T) {
+	for _, want := range []Money{usd("-15.00"), usd("0")} {
+		data, err := json.Marshal(want)
+		require.NoError(t, err)
+
+		var got Money
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.True(t, want.Equal(got))
+	}
+}
+
+func TestMoneyJSONMarshalRejectsInvalid(t *testing.T) {
+	var m Money
+	_, err := json.Marshal(m)
+	require.Error(t, err)
+}
+
+func TestMoneyJSONUnmarshalRejectsMissingCurrency(t *testing.T) {
+	var m Money
+	err := json.Unmarshal([]byte(`{"amount":"123.45"}`), &m)
+	require.ErrorIs(t, err, ErrInvalidCurrency)
+}
+
+func TestMoneyJSONUnmarshalRejectsCrossFieldGarbage(t *testing.T) {
+	var m Money
+	err := json.Unmarshal([]byte(`{"amount":"abc","currency":"USD"}`), &m)
+	require.ErrorIs(t, err, ErrSyntax)
+}
+
+// TestNoRawScaledIntegersInJSON pins ADR-004's rule that raw scaled integers
+// are never exposed in ordinary public JSON: every field must be textual.
+func TestNoRawScaledIntegersInJSON(t *testing.T) {
+	p := MustParsePrice("1.08473")
+	data, err := json.Marshal(p)
+	require.NoError(t, err)
+	assert.Equal(t, `"1.08473"`, string(data))
+
+	m := usd("123.45")
+	data, err = json.Marshal(m)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	for k, v := range raw {
+		_, isString := v.(string)
+		assert.Truef(t, isString, "field %q is not a string: %v", k, v)
+	}
+}

--- a/num/encoding_test.go
+++ b/num/encoding_test.go
@@ -122,6 +122,20 @@ func TestCurrencyUnmarshalRejectsMalformed(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidCurrency)
 }
 
+// TestCurrencyMarshalRejectsInvalid guards against silently writing an
+// invalid Currency, including the Go zero value, as an empty string. An
+// empty currency code is not a valid wire value: it must fail loudly, not
+// round-trip as if it were legitimate.
+func TestCurrencyMarshalRejectsInvalid(t *testing.T) {
+	var zero Currency
+
+	_, err := zero.MarshalText()
+	require.ErrorIs(t, err, ErrInvalidCurrency)
+
+	_, err = json.Marshal(zero)
+	require.ErrorIs(t, err, ErrInvalidCurrency)
+}
+
 func TestMoneyTextRoundTrip(t *testing.T) {
 	want := usd("123.45")
 

--- a/num/errors.go
+++ b/num/errors.go
@@ -1,0 +1,84 @@
+package num
+
+import (
+	"errors"
+
+	"github.com/rustyeddy/trader/num/internal/fixed"
+)
+
+// Errors returned by num's semantic operations.
+//
+// num/internal/fixed's representation errors (overflow, underflow, divide by
+// zero, syntax, precision, range) are not re-exported by identity; num wraps
+// them so callers can use errors.Is against the sentinels below without ever
+// importing num/internal/fixed, which packages outside num are forbidden to
+// do.
+var (
+	// ErrOverflow reports a result too large for the exact representation.
+	ErrOverflow = errors.New("num: value overflows exact representation")
+
+	// ErrUnderflow reports a result too small (too negative) for the exact
+	// representation.
+	ErrUnderflow = errors.New("num: value underflows exact representation")
+
+	// ErrDivideByZero reports division by an exact zero.
+	ErrDivideByZero = errors.New("num: division by zero")
+
+	// ErrNotRepresentable reports an operation, such as negating the most
+	// negative representable value, whose result has no representation.
+	ErrNotRepresentable = errors.New("num: result is not representable")
+
+	// ErrSyntax reports decimal text that is not a well-formed plain decimal
+	// number.
+	ErrSyntax = errors.New("num: invalid decimal syntax")
+
+	// ErrPrecision reports decimal text carrying more than eight decimal
+	// places of significant precision.
+	ErrPrecision = errors.New("num: excess decimal precision")
+
+	// ErrRange reports decimal text or a scaled value outside the
+	// representable range.
+	ErrRange = errors.New("num: value out of range")
+
+	// ErrNegative reports a negative value where the semantic type requires a
+	// non-negative one, such as Price or Quantity.
+	ErrNegative = errors.New("num: negative value not permitted")
+
+	// ErrCurrencyMismatch reports an operation attempted between Money values
+	// denominated in different currencies.
+	ErrCurrencyMismatch = errors.New("num: currency mismatch")
+
+	// ErrInvalidCurrency reports a currency code that fails structural
+	// validation: it must be 3 to 5 uppercase ASCII letters.
+	ErrInvalidCurrency = errors.New("num: invalid currency code")
+
+	// ErrMissingCurrency reports a Money value or operation missing its
+	// required currency, including the Go zero value of Money.
+	ErrMissingCurrency = errors.New("num: missing currency")
+)
+
+// wrapFixedErr translates a num/internal/fixed representation error into its
+// num sentinel, so num is the only package that ever names the fixed package.
+// Non-representation errors, including nil, pass through unchanged.
+func wrapFixedErr(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, fixed.ErrOverflow):
+		return ErrOverflow
+	case errors.Is(err, fixed.ErrUnderflow):
+		return ErrUnderflow
+	case errors.Is(err, fixed.ErrDivideByZero):
+		return ErrDivideByZero
+	case errors.Is(err, fixed.ErrNotRepresentable):
+		return ErrNotRepresentable
+	case errors.Is(err, fixed.ErrSyntax):
+		return ErrSyntax
+	case errors.Is(err, fixed.ErrPrecision):
+		return ErrPrecision
+	case errors.Is(err, fixed.ErrRange):
+		return ErrRange
+	default:
+		return err
+	}
+}

--- a/num/internal/fixed/checked.go
+++ b/num/internal/fixed/checked.go
@@ -1,0 +1,91 @@
+package fixed
+
+// Checked int64 arithmetic on raw scaled values.
+//
+// Every operation here reports failure rather than wrapping.  ADR-004 forbids
+// authoritative arithmetic from silently wrapping, saturating, clamping,
+// discarding overflow, or escaping range constraints through float64.
+//
+// Addition and subtraction operate directly on raw scaled values because both
+// operands share the common scale: (a*S) + (b*S) == (a+b)*S.  Multiplication
+// and division do not have that property and live in wide.go.
+
+// Add returns a+b, or an error if the true sum falls outside int64.
+//
+// The bound is rearranged rather than computed, so no intermediate ever wraps:
+// a+b exceeds MaxRaw exactly when a > MaxRaw-b, and MaxRaw-b is itself
+// representable whenever b is positive.
+func Add(a, b int64) (int64, error) {
+	if b > 0 && a > MaxRaw-b {
+		return 0, ErrOverflow
+	}
+	if b < 0 && a < MinRaw-b {
+		return 0, ErrUnderflow
+	}
+	return a + b, nil
+}
+
+// Sub returns a-b, or an error if the true difference falls outside int64.
+//
+// Sub is implemented directly rather than as Add(a, -b) because b may be
+// MinRaw, which cannot be negated.
+func Sub(a, b int64) (int64, error) {
+	if b < 0 && a > MaxRaw+b {
+		return 0, ErrOverflow
+	}
+	if b > 0 && a < MinRaw+b {
+		return 0, ErrUnderflow
+	}
+	return a - b, nil
+}
+
+// Neg returns -a.
+//
+// MinRaw is rejected: its positive counterpart is not representable in signed
+// int64, so negating it would wrap back to itself.
+func Neg(a int64) (int64, error) {
+	if a == MinRaw {
+		return 0, ErrNotRepresentable
+	}
+	return -a, nil
+}
+
+// Abs returns the absolute value of a.
+//
+// MinRaw is rejected for the same reason as Neg.
+func Abs(a int64) (int64, error) {
+	if a == MinRaw {
+		return 0, ErrNotRepresentable
+	}
+	if a < 0 {
+		return -a, nil
+	}
+	return a, nil
+}
+
+// Sign reports -1, 0, or +1 according to the sign of a.
+func Sign(a int64) int {
+	switch {
+	case a < 0:
+		return -1
+	case a > 0:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// Cmp compares two raw scaled values, returning -1, 0, or +1.
+//
+// Both operands share the common scale, so raw comparison is exact and needs
+// no widening.
+func Cmp(a, b int64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/num/internal/fixed/checked_test.go
+++ b/num/internal/fixed/checked_test.go
@@ -1,0 +1,167 @@
+package fixed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdd(t *testing.T) {
+	tests := []struct {
+		name    string
+		a, b    int64
+		want    int64
+		wantErr error
+	}{
+		{name: "zero and zero", a: 0, b: 0, want: 0},
+		{name: "positive and positive", a: 3 * Scale, b: 4 * Scale, want: 7 * Scale},
+		{name: "positive and negative", a: 3 * Scale, b: -4 * Scale, want: -1 * Scale},
+		{name: "negative and negative", a: -3 * Scale, b: -4 * Scale, want: -7 * Scale},
+		{name: "quantum granularity", a: 1, b: 2, want: 3},
+		{name: "cancels to zero", a: MinRaw, b: MaxRaw, want: -1},
+		{name: "reaches maximum exactly", a: MaxRaw - 1, b: 1, want: MaxRaw},
+		{name: "reaches minimum exactly", a: MinRaw + 1, b: -1, want: MinRaw},
+		{name: "overflows past maximum", a: MaxRaw, b: 1, wantErr: ErrOverflow},
+		{name: "overflows from two large positives", a: MaxRaw, b: MaxRaw, wantErr: ErrOverflow},
+		{name: "underflows past minimum", a: MinRaw, b: -1, wantErr: ErrUnderflow},
+		{name: "underflows from two large negatives", a: MinRaw, b: MinRaw, wantErr: ErrUnderflow},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Add(tt.a, tt.b)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Zero(t, got, "failed operations must not return a partial result")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSub(t *testing.T) {
+	tests := []struct {
+		name    string
+		a, b    int64
+		want    int64
+		wantErr error
+	}{
+		{name: "zero and zero", a: 0, b: 0, want: 0},
+		{name: "positive difference", a: 7 * Scale, b: 4 * Scale, want: 3 * Scale},
+		{name: "negative difference", a: 4 * Scale, b: 7 * Scale, want: -3 * Scale},
+		{name: "subtracting a negative", a: 4 * Scale, b: -3 * Scale, want: 7 * Scale},
+		{name: "subtracting the minimum from zero overflows", a: 0, b: MinRaw, wantErr: ErrOverflow},
+		{name: "reaches maximum exactly", a: 0, b: -MaxRaw, want: MaxRaw},
+		{name: "reaches minimum exactly", a: -1, b: MaxRaw, want: MinRaw},
+		{name: "overflows past maximum", a: MaxRaw, b: -1, wantErr: ErrOverflow},
+		{name: "underflows past minimum", a: MinRaw, b: 1, wantErr: ErrUnderflow},
+		{name: "underflows from opposite extremes", a: MinRaw, b: MaxRaw, wantErr: ErrUnderflow},
+		{name: "extremes cancel", a: MinRaw, b: MinRaw, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Sub(tt.a, tt.b)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Zero(t, got, "failed operations must not return a partial result")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestAddSubNeverWrap checks the property that distinguishes checked
+// arithmetic from Go's native operators: every accepted result must be the
+// true mathematical one, and every rejected pair must genuinely be out of
+// range.  Native wrapping would satisfy neither.
+func TestAddSubNeverWrap(t *testing.T) {
+	operands := []int64{
+		MinRaw, MinRaw + 1, -Scale, -1, 0, 1, Scale, MaxRaw - 1, MaxRaw,
+	}
+
+	for _, a := range operands {
+		for _, b := range operands {
+			if sum, err := Add(a, b); err == nil {
+				assert.Equal(t, a, sum-b, "Add(%d,%d) is not the true sum", a, b)
+			}
+			if diff, err := Sub(a, b); err == nil {
+				assert.Equal(t, a, diff+b, "Sub(%d,%d) is not the true difference", a, b)
+			}
+		}
+	}
+}
+
+func TestNeg(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      int64
+		want    int64
+		wantErr error
+	}{
+		{name: "zero stays zero", in: 0, want: 0},
+		{name: "positive becomes negative", in: 5 * Scale, want: -5 * Scale},
+		{name: "negative becomes positive", in: -5 * Scale, want: 5 * Scale},
+		{name: "maximum is negatable", in: MaxRaw, want: -MaxRaw},
+		{name: "minimum is not representable", in: MinRaw, wantErr: ErrNotRepresentable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Neg(tt.in)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAbs(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      int64
+		want    int64
+		wantErr error
+	}{
+		{name: "zero stays zero", in: 0, want: 0},
+		{name: "positive is unchanged", in: 5 * Scale, want: 5 * Scale},
+		{name: "negative is inverted", in: -5 * Scale, want: 5 * Scale},
+		{name: "maximum is unchanged", in: MaxRaw, want: MaxRaw},
+		{name: "minimum plus one is representable", in: MinRaw + 1, want: MaxRaw},
+		{name: "minimum is not representable", in: MinRaw, wantErr: ErrNotRepresentable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Abs(tt.in)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSignAndCmp(t *testing.T) {
+	assert.Equal(t, -1, Sign(MinRaw))
+	assert.Equal(t, -1, Sign(-1))
+	assert.Equal(t, 0, Sign(0))
+	assert.Equal(t, 1, Sign(1))
+	assert.Equal(t, 1, Sign(MaxRaw))
+
+	assert.Equal(t, -1, Cmp(MinRaw, MaxRaw))
+	assert.Equal(t, 0, Cmp(0, 0))
+	assert.Equal(t, 0, Cmp(MinRaw, MinRaw))
+	assert.Equal(t, 1, Cmp(MaxRaw, MinRaw))
+	assert.Equal(t, 1, Cmp(1, 0))
+}

--- a/num/internal/fixed/decimal.go
+++ b/num/internal/fixed/decimal.go
@@ -1,0 +1,188 @@
+package fixed
+
+import "math"
+
+// Exact decimal text conversion.
+//
+// Parsing and formatting both operate directly on the scaled integer
+// representation.  Neither routes through float64, which cannot represent most
+// decimal values exactly and would silently reintroduce the approximation the
+// whole package exists to avoid.
+
+// Parse converts plain decimal text to a raw scaled value.
+//
+// Accepted input is an optional sign, one or more integer digits, and
+// optionally a decimal point followed by one or more fraction digits:
+//
+//	123        -123        +0.5        0.00000001
+//
+// Parse rejects, rather than repairing or rounding:
+//
+//   - empty input, a bare sign, or a bare decimal point;
+//   - a missing integer part (".5") or a trailing point ("5.");
+//   - more than one sign or more than one decimal point;
+//   - exponent notation, which an adapter must expand first;
+//   - grouping separators, currency symbols, and locale-dependent forms;
+//   - leading, trailing, or embedded whitespace;
+//   - significant precision beyond Places decimal places;
+//   - values outside the representable scaled range.
+//
+// Trailing zeros beyond Places are accepted because dropping them is exact and
+// requires no rounding; ADR-004 allows readers to accept equivalent exact
+// forms.  A non-zero digit beyond Places reports ErrPrecision, since honouring
+// it would require discarding information.
+//
+// The full signed range is parsable, including the most negative value.  The
+// magnitude is accumulated unsigned and the sign applied only at the end, so
+// there is no one-value gap where an unrepresentable positive intermediate
+// would be constructed on the way to a representable negative result.
+func Parse(s string) (int64, error) {
+	if s == "" {
+		return 0, ErrSyntax
+	}
+
+	i := 0
+	negative := false
+	switch s[0] {
+	case '-':
+		negative = true
+		i++
+	case '+':
+		i++
+	}
+
+	// Integer part: at least one digit, accumulated as a magnitude.
+	start := i
+	var mag uint64
+	for ; i < len(s) && isDigit(s[i]); i++ {
+		d := uint64(s[i] - '0')
+		if mag > (math.MaxUint64-d)/10 {
+			return 0, ErrRange
+		}
+		mag = mag*10 + d
+	}
+	if i == start {
+		return 0, ErrSyntax
+	}
+
+	// Apply the scale to the integer part before adding the fraction, so the
+	// two halves are combined in one exactly-scaled magnitude.
+	if mag > math.MaxUint64/uint64(Scale) {
+		return 0, ErrRange
+	}
+	mag *= uint64(Scale)
+
+	if i < len(s) {
+		if s[i] != '.' {
+			return 0, ErrSyntax
+		}
+		i++
+
+		start = i
+		var frac uint64
+		places := 0
+		for ; i < len(s) && isDigit(s[i]); i++ {
+			d := uint64(s[i] - '0')
+			switch {
+			case places < Places:
+				frac = frac*10 + d
+				places++
+			case d != 0:
+				return 0, ErrPrecision
+			}
+		}
+		if i == start {
+			return 0, ErrSyntax
+		}
+		if i != len(s) {
+			return 0, ErrSyntax
+		}
+
+		// Left-align the fraction to the common scale: "0.5" contributes one
+		// place and must become 50000000, not 5.
+		for ; places < Places; places++ {
+			frac *= 10
+		}
+
+		if mag > math.MaxUint64-frac {
+			return 0, ErrRange
+		}
+		mag += frac
+	}
+
+	raw, err := fromMagnitude(mag, negative)
+	if err != nil {
+		return 0, ErrRange
+	}
+	return raw, nil
+}
+
+// Format renders a raw scaled value as canonical plain decimal text.
+//
+// Canonical output uses no scientific notation, no grouping separators, no
+// unnecessary trailing zeros, and no trailing decimal point.  Negative zero is
+// not representable in this integer form, so zero always renders as "0".
+// Format and Parse round-trip to the identical raw value.
+//
+//	12345000000 -> "123.45"
+//	  100000000 -> "1"
+//	          1 -> "0.00000001"
+//	          0 -> "0"
+func Format(raw int64) string {
+	if raw == 0 {
+		return "0"
+	}
+
+	mag := magnitude(raw)
+	whole := mag / uint64(Scale)
+	frac := mag % uint64(Scale)
+
+	// Longest possible output: sign, 11 integer digits, point, 8 fraction
+	// digits.
+	buf := make([]byte, 0, 21)
+	if raw < 0 {
+		buf = append(buf, '-')
+	}
+	buf = appendUint(buf, whole)
+
+	if frac == 0 {
+		return string(buf)
+	}
+
+	// Render the fraction zero-padded to the full scale, then trim the
+	// trailing zeros that padding and the scale itself introduced.
+	var digits [Places]byte
+	for i := Places - 1; i >= 0; i-- {
+		digits[i] = byte('0' + frac%10)
+		frac /= 10
+	}
+	end := Places
+	for end > 1 && digits[end-1] == '0' {
+		end--
+	}
+
+	buf = append(buf, '.')
+	buf = append(buf, digits[:end]...)
+	return string(buf)
+}
+
+// appendUint appends the decimal digits of v to buf without using strconv, so
+// that formatting stays a pure integer operation in one place.
+func appendUint(buf []byte, v uint64) []byte {
+	if v == 0 {
+		return append(buf, '0')
+	}
+
+	var digits [20]byte
+	i := len(digits)
+	for v > 0 {
+		i--
+		digits[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return append(buf, digits[i:]...)
+}
+
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}

--- a/num/internal/fixed/decimal_test.go
+++ b/num/internal/fixed/decimal_test.go
@@ -1,0 +1,208 @@
+package fixed
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseValid(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int64
+	}{
+		{name: "zero", in: "0", want: 0},
+		{name: "signed zero is normalized", in: "-0", want: 0},
+		{name: "explicitly positive zero", in: "+0", want: 0},
+		{name: "zero with a zero fraction", in: "0.00000000", want: 0},
+		{name: "negative zero fraction is normalized", in: "-0.00000000", want: 0},
+
+		{name: "whole number", in: "1", want: Scale},
+		{name: "negative whole number", in: "-1", want: -Scale},
+		{name: "explicit plus sign", in: "+1", want: Scale},
+		{name: "leading zeros are accepted", in: "007", want: 7 * Scale},
+
+		{name: "one decimal place", in: "0.5", want: 50_000_000},
+		{name: "two decimal places", in: "123.45", want: 12_345_000_000},
+		{name: "five decimal places", in: "1.08473", want: 108_473_000},
+		{name: "all eight decimal places", in: "1.12345678", want: 112_345_678},
+		{name: "one quantum", in: "0.00000001", want: 1},
+		{name: "one negative quantum", in: "-0.00000001", want: -1},
+		{name: "smallest fraction digit in each place", in: "0.00000009", want: 9},
+
+		{name: "trailing zeros are accepted", in: "1.00000000", want: Scale},
+		{name: "trailing zeros within the scale", in: "123.45000000", want: 12_345_000_000},
+		// Digits beyond the scale are accepted only when dropping them is
+		// exact; no rounding is involved.
+		{name: "zeros beyond the scale are exact", in: "1.000000000000", want: Scale},
+		{name: "many zeros beyond the scale", in: "0.5000000000000000000", want: 50_000_000},
+
+		{name: "maximum representable value", in: "92233720368.54775807", want: MaxRaw},
+		{name: "minimum representable value", in: "-92233720368.54775808", want: MinRaw},
+		{name: "one above the minimum", in: "-92233720368.54775807", want: MinRaw + 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestParseFullNegativeRange guards the one-value gap that appears when an
+// implementation parses the magnitude into a signed integer and only then
+// applies the sign: math.MinInt64's positive counterpart is not representable,
+// so that approach rejects the most negative value it is required to accept.
+func TestParseFullNegativeRange(t *testing.T) {
+	got, err := Parse("-92233720368.54775808")
+	require.NoError(t, err)
+	assert.Equal(t, int64(math.MinInt64), got)
+
+	// Its positive counterpart is genuinely out of range.
+	_, err = Parse("92233720368.54775808")
+	require.ErrorIs(t, err, ErrRange)
+}
+
+func TestParseInvalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr error
+	}{
+		{name: "empty", in: "", wantErr: ErrSyntax},
+		{name: "bare minus", in: "-", wantErr: ErrSyntax},
+		{name: "bare plus", in: "+", wantErr: ErrSyntax},
+		{name: "bare point", in: ".", wantErr: ErrSyntax},
+		{name: "signed bare point", in: "-.", wantErr: ErrSyntax},
+		{name: "missing integer part", in: ".5", wantErr: ErrSyntax},
+		{name: "trailing decimal point", in: "5.", wantErr: ErrSyntax},
+		{name: "double decimal point", in: "1.2.3", wantErr: ErrSyntax},
+		{name: "double sign", in: "--1", wantErr: ErrSyntax},
+		{name: "trailing sign", in: "1-", wantErr: ErrSyntax},
+		{name: "sign after point", in: "1.-2", wantErr: ErrSyntax},
+
+		{name: "leading whitespace", in: " 1", wantErr: ErrSyntax},
+		{name: "trailing whitespace", in: "1 ", wantErr: ErrSyntax},
+		{name: "embedded whitespace", in: "1 000", wantErr: ErrSyntax},
+		{name: "tab", in: "\t1", wantErr: ErrSyntax},
+		{name: "newline", in: "1\n", wantErr: ErrSyntax},
+
+		{name: "comma grouping", in: "1,000.00", wantErr: ErrSyntax},
+		{name: "underscore grouping", in: "1_000", wantErr: ErrSyntax},
+		{name: "apostrophe grouping", in: "1'000", wantErr: ErrSyntax},
+		{name: "currency symbol", in: "$1.00", wantErr: ErrSyntax},
+		{name: "trailing currency code", in: "1.00USD", wantErr: ErrSyntax},
+		{name: "percent suffix", in: "5%", wantErr: ErrSyntax},
+
+		{name: "lowercase exponent", in: "1e5", wantErr: ErrSyntax},
+		{name: "uppercase exponent", in: "1E5", wantErr: ErrSyntax},
+		{name: "negative exponent", in: "1.5e-3", wantErr: ErrSyntax},
+
+		{name: "hexadecimal", in: "0x10", wantErr: ErrSyntax},
+		{name: "letters", in: "abc", wantErr: ErrSyntax},
+		{name: "not a number", in: "NaN", wantErr: ErrSyntax},
+		{name: "infinity", in: "Inf", wantErr: ErrSyntax},
+		{name: "non-ascii digits", in: "١٢٣", wantErr: ErrSyntax},
+
+		{name: "nine significant decimal places", in: "1.123456789", wantErr: ErrPrecision},
+		{name: "significant digit far beyond the scale", in: "0.0000000000000001", wantErr: ErrPrecision},
+		{name: "trailing zeros then a significant digit", in: "1.000000000001", wantErr: ErrPrecision},
+
+		{name: "one quantum above the maximum", in: "92233720368.54775808", wantErr: ErrRange},
+		{name: "one quantum below the minimum", in: "-92233720368.54775809", wantErr: ErrRange},
+		{name: "far above the maximum", in: "99999999999", wantErr: ErrRange},
+		{name: "absurdly large", in: "999999999999999999999999999999", wantErr: ErrRange},
+		{name: "absurdly small", in: "-999999999999999999999999999999", wantErr: ErrRange},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.in)
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Zero(t, got, "rejected input must not return a partial value")
+		})
+	}
+}
+
+func TestFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int64
+		want string
+	}{
+		{name: "zero", in: 0, want: "0"},
+		{name: "whole number", in: Scale, want: "1"},
+		{name: "negative whole number", in: -Scale, want: "-1"},
+		{name: "trailing zeros are removed", in: 12_345_000_000, want: "123.45"},
+		{name: "all eight places are kept when significant", in: 112_345_678, want: "1.12345678"},
+		{name: "one quantum", in: 1, want: "0.00000001"},
+		{name: "one negative quantum", in: -1, want: "-0.00000001"},
+		{name: "leading fraction zeros are kept", in: 50_000_000, want: "0.5"},
+		{name: "interior zeros are kept", in: 100_000_001, want: "1.00000001"},
+		{name: "five decimal places", in: 108_473_000, want: "1.08473"},
+		{name: "maximum", in: MaxRaw, want: "92233720368.54775807"},
+		{name: "minimum", in: MinRaw, want: "-92233720368.54775808"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Format(tt.in))
+		})
+	}
+}
+
+// TestFormatIsCanonical states the canonical-output rules from ADR-004 as
+// assertions over the whole representable spread, so a future change to
+// Format cannot quietly reintroduce scientific notation or padding.
+func TestFormatIsCanonical(t *testing.T) {
+	values := []int64{
+		MinRaw, MinRaw + 1, -Scale, -1, 0, 1, Scale, 12_345_000_000, MaxRaw,
+	}
+
+	for _, v := range values {
+		out := Format(v)
+
+		assert.NotContains(t, out, "e", "no scientific notation: %q", out)
+		assert.NotContains(t, out, "E", "no scientific notation: %q", out)
+		assert.NotContains(t, out, ",", "no grouping separators: %q", out)
+		assert.NotContains(t, out, " ", "no whitespace: %q", out)
+		assert.NotEqual(t, byte('.'), out[len(out)-1], "no trailing decimal point: %q", out)
+		assert.NotEqual(t, "-0", out, "negative zero is normalized: %q", out)
+
+		if i := indexByte(out, '.'); i >= 0 {
+			assert.NotEqual(t, byte('0'), out[len(out)-1],
+				"no unnecessary trailing zeros: %q", out)
+			assert.LessOrEqual(t, len(out)-i-1, Places,
+				"never more than the scale's places: %q", out)
+		}
+	}
+}
+
+func TestParseFormatRoundTrip(t *testing.T) {
+	values := []int64{
+		MinRaw, MinRaw + 1, -12_345_000_000, -Scale, -1, 0, 1,
+		9, 50_000_000, Scale, 108_473_000, 112_345_678, 12_345_000_000,
+		MaxRaw - 1, MaxRaw,
+	}
+
+	for _, v := range values {
+		text := Format(v)
+		got, err := Parse(text)
+		require.NoErrorf(t, err, "Format produced text Parse rejects: %q", text)
+		assert.Equalf(t, v, got, "round trip changed the value through %q", text)
+	}
+}
+
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/num/internal/fixed/errors.go
+++ b/num/internal/fixed/errors.go
@@ -1,0 +1,40 @@
+package fixed
+
+import "errors"
+
+// Representation-level errors.
+//
+// These describe failures of the exact scaled-integer representation itself.
+// The num package wraps or re-exports them where a caller needs to distinguish
+// causes with errors.Is; it does not expose this package's identity.
+var (
+	// ErrOverflow reports a result too large for the scaled representation.
+	ErrOverflow = errors.New("value overflows exact representation")
+
+	// ErrUnderflow reports a result too small (too negative) for the scaled
+	// representation.
+	ErrUnderflow = errors.New("value underflows exact representation")
+
+	// ErrDivideByZero reports division by an exact zero.
+	ErrDivideByZero = errors.New("division by zero")
+
+	// ErrNotRepresentable reports an operation whose result cannot be
+	// represented even though it is within range.  Negation and absolute value
+	// of MinRaw are the canonical cases: the positive counterpart of MinInt64
+	// does not exist in signed int64.
+	ErrNotRepresentable = errors.New("result is not representable")
+
+	// ErrSyntax reports decimal text that is not a well-formed plain decimal
+	// number: empty input, stray signs, missing digits, embedded whitespace,
+	// grouping separators, exponent notation, or any other malformed form.
+	ErrSyntax = errors.New("invalid decimal syntax")
+
+	// ErrPrecision reports decimal text carrying more than Places decimal
+	// places.  Exact parsing never silently rounds; excess precision is an
+	// error the caller must resolve.
+	ErrPrecision = errors.New("excess decimal precision")
+
+	// ErrRange reports decimal text whose value lies outside the representable
+	// scaled range.
+	ErrRange = errors.New("value out of range")
+)

--- a/num/internal/fixed/errors.go
+++ b/num/internal/fixed/errors.go
@@ -37,4 +37,10 @@ var (
 	// ErrRange reports decimal text whose value lies outside the representable
 	// scaled range.
 	ErrRange = errors.New("value out of range")
+
+	// ErrInvalidRounding reports a Rounding value that is none of the four
+	// named policies.  An unrecognized mode is rejected outright rather than
+	// silently resolved to a default: ADR-004 forbids exactly this kind of
+	// hidden policy fallback.
+	ErrInvalidRounding = errors.New("invalid rounding mode")
 )

--- a/num/internal/fixed/fuzz_test.go
+++ b/num/internal/fixed/fuzz_test.go
@@ -1,0 +1,131 @@
+package fixed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzFormatParse exercises the round trip in the direction that must always
+// succeed: every representable raw value has canonical text, and that text
+// must parse back to the identical raw value.  A failure here means an
+// authoritative value could change merely by being written and read again.
+func FuzzFormatParse(f *testing.F) {
+	seeds := []int64{
+		MinRaw, MinRaw + 1, -12_345_000_000, -Scale, -9, -1, 0, 1, 9,
+		50_000_000, Scale, 108_473_000, 112_345_678, MaxRaw - 1, MaxRaw,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, raw int64) {
+		text := Format(raw)
+
+		got, err := Parse(text)
+		require.NoErrorf(t, err, "Format produced text Parse rejects: %q", text)
+		assert.Equalf(t, raw, got, "round trip changed the value through %q", text)
+	})
+}
+
+// FuzzParseFormat exercises the opposite direction, where most inputs are
+// expected to be rejected.  The invariant is that acceptance is stable: any
+// text Parse accepts must format to canonical text that parses to the same
+// value, so no accepted input can smuggle in a value the formatter cannot
+// reproduce.  Parse must also never panic, whatever bytes arrive.
+func FuzzParseFormat(f *testing.F) {
+	seeds := []string{
+		"", "0", "-0", "+0", "1", "-1", "0.5", "123.45", "1.08473",
+		"0.00000001", "1.00000000", "007", "1.000000000000",
+		"92233720368.54775807", "-92233720368.54775808",
+		".", "-", "+", ".5", "5.", "1e5", "1,000", " 1", "abc", "NaN",
+		"1.123456789", "99999999999999999999",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, text string) {
+		raw, err := Parse(text)
+		if err != nil {
+			assert.Zero(t, raw, "rejected input must not return a partial value")
+			return
+		}
+
+		canonical := Format(raw)
+		again, err := Parse(canonical)
+		require.NoErrorf(t, err, "canonical form of %q was rejected: %q", text, canonical)
+		assert.Equalf(t, raw, again, "canonical form of %q lost value: %q", text, canonical)
+	})
+}
+
+// FuzzAddSub checks that checked addition and subtraction either return the
+// true mathematical result or report an error.  Silent wrapping, the failure
+// mode ADR-004 forbids, would show up here as an accepted but incorrect
+// result.
+func FuzzAddSub(f *testing.F) {
+	seeds := [][2]int64{
+		{0, 0}, {1, -1}, {MaxRaw, 1}, {MinRaw, -1}, {MaxRaw, MaxRaw},
+		{MinRaw, MinRaw}, {MinRaw, MaxRaw}, {Scale, Scale},
+	}
+	for _, s := range seeds {
+		f.Add(s[0], s[1])
+	}
+
+	f.Fuzz(func(t *testing.T, a, b int64) {
+		if sum, err := Add(a, b); err == nil {
+			// Recovering a by undoing b cannot itself overflow, because sum is
+			// representable and b was one of its addends.
+			assert.Equalf(t, a, sum-b, "Add(%d,%d) returned a wrapped result", a, b)
+		}
+
+		if diff, err := Sub(a, b); err == nil {
+			assert.Equalf(t, a, diff+b, "Sub(%d,%d) returned a wrapped result", a, b)
+		}
+	})
+}
+
+// FuzzMulDivScaled checks the widened path for the same wrapping property, and
+// for the exactness relationship between multiplication and division: dividing
+// a product by one of its operands must return the other, whenever the inputs
+// make that exact.
+func FuzzMulDivScaled(f *testing.F) {
+	seeds := [][2]int64{
+		{0, 0}, {Scale, Scale}, {108_473_000, 105_000_000}, {MaxRaw, Scale},
+		{MinRaw, Scale}, {MaxRaw, MaxRaw}, {1, 250_000_000}, {-1, 150_000_000},
+	}
+	for _, s := range seeds {
+		f.Add(s[0], s[1])
+	}
+
+	f.Fuzz(func(t *testing.T, a, b int64) {
+		product, err := MulScaled(a, b, RoundHalfEven)
+		if err != nil {
+			assert.Zero(t, product, "failed multiplication must not return a partial result")
+			return
+		}
+
+		// Scaling by exactly one is the identity, in both directions.
+		if b == Scale {
+			assert.Equalf(t, a, product, "MulScaled(%d, 1) is not the identity", a)
+		}
+
+		// Zero propagates rather than producing a spurious remainder.
+		if a == 0 || b == 0 {
+			assert.Zerof(t, product, "MulScaled(%d,%d) should be zero", a, b)
+		}
+
+		quotient, err := DivScaled(product, b, RoundHalfEven)
+		if err != nil || b == 0 {
+			return
+		}
+
+		// Recovering a exactly requires the product to have been exact, which
+		// holds when multiplying back reproduces it.
+		if check, err := MulScaled(quotient, b, RoundHalfEven); err == nil {
+			assert.Equalf(t, product, check,
+				"round trip through DivScaled lost the product of %d and %d", a, b)
+		}
+	})
+}

--- a/num/internal/fixed/rounding.go
+++ b/num/internal/fixed/rounding.go
@@ -42,6 +42,19 @@ func (r Rounding) String() string {
 	}
 }
 
+// valid reports whether r is one of the four named policies. It is checked at
+// every entry point that accepts a caller-supplied Rounding (MulScaled,
+// DivScaled) so that an unrecognized value is rejected outright rather than
+// silently resolved to a default — see roundMagnitude for why that matters.
+func (r Rounding) valid() bool {
+	switch r {
+	case RoundHalfEven, RoundTowardZero, RoundDown, RoundUp:
+		return true
+	default:
+		return false
+	}
+}
+
 // roundMagnitude reports whether the magnitude of a quotient should be
 // incremented, given the truncated magnitude quotient, the magnitude
 // remainder, the divisor magnitude, and the sign of the true result.
@@ -51,6 +64,11 @@ func (r Rounding) String() string {
 // remainder is strictly less than the divisor, and the divisor is at most
 // 2^63, so doubling the remainder to compare against the divisor cannot
 // overflow uint64.
+//
+// mode is assumed valid: every caller reaches this function through
+// MulScaled or DivScaled, which reject an unrecognized Rounding before
+// getting here.  The switch below is therefore exhaustive over Rounding's
+// four named values, not a silent fallback for a fifth one.
 func roundMagnitude(quo, rem, div uint64, negative bool, mode Rounding) bool {
 	if rem == 0 {
 		return false
@@ -66,7 +84,7 @@ func roundMagnitude(quo, rem, div uint64, negative bool, mode Rounding) bool {
 	case RoundUp:
 		return !negative
 
-	default: // RoundHalfEven
+	case RoundHalfEven:
 		twice := rem * 2
 		switch {
 		case twice > div:
@@ -77,5 +95,11 @@ func roundMagnitude(quo, rem, div uint64, negative bool, mode Rounding) bool {
 			// Exact midpoint: move to the even neighbour.
 			return quo%2 == 1
 		}
+
+	default:
+		// Unreachable: MulScaled and DivScaled validate mode before calling
+		// mulDiv. A panic here would indicate that guarantee was bypassed,
+		// not a value a caller could trigger through the public API.
+		panic("fixed: roundMagnitude called with unvalidated Rounding")
 	}
 }

--- a/num/internal/fixed/rounding.go
+++ b/num/internal/fixed/rounding.go
@@ -1,0 +1,81 @@
+package fixed
+
+// Rounding selects how a result that is not exactly representable at the
+// common scale is resolved.
+//
+// ADR-004 names four supported policies and makes nearest/ties-to-even the
+// default.  All four are implemented here; the num package currently exposes
+// only the default, because no domain operation has yet required a
+// caller-selected policy.  Implicit integer truncation is not one of these
+// policies: [RoundTowardZero] must be chosen deliberately.
+type Rounding uint8
+
+const (
+	// RoundHalfEven rounds to the nearest representable value, resolving exact
+	// midpoints toward the even neighbour.  This is the ADR-004 default.
+	RoundHalfEven Rounding = iota
+
+	// RoundTowardZero discards the remainder, moving toward zero for both
+	// signs.
+	RoundTowardZero
+
+	// RoundDown rounds toward negative infinity.
+	RoundDown
+
+	// RoundUp rounds toward positive infinity.
+	RoundUp
+)
+
+// String returns the policy name, for error messages and test output.
+func (r Rounding) String() string {
+	switch r {
+	case RoundHalfEven:
+		return "half-even"
+	case RoundTowardZero:
+		return "toward-zero"
+	case RoundDown:
+		return "down"
+	case RoundUp:
+		return "up"
+	default:
+		return "unknown"
+	}
+}
+
+// roundMagnitude reports whether the magnitude of a quotient should be
+// incremented, given the truncated magnitude quotient, the magnitude
+// remainder, the divisor magnitude, and the sign of the true result.
+//
+// All three numeric inputs are magnitudes, so the caller's sign handling stays
+// in one place instead of being threaded through every comparison.  The
+// remainder is strictly less than the divisor, and the divisor is at most
+// 2^63, so doubling the remainder to compare against the divisor cannot
+// overflow uint64.
+func roundMagnitude(quo, rem, div uint64, negative bool, mode Rounding) bool {
+	if rem == 0 {
+		return false
+	}
+
+	switch mode {
+	case RoundTowardZero:
+		return false
+
+	case RoundDown:
+		return negative
+
+	case RoundUp:
+		return !negative
+
+	default: // RoundHalfEven
+		twice := rem * 2
+		switch {
+		case twice > div:
+			return true
+		case twice < div:
+			return false
+		default:
+			// Exact midpoint: move to the even neighbour.
+			return quo%2 == 1
+		}
+	}
+}

--- a/num/internal/fixed/scale.go
+++ b/num/internal/fixed/scale.go
@@ -1,0 +1,47 @@
+// Package fixed implements the exact scaled-integer representation mechanics
+// used by the num package.
+//
+// This package is deliberately unexported outside num.  It knows nothing about
+// prices, quantities, money, or currencies; it knows only how to represent an
+// exact decimal value as a signed int64 scaled by [Scale], how to do checked
+// arithmetic on such values, and how to convert between that representation
+// and canonical decimal text.
+//
+// The division of responsibility is:
+//
+//	code outside num          expresses financial intent
+//	code inside num           attaches semantic meaning to exact values
+//	code inside num/internal/fixed  implements exact representation mechanics
+//
+// Binary floating point is prohibited here.  Nothing in this package may
+// declare a float32 or float64, and no arithmetic may route through one.  A
+// test enforces this by parsing the package source.
+//
+// See docs/arch/adr-004-exact-numeric-representation.org.
+package fixed
+
+import "math"
+
+// Places is the number of decimal places retained by the common scale.
+const Places = 8
+
+// Scale is the common scaling factor applied to every authoritative Trader
+// numeric value.  A decimal value v is represented as the integer v*Scale.
+//
+// ADR-004 fixes this at 1e8.  The scale is an internal representation detail:
+// it is not an instrument tick size, a display precision, a wire-format scale,
+// or a provider quotation convention.
+const Scale int64 = 100_000_000
+
+// Representable bounds of the scaled representation, expressed as decimal
+// values rather than raw integers:
+//
+//	minimum: -92,233,720,368.54775808
+//	maximum:  92,233,720,368.54775807
+const (
+	// MinRaw is the smallest representable raw scaled value.
+	MinRaw int64 = math.MinInt64
+
+	// MaxRaw is the largest representable raw scaled value.
+	MaxRaw int64 = math.MaxInt64
+)

--- a/num/internal/fixed/wide.go
+++ b/num/internal/fixed/wide.go
@@ -1,0 +1,124 @@
+package fixed
+
+import "math/bits"
+
+// Widened multiplication and division of scaled values.
+//
+// Two operands at the common scale cannot be multiplied directly: the raw
+// product (a*S)*(b*S) carries the scale twice and, for realistic market
+// values, exceeds int64 long before the true result does.  ADR-004 therefore
+// requires a widened signed intermediate followed by scale restoration:
+//
+//	result = round((a * b) / S)
+//
+// Division is the same primitive with the operands rearranged:
+//
+//	result = round((a * S) / b)
+//
+// Both reduce to one exact 128-bit multiply-then-divide.  There is no float64
+// escape path: a product that cannot be restored to the common scale is an
+// error, never an approximation.
+
+// MulScaled returns the product of two raw scaled values, restored to the
+// common scale and rounded by mode.
+func MulScaled(a, b int64, mode Rounding) (int64, error) {
+	return mulDiv(a, b, Scale, mode)
+}
+
+// DivScaled returns the quotient of two raw scaled values, restored to the
+// common scale and rounded by mode.
+//
+// A zero divisor reports ErrDivideByZero.
+func DivScaled(a, b int64, mode Rounding) (int64, error) {
+	if b == 0 {
+		return 0, ErrDivideByZero
+	}
+	return mulDiv(a, Scale, b, mode)
+}
+
+// mulDiv computes round(a*b/c) exactly, using a 128-bit intermediate product.
+//
+// Signs are stripped first so the 128-bit work operates on magnitudes only.
+// Handling the sign in one place keeps rounding policies from having to reason
+// about negative remainders, which is where truncating integer division
+// usually goes wrong.
+func mulDiv(a, b, c int64, mode Rounding) (int64, error) {
+	if c == 0 {
+		return 0, ErrDivideByZero
+	}
+
+	negative := (a < 0) != (b < 0) != (c < 0)
+	if a == 0 || b == 0 {
+		return 0, nil
+	}
+
+	hi, lo := bits.Mul64(magnitude(a), magnitude(b))
+	div := magnitude(c)
+
+	// 128-by-64 division in two steps.  The first step's remainder is strictly
+	// less than div, which is exactly the precondition bits.Div64 requires of
+	// its high word, so neither call can panic.
+	quoHi, rem := bits.Div64(0, hi, div)
+	quoLo, rem := bits.Div64(rem, lo, div)
+
+	// A quotient needing more than 64 bits cannot be narrowed to int64 under
+	// any rounding policy.
+	if quoHi != 0 {
+		return 0, overflowFor(negative)
+	}
+
+	if roundMagnitude(quoLo, rem, div, negative, mode) {
+		quoLo++
+		if quoLo == 0 { // wrapped past the top of uint64
+			return 0, overflowFor(negative)
+		}
+	}
+
+	return fromMagnitude(quoLo, negative)
+}
+
+// magnitude returns the absolute value of v as an unsigned integer.
+//
+// Unsigned negation is used rather than -v so that MinRaw, whose positive
+// counterpart is not a valid int64, yields its true magnitude of 2^63.
+func magnitude(v int64) uint64 {
+	u := uint64(v)
+	if v < 0 {
+		u = -u
+	}
+	return u
+}
+
+// fromMagnitude converts a magnitude and sign back to a raw scaled value,
+// reporting overflow or underflow when the signed range cannot hold it.
+//
+// The negative range extends one further than the positive range, so the two
+// signs are bounded separately.
+func fromMagnitude(mag uint64, negative bool) (int64, error) {
+	const negativeLimit = uint64(1) << 63 // magnitude of MinRaw
+
+	if negative {
+		switch {
+		case mag > negativeLimit:
+			return 0, ErrUnderflow
+		case mag == negativeLimit:
+			return MinRaw, nil
+		default:
+			return -int64(mag), nil
+		}
+	}
+
+	if mag > uint64(MaxRaw) {
+		return 0, ErrOverflow
+	}
+	return int64(mag), nil
+}
+
+// overflowFor reports the range error matching the sign of an out-of-range
+// result.
+func overflowFor(negative bool) error {
+	if negative {
+		return ErrUnderflow
+	}
+	return ErrOverflow
+}

--- a/num/internal/fixed/wide.go
+++ b/num/internal/fixed/wide.go
@@ -21,15 +21,25 @@ import "math/bits"
 
 // MulScaled returns the product of two raw scaled values, restored to the
 // common scale and rounded by mode.
+//
+// An unrecognized mode reports ErrInvalidRounding rather than silently
+// falling back to a default policy.
 func MulScaled(a, b int64, mode Rounding) (int64, error) {
+	if !mode.valid() {
+		return 0, ErrInvalidRounding
+	}
 	return mulDiv(a, b, Scale, mode)
 }
 
 // DivScaled returns the quotient of two raw scaled values, restored to the
 // common scale and rounded by mode.
 //
-// A zero divisor reports ErrDivideByZero.
+// A zero divisor reports ErrDivideByZero. An unrecognized mode reports
+// ErrInvalidRounding rather than silently falling back to a default policy.
 func DivScaled(a, b int64, mode Rounding) (int64, error) {
+	if !mode.valid() {
+		return 0, ErrInvalidRounding
+	}
 	if b == 0 {
 		return 0, ErrDivideByZero
 	}

--- a/num/internal/fixed/wide_test.go
+++ b/num/internal/fixed/wide_test.go
@@ -188,6 +188,20 @@ func TestRoundingNeighbourhood(t *testing.T) {
 	}
 }
 
+// TestUnrecognizedRoundingIsRejected guards against the hidden-fallback
+// failure mode: an out-of-range Rounding value must be rejected explicitly,
+// not silently resolved to RoundHalfEven by a switch statement's default
+// case.
+func TestUnrecognizedRoundingIsRejected(t *testing.T) {
+	const bogus Rounding = 99
+
+	_, err := MulScaled(Scale, Scale, bogus)
+	require.ErrorIs(t, err, ErrInvalidRounding)
+
+	_, err = DivScaled(Scale, Scale, bogus)
+	require.ErrorIs(t, err, ErrInvalidRounding)
+}
+
 func TestRoundingString(t *testing.T) {
 	assert.Equal(t, "half-even", RoundHalfEven.String())
 	assert.Equal(t, "toward-zero", RoundTowardZero.String())

--- a/num/internal/fixed/wide_test.go
+++ b/num/internal/fixed/wide_test.go
@@ -1,0 +1,207 @@
+package fixed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMulScaled(t *testing.T) {
+	tests := []struct {
+		name    string
+		a, b    int64
+		want    int64
+		wantErr error
+	}{
+		{name: "zero times anything", a: 0, b: 5 * Scale, want: 0},
+		{name: "anything times zero", a: 5 * Scale, b: 0, want: 0},
+		{name: "identity", a: 7 * Scale, b: Scale, want: 7 * Scale},
+		{name: "negative identity", a: -7 * Scale, b: Scale, want: -7 * Scale},
+		{name: "two negatives give a positive", a: -3 * Scale, b: -4 * Scale, want: 12 * Scale},
+		{name: "mixed signs give a negative", a: -3 * Scale, b: 4 * Scale, want: -12 * Scale},
+
+		// Realistic Price * Rate: 1.08473 marked up by 1.05.
+		{name: "price times rate", a: 108_473_000, b: 105_000_000, want: 113_896_650},
+
+		// Realistic Quantity * Rate: 1000 units at a 0.005 financing rate.
+		{name: "quantity times rate", a: 1000 * Scale, b: 500_000, want: 5 * Scale},
+
+		// Realistic Price * Quantity, which needs the widened intermediate:
+		// the raw product of 1.08473 and 1,000,000 units exceeds int64 by four
+		// orders of magnitude before the scale is restored.
+		{name: "price times large quantity", a: 108_473_000, b: 1_000_000 * Scale, want: 1_084_730 * Scale},
+
+		// The full negative range is reachable; its positive counterpart is
+		// one quantum beyond the representable maximum.
+		{name: "reaches the minimum exactly", a: MinRaw, b: Scale, want: MinRaw},
+		{name: "reaches the maximum exactly", a: MaxRaw, b: Scale, want: MaxRaw},
+		{name: "negating the minimum overflows", a: MinRaw, b: -Scale, wantErr: ErrOverflow},
+
+		{name: "overflows past the maximum", a: MaxRaw, b: 2 * Scale, wantErr: ErrOverflow},
+		{name: "underflows past the minimum", a: MinRaw, b: 2 * Scale, wantErr: ErrUnderflow},
+		{name: "quotient wider than 64 bits overflows", a: MaxRaw, b: MaxRaw, wantErr: ErrOverflow},
+		{name: "negative quotient wider than 64 bits underflows", a: MinRaw, b: MaxRaw, wantErr: ErrUnderflow},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MulScaled(tt.a, tt.b, RoundHalfEven)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Zero(t, got, "failed operations must not return a partial result")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMulScaledIsCommutative(t *testing.T) {
+	values := []int64{0, 1, -1, Scale, -Scale, 108_473_000, -250_000_000, 3 * Scale}
+
+	for _, a := range values {
+		for _, b := range values {
+			ab, errAB := MulScaled(a, b, RoundHalfEven)
+			ba, errBA := MulScaled(b, a, RoundHalfEven)
+			assert.Equal(t, errAB, errBA, "MulScaled(%d,%d) and its reverse disagree on error", a, b)
+			assert.Equal(t, ab, ba, "MulScaled(%d,%d) and its reverse disagree on result", a, b)
+		}
+	}
+}
+
+func TestDivScaled(t *testing.T) {
+	tests := []struct {
+		name    string
+		a, b    int64
+		want    int64
+		wantErr error
+	}{
+		{name: "zero divided by anything", a: 0, b: 5 * Scale, want: 0},
+		{name: "identity", a: 7 * Scale, b: Scale, want: 7 * Scale},
+		{name: "exact halving", a: 3 * Scale, b: 2 * Scale, want: 150_000_000},
+		{name: "negative dividend", a: -3 * Scale, b: 2 * Scale, want: -150_000_000},
+		{name: "negative divisor", a: 3 * Scale, b: -2 * Scale, want: -150_000_000},
+		{name: "two negatives give a positive", a: -3 * Scale, b: -2 * Scale, want: 150_000_000},
+
+		// Repeating decimals must round at the last representable place, not
+		// truncate: 1/3 rounds down, 2/3 rounds up.
+		{name: "one third rounds down", a: Scale, b: 3 * Scale, want: 33_333_333},
+		{name: "two thirds rounds up", a: 2 * Scale, b: 3 * Scale, want: 66_666_667},
+
+		// Realistic Price / Price producing a Rate.
+		{name: "price ratio", a: 108_473_000, b: 108_000_000, want: 100_437_963},
+
+		{name: "divide by zero", a: 5 * Scale, b: 0, wantErr: ErrDivideByZero},
+		{name: "zero divided by zero", a: 0, b: 0, wantErr: ErrDivideByZero},
+		{name: "overflows past the maximum", a: MaxRaw, b: 1, wantErr: ErrOverflow},
+		{name: "underflows past the minimum", a: MinRaw, b: 1, wantErr: ErrUnderflow},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DivScaled(tt.a, tt.b, RoundHalfEven)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Zero(t, got, "failed operations must not return a partial result")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestRoundingPolicies pins the behavior of all four ADR-004 policies at exact
+// midpoints, for both signs.  Multiplying by one quantum makes the operand
+// itself the value being rounded, so 250_000_000 is the midpoint 2.5.
+func TestRoundingPolicies(t *testing.T) {
+	const (
+		twoAndAHalf = 250_000_000
+		oneAndAHalf = 150_000_000
+	)
+
+	tests := []struct {
+		name string
+		a, b int64
+		mode Rounding
+		want int64
+	}{
+		{name: "half-even leaves 2.5 at the even 2", a: 1, b: twoAndAHalf, mode: RoundHalfEven, want: 2},
+		{name: "half-even lifts 1.5 to the even 2", a: 1, b: oneAndAHalf, mode: RoundHalfEven, want: 2},
+		{name: "half-even leaves -2.5 at the even -2", a: -1, b: twoAndAHalf, mode: RoundHalfEven, want: -2},
+		{name: "half-even lowers -1.5 to the even -2", a: -1, b: oneAndAHalf, mode: RoundHalfEven, want: -2},
+
+		{name: "toward zero drops 2.5 to 2", a: 1, b: twoAndAHalf, mode: RoundTowardZero, want: 2},
+		{name: "toward zero drops 1.5 to 1", a: 1, b: oneAndAHalf, mode: RoundTowardZero, want: 1},
+		{name: "toward zero raises -2.5 to -2", a: -1, b: twoAndAHalf, mode: RoundTowardZero, want: -2},
+		{name: "toward zero raises -1.5 to -1", a: -1, b: oneAndAHalf, mode: RoundTowardZero, want: -1},
+
+		{name: "down leaves 2.5 at 2", a: 1, b: twoAndAHalf, mode: RoundDown, want: 2},
+		{name: "down leaves 1.5 at 1", a: 1, b: oneAndAHalf, mode: RoundDown, want: 1},
+		{name: "down pushes -2.5 to -3", a: -1, b: twoAndAHalf, mode: RoundDown, want: -3},
+		{name: "down pushes -1.5 to -2", a: -1, b: oneAndAHalf, mode: RoundDown, want: -2},
+
+		{name: "up lifts 2.5 to 3", a: 1, b: twoAndAHalf, mode: RoundUp, want: 3},
+		{name: "up lifts 1.5 to 2", a: 1, b: oneAndAHalf, mode: RoundUp, want: 2},
+		{name: "up raises -2.5 to -2", a: -1, b: twoAndAHalf, mode: RoundUp, want: -2},
+		{name: "up raises -1.5 to -1", a: -1, b: oneAndAHalf, mode: RoundUp, want: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MulScaled(tt.a, tt.b, tt.mode)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestRoundingNeighbourhood covers the values immediately below, at, and above
+// a midpoint.  ADR-004 requires threshold behavior to be tested on both sides
+// of the boundary, not only at it.
+func TestRoundingNeighbourhood(t *testing.T) {
+	tests := []struct {
+		name string
+		b    int64
+		want int64
+	}{
+		{name: "just below the midpoint rounds down", b: 149_999_999, want: 1},
+		{name: "at the midpoint rounds to even", b: 150_000_000, want: 2},
+		{name: "just above the midpoint rounds up", b: 150_000_001, want: 2},
+		{name: "just below the next midpoint", b: 249_999_999, want: 2},
+		{name: "at the next midpoint rounds to even", b: 250_000_000, want: 2},
+		{name: "just above the next midpoint", b: 250_000_001, want: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			positive, err := MulScaled(1, tt.b, RoundHalfEven)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, positive)
+
+			negative, err := MulScaled(-1, tt.b, RoundHalfEven)
+			require.NoError(t, err)
+			assert.Equal(t, -tt.want, negative, "rounding must be symmetric about zero under half-even")
+		})
+	}
+}
+
+func TestRoundingString(t *testing.T) {
+	assert.Equal(t, "half-even", RoundHalfEven.String())
+	assert.Equal(t, "toward-zero", RoundTowardZero.String())
+	assert.Equal(t, "down", RoundDown.String())
+	assert.Equal(t, "up", RoundUp.String())
+	assert.Equal(t, "unknown", Rounding(99).String())
+}
+
+func TestMagnitudeHandlesTheMostNegativeValue(t *testing.T) {
+	// The magnitude of MinRaw has no int64 counterpart; representing it
+	// unsigned is what lets the full negative range participate in widened
+	// arithmetic and parsing.
+	assert.Equal(t, uint64(1)<<63, magnitude(MinRaw))
+	assert.Equal(t, uint64(MaxRaw), magnitude(MaxRaw))
+	assert.Equal(t, uint64(0), magnitude(0))
+	assert.Equal(t, uint64(1), magnitude(-1))
+}

--- a/num/money.go
+++ b/num/money.go
@@ -1,0 +1,233 @@
+package num
+
+import "github.com/rustyeddy/trader/num/internal/fixed"
+
+// Money is an immutable, self-describing monetary amount: a signed scaled
+// int64 at the common 1e8 scale (ADR-004), paired with a mandatory Currency.
+//
+// The Go zero value of Money is invalid because it has no currency. Valid
+// zero money must be constructed explicitly with a currency, for example
+// MustParseMoney("0", MustParseCurrency("USD")).
+//
+// Same-currency amounts may be compared, added, and subtracted with checked
+// arithmetic. Cross-currency arithmetic and comparison are rejected outright:
+// currency is never silently assumed, dropped, or coerced. Currency
+// conversion is not implicit; it is not implemented by this type at all. Any
+// future conversion operation must require an explicit target currency, an
+// explicit rate, and provenance for that rate — Money.MulRate deliberately
+// keeps the existing currency rather than serving as a disguised conversion.
+type Money struct {
+	amount   int64
+	currency Currency
+	valid    bool
+}
+
+// ParseMoney parses exact decimal text into a Money value denominated in
+// currency.
+//
+// currency must itself be valid; an invalid or zero-value Currency is
+// rejected with ErrMissingCurrency so a caller cannot construct money that
+// looks self-describing but silently isn't.
+func ParseMoney(s string, currency Currency) (Money, error) {
+	if !currency.IsValid() {
+		return Money{}, ErrMissingCurrency
+	}
+	raw, err := fixed.Parse(s)
+	if err != nil {
+		return Money{}, wrapFixedErr(err)
+	}
+	return Money{amount: raw, currency: currency, valid: true}, nil
+}
+
+// MustParseMoney is like ParseMoney but panics on error.
+//
+// It is intended for programmer-controlled constants, fixtures, and tests,
+// not for parsing external or market input.
+func MustParseMoney(s string, currency Currency) Money {
+	m, err := ParseMoney(s, currency)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// MoneyFromScaled constructs Money directly from a raw amount already scaled
+// by 1e8, and a currency.
+//
+// This is a narrowly scoped escape hatch for trusted internal code,
+// persistence reconstruction, and tests that exercise representation
+// boundaries directly. Ordinary callers should use ParseMoney.
+func MoneyFromScaled(raw int64, currency Currency) (Money, error) {
+	if !currency.IsValid() {
+		return Money{}, ErrMissingCurrency
+	}
+	return Money{amount: raw, currency: currency, valid: true}, nil
+}
+
+// IsValid reports whether m has a valid currency. The Go zero value of Money,
+// and any Money left unset, reports false.
+func (m Money) IsValid() bool {
+	return m.valid && m.currency.IsValid()
+}
+
+// Currency returns m's denomination.
+func (m Money) Currency() Currency {
+	return m.currency
+}
+
+// Scaled returns the raw amount backing m, scaled by 1e8.
+func (m Money) Scaled() int64 {
+	return m.amount
+}
+
+// String returns m formatted as "<canonical amount> <currency>", for example
+// "123.45 USD". This is Money's canonical text form; see MarshalText.
+func (m Money) String() string {
+	return fixed.Format(m.amount) + " " + m.currency.String()
+}
+
+// IsZero reports whether m's amount is exactly zero. IsZero does not imply
+// IsValid: a currency-less zero amount is still invalid Money.
+func (m Money) IsZero() bool {
+	return m.amount == 0
+}
+
+// sameCurrency reports whether m and o are both valid and share a currency,
+// returning the mismatch error to return otherwise.
+func (m Money) sameCurrency(o Money) error {
+	if !m.IsValid() || !o.IsValid() {
+		return ErrMissingCurrency
+	}
+	if !m.currency.Equal(o.currency) {
+		return ErrCurrencyMismatch
+	}
+	return nil
+}
+
+// Cmp compares m and o, returning -1, 0, or +1.
+//
+// Cmp reports an error, rather than a meaningless ordering, when the two
+// values are not both valid same-currency Money.
+func (m Money) Cmp(o Money) (int, error) {
+	if err := m.sameCurrency(o); err != nil {
+		return 0, err
+	}
+	return fixed.Cmp(m.amount, o.amount), nil
+}
+
+// Equal reports whether m and o are the exact same amount in the same
+// currency. Unlike Cmp, Equal never errors: differing or invalid currencies
+// simply make two Money values unequal.
+func (m Money) Equal(o Money) bool {
+	return m.valid && o.valid && m.currency.Equal(o.currency) && m.amount == o.amount
+}
+
+// Add returns m+o using checked arithmetic.
+//
+// Add reports ErrCurrencyMismatch if m and o are denominated differently, and
+// ErrMissingCurrency if either is invalid.
+func (m Money) Add(o Money) (Money, error) {
+	if err := m.sameCurrency(o); err != nil {
+		return Money{}, err
+	}
+	raw, err := fixed.Add(m.amount, o.amount)
+	if err != nil {
+		return Money{}, wrapFixedErr(err)
+	}
+	return Money{amount: raw, currency: m.currency, valid: true}, nil
+}
+
+// Sub returns m-o using checked arithmetic.
+//
+// Sub reports ErrCurrencyMismatch if m and o are denominated differently, and
+// ErrMissingCurrency if either is invalid. Unlike Price and Quantity, a
+// negative result is valid: Money is signed, since balances, fees, and PnL
+// are routinely negative.
+func (m Money) Sub(o Money) (Money, error) {
+	if err := m.sameCurrency(o); err != nil {
+		return Money{}, err
+	}
+	raw, err := fixed.Sub(m.amount, o.amount)
+	if err != nil {
+		return Money{}, wrapFixedErr(err)
+	}
+	return Money{amount: raw, currency: m.currency, valid: true}, nil
+}
+
+// Neg returns -m, preserving currency.
+//
+// Neg rejects the one amount whose negation is not representable: the value
+// backed by math.MinInt64.
+func (m Money) Neg() (Money, error) {
+	if !m.IsValid() {
+		return Money{}, ErrMissingCurrency
+	}
+	raw, err := fixed.Neg(m.amount)
+	if err != nil {
+		return Money{}, wrapFixedErr(err)
+	}
+	return Money{amount: raw, currency: m.currency, valid: true}, nil
+}
+
+// Abs returns the absolute value of m, preserving currency.
+//
+// Abs rejects the one amount whose absolute value is not representable: the
+// value backed by math.MinInt64.
+func (m Money) Abs() (Money, error) {
+	if !m.IsValid() {
+		return Money{}, ErrMissingCurrency
+	}
+	raw, err := fixed.Abs(m.amount)
+	if err != nil {
+		return Money{}, wrapFixedErr(err)
+	}
+	return Money{amount: raw, currency: m.currency, valid: true}, nil
+}
+
+// MulRate returns m*r, preserving currency and rounding to nearest with ties
+// to even.
+//
+// MulRate is not currency conversion: the result stays denominated in m's
+// existing currency. It is meaningful for fee schedules, financing rates, and
+// proportional adjustments, not for converting one currency into another.
+func (m Money) MulRate(r Rate) (Money, error) {
+	if !m.IsValid() {
+		return Money{}, ErrMissingCurrency
+	}
+	raw, err := fixed.MulScaled(m.amount, r.raw, fixed.RoundHalfEven)
+	if err != nil {
+		return Money{}, wrapFixedErr(err)
+	}
+	return Money{amount: raw, currency: m.currency, valid: true}, nil
+}
+
+// DivRate returns m/r, preserving currency and rounding to nearest with ties
+// to even.
+//
+// DivRate reports ErrDivideByZero when r is zero.
+func (m Money) DivRate(r Rate) (Money, error) {
+	if !m.IsValid() {
+		return Money{}, ErrMissingCurrency
+	}
+	raw, err := fixed.DivScaled(m.amount, r.raw, fixed.RoundHalfEven)
+	if err != nil {
+		return Money{}, wrapFixedErr(err)
+	}
+	return Money{amount: raw, currency: m.currency, valid: true}, nil
+}
+
+// Div returns m/o as a dimensionless Rate, rounded to nearest with ties to
+// even.
+//
+// Div reports ErrCurrencyMismatch if m and o are denominated differently, and
+// ErrDivideByZero when o is zero.
+func (m Money) Div(o Money) (Rate, error) {
+	if err := m.sameCurrency(o); err != nil {
+		return Rate{}, err
+	}
+	raw, err := fixed.DivScaled(m.amount, o.amount, fixed.RoundHalfEven)
+	if err != nil {
+		return Rate{}, wrapFixedErr(err)
+	}
+	return Rate{raw: raw}, nil
+}

--- a/num/money.go
+++ b/num/money.go
@@ -51,19 +51,6 @@ func MustParseMoney(s string, currency Currency) Money {
 	return m
 }
 
-// MoneyFromScaled constructs Money directly from a raw amount already scaled
-// by 1e8, and a currency.
-//
-// This is a narrowly scoped escape hatch for trusted internal code,
-// persistence reconstruction, and tests that exercise representation
-// boundaries directly. Ordinary callers should use ParseMoney.
-func MoneyFromScaled(raw int64, currency Currency) (Money, error) {
-	if !currency.IsValid() {
-		return Money{}, ErrMissingCurrency
-	}
-	return Money{amount: raw, currency: currency, valid: true}, nil
-}
-
 // IsValid reports whether m has a valid currency. The Go zero value of Money,
 // and any Money left unset, reports false.
 func (m Money) IsValid() bool {
@@ -75,14 +62,19 @@ func (m Money) Currency() Currency {
 	return m.currency
 }
 
-// Scaled returns the raw amount backing m, scaled by 1e8.
-func (m Money) Scaled() int64 {
-	return m.amount
-}
-
 // String returns m formatted as "<canonical amount> <currency>", for example
 // "123.45 USD". This is Money's canonical text form; see MarshalText.
+//
+// String renders invalid Money, including the Go zero value, as
+// "<invalid money>" rather than a currency-shaped string such as "0 ": an
+// amount with no currency is not canonical output and must not be mistaken
+// for it. MarshalText and MarshalJSON reject invalid Money outright; String
+// exists for logging and debugging, where a caller cannot check an error, so
+// it makes the problem visible instead.
 func (m Money) String() string {
+	if !m.IsValid() {
+		return "<invalid money>"
+	}
 	return fixed.Format(m.amount) + " " + m.currency.String()
 }
 

--- a/num/money_test.go
+++ b/num/money_test.go
@@ -63,19 +63,19 @@ func TestMoneyZeroValueIsInvalid(t *testing.T) {
 	assert.False(t, m.Currency().IsValid())
 }
 
+// TestMoneyStringMarksInvalidMoneyVisibly guards against String() rendering
+// invalid Money as something that merely looks like canonical output, such as
+// "0 " for the Go zero value.
+func TestMoneyStringMarksInvalidMoneyVisibly(t *testing.T) {
+	var m Money
+	assert.Equal(t, "<invalid money>", m.String())
+	assert.NotContains(t, m.String(), " USD")
+}
+
 func TestMoneyExplicitZeroIsValid(t *testing.T) {
 	m := usd("0")
 	assert.True(t, m.IsValid())
 	assert.True(t, m.IsZero())
-}
-
-func TestMoneyFromScaled(t *testing.T) {
-	m, err := MoneyFromScaled(12_345_000_000, MustParseCurrency("USD"))
-	require.NoError(t, err)
-	assert.Equal(t, "123.45 USD", m.String())
-
-	_, err = MoneyFromScaled(100, Currency{})
-	require.ErrorIs(t, err, ErrMissingCurrency)
 }
 
 func TestMoneySameCurrencyArithmetic(t *testing.T) {
@@ -174,10 +174,12 @@ func TestMoneyNegAbs(t *testing.T) {
 }
 
 func TestMoneyNegAbsMinInt64(t *testing.T) {
-	m, err := MoneyFromScaled(math.MinInt64, MustParseCurrency("USD"))
-	require.NoError(t, err)
+	// Money{amount: ..., currency: ..., valid: true} is a
+	// representation-boundary test construction, not a public API: num
+	// exports no raw-scaled constructor. See doc.go.
+	m := Money{amount: math.MinInt64, currency: MustParseCurrency("USD"), valid: true}
 
-	_, err = m.Neg()
+	_, err := m.Neg()
 	require.ErrorIs(t, err, ErrNotRepresentable)
 
 	_, err = m.Abs()
@@ -185,11 +187,10 @@ func TestMoneyNegAbsMinInt64(t *testing.T) {
 }
 
 func TestMoneyOverflow(t *testing.T) {
-	max, err := MoneyFromScaled(math.MaxInt64, MustParseCurrency("USD"))
-	require.NoError(t, err)
+	max := Money{amount: math.MaxInt64, currency: MustParseCurrency("USD"), valid: true}
 	one := usd("0.00000001")
 
-	_, err = max.Add(one)
+	_, err := max.Add(one)
 	require.ErrorIs(t, err, ErrOverflow)
 }
 

--- a/num/money_test.go
+++ b/num/money_test.go
@@ -1,0 +1,235 @@
+package num
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func usd(s string) Money {
+	return MustParseMoney(s, MustParseCurrency("USD"))
+}
+
+func eur(s string) Money {
+	return MustParseMoney(s, MustParseCurrency("EUR"))
+}
+
+func TestParseMoneyValid(t *testing.T) {
+	tests := []struct {
+		name       string
+		amount     string
+		currency   string
+		wantString string
+	}{
+		{name: "positive", amount: "123.45", currency: "USD", wantString: "123.45 USD"},
+		{name: "negative", amount: "-50.00", currency: "EUR", wantString: "-50 EUR"},
+		{name: "explicit zero", amount: "0", currency: "USD", wantString: "0 USD"},
+		{name: "full precision", amount: "0.00000001", currency: "BTC", wantString: "0.00000001 BTC"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := ParseMoney(tt.amount, MustParseCurrency(tt.currency))
+			require.NoError(t, err)
+			assert.True(t, m.IsValid())
+			assert.Equal(t, tt.wantString, m.String())
+		})
+	}
+}
+
+func TestParseMoneyRejectsInvalidCurrency(t *testing.T) {
+	_, err := ParseMoney("100.00", Currency{})
+	require.ErrorIs(t, err, ErrMissingCurrency)
+
+	_, err = ParseMoney("100.00", Currency{code: "usd"})
+	require.ErrorIs(t, err, ErrMissingCurrency)
+}
+
+func TestParseMoneyRejectsMalformedAmount(t *testing.T) {
+	usdCode := MustParseCurrency("USD")
+
+	_, err := ParseMoney("abc", usdCode)
+	require.ErrorIs(t, err, ErrSyntax)
+
+	_, err = ParseMoney("1.123456789", usdCode)
+	require.ErrorIs(t, err, ErrPrecision)
+}
+
+func TestMoneyZeroValueIsInvalid(t *testing.T) {
+	var m Money
+	assert.False(t, m.IsValid())
+	assert.False(t, m.Currency().IsValid())
+}
+
+func TestMoneyExplicitZeroIsValid(t *testing.T) {
+	m := usd("0")
+	assert.True(t, m.IsValid())
+	assert.True(t, m.IsZero())
+}
+
+func TestMoneyFromScaled(t *testing.T) {
+	m, err := MoneyFromScaled(12_345_000_000, MustParseCurrency("USD"))
+	require.NoError(t, err)
+	assert.Equal(t, "123.45 USD", m.String())
+
+	_, err = MoneyFromScaled(100, Currency{})
+	require.ErrorIs(t, err, ErrMissingCurrency)
+}
+
+func TestMoneySameCurrencyArithmetic(t *testing.T) {
+	a := usd("100.00")
+	b := usd("40.00")
+
+	sum, err := a.Add(b)
+	require.NoError(t, err)
+	assert.Equal(t, "140 USD", sum.String())
+
+	diff, err := a.Sub(b)
+	require.NoError(t, err)
+	assert.Equal(t, "60 USD", diff.String())
+}
+
+func TestMoneySubCanGoNegative(t *testing.T) {
+	// Unlike Price and Quantity, Money is signed: a fee or realized loss is
+	// ordinary negative money, not an error.
+	a := usd("10.00")
+	b := usd("25.00")
+
+	diff, err := a.Sub(b)
+	require.NoError(t, err)
+	assert.Equal(t, "-15 USD", diff.String())
+}
+
+func TestMoneyCrossCurrencyArithmeticRejected(t *testing.T) {
+	a := usd("100.00")
+	b := eur("100.00")
+
+	_, err := a.Add(b)
+	require.ErrorIs(t, err, ErrCurrencyMismatch)
+
+	_, err = a.Sub(b)
+	require.ErrorIs(t, err, ErrCurrencyMismatch)
+
+	_, err = a.Div(b)
+	require.ErrorIs(t, err, ErrCurrencyMismatch)
+
+	_, err = a.Cmp(b)
+	require.ErrorIs(t, err, ErrCurrencyMismatch)
+}
+
+func TestMoneyArithmeticWithInvalidOperandRejected(t *testing.T) {
+	var zero Money
+	a := usd("1.00")
+
+	_, err := a.Add(zero)
+	require.ErrorIs(t, err, ErrMissingCurrency)
+
+	_, err = zero.Add(a)
+	require.ErrorIs(t, err, ErrMissingCurrency)
+}
+
+func TestMoneyEqual(t *testing.T) {
+	a := usd("100.00")
+	b := usd("100.00")
+	c := usd("100.01")
+	d := eur("100.00")
+
+	assert.True(t, a.Equal(b))
+	assert.False(t, a.Equal(c))
+	assert.False(t, a.Equal(d), "different currencies are never equal")
+
+	var zero Money
+	assert.False(t, zero.Equal(zero), "the invalid zero value is never equal to itself")
+}
+
+func TestMoneyCmp(t *testing.T) {
+	low := usd("10.00")
+	high := usd("20.00")
+
+	got, err := low.Cmp(high)
+	require.NoError(t, err)
+	assert.Equal(t, -1, got)
+
+	got, err = high.Cmp(low)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got)
+
+	got, err = low.Cmp(low)
+	require.NoError(t, err)
+	assert.Equal(t, 0, got)
+}
+
+func TestMoneyNegAbs(t *testing.T) {
+	a := usd("15.00")
+
+	neg, err := a.Neg()
+	require.NoError(t, err)
+	assert.Equal(t, "-15 USD", neg.String())
+
+	abs, err := neg.Abs()
+	require.NoError(t, err)
+	assert.Equal(t, "15 USD", abs.String())
+}
+
+func TestMoneyNegAbsMinInt64(t *testing.T) {
+	m, err := MoneyFromScaled(math.MinInt64, MustParseCurrency("USD"))
+	require.NoError(t, err)
+
+	_, err = m.Neg()
+	require.ErrorIs(t, err, ErrNotRepresentable)
+
+	_, err = m.Abs()
+	require.ErrorIs(t, err, ErrNotRepresentable)
+}
+
+func TestMoneyOverflow(t *testing.T) {
+	max, err := MoneyFromScaled(math.MaxInt64, MustParseCurrency("USD"))
+	require.NoError(t, err)
+	one := usd("0.00000001")
+
+	_, err = max.Add(one)
+	require.ErrorIs(t, err, ErrOverflow)
+}
+
+func TestMoneyMulRate(t *testing.T) {
+	// A 1.05 markup preserves the existing currency; it is not conversion.
+	m := usd("100.00")
+	rate := MustParseRate("1.05")
+
+	got, err := m.MulRate(rate)
+	require.NoError(t, err)
+	assert.Equal(t, "105 USD", got.String())
+	assert.Equal(t, "USD", got.Currency().String())
+}
+
+func TestMoneyDivRate(t *testing.T) {
+	m := usd("105.00")
+	rate := MustParseRate("1.05")
+
+	got, err := m.DivRate(rate)
+	require.NoError(t, err)
+	assert.Equal(t, "100 USD", got.String())
+}
+
+func TestMoneyDivRateByZero(t *testing.T) {
+	m := usd("100.00")
+	_, err := m.DivRate(Rate{})
+	require.ErrorIs(t, err, ErrDivideByZero)
+}
+
+func TestMoneyDivSameCurrency(t *testing.T) {
+	a := usd("50.00")
+	b := usd("200.00")
+
+	got, err := a.Div(b)
+	require.NoError(t, err)
+	assert.Equal(t, "0.25", got.String())
+}
+
+func TestMoneyDivByZero(t *testing.T) {
+	a := usd("50.00")
+	_, err := a.Div(usd("0"))
+	require.ErrorIs(t, err, ErrDivideByZero)
+}

--- a/num/price.go
+++ b/num/price.go
@@ -45,27 +45,6 @@ func MustParsePrice(s string) Price {
 	return p
 }
 
-// PriceFromScaled constructs a Price directly from a raw value already scaled
-// by 1e8.
-//
-// This is a narrowly scoped escape hatch for trusted internal code,
-// persistence reconstruction, and tests that exercise representation
-// boundaries directly. Ordinary callers should use ParsePrice.
-//
-// PriceFromScaled rejects a negative raw value, matching ParsePrice, since a
-// deserialized Price is still subject to the same domain invariant.
-func PriceFromScaled(raw int64) (Price, error) {
-	if raw < 0 {
-		return Price{}, ErrNegative
-	}
-	return Price{raw: raw}, nil
-}
-
-// Scaled returns the raw value backing p, scaled by 1e8.
-func (p Price) Scaled() int64 {
-	return p.raw
-}
-
 // String returns p formatted as canonical decimal text.
 func (p Price) String() string {
 	return fixed.Format(p.raw)

--- a/num/price.go
+++ b/num/price.go
@@ -1,0 +1,139 @@
+package num
+
+import "github.com/rustyeddy/trader/num/internal/fixed"
+
+// Price represents an authoritative instrument price.
+//
+// Price is backed by a scaled int64 at the common 1e8 scale (ADR-004). Normal
+// domain values are non-negative; constructors and parsers reject negative
+// input. Zero is representable — whether zero is a valid price is decided by
+// the surrounding context, not by this type.
+//
+// Tick size, permitted increments, and display precision are instrument
+// rules, not properties of Price. Price increment validation is exact when
+// price and tick size share this scale: priceRaw % tickRaw == 0.
+//
+// The zero value of Price is the exact value 0 and is valid.
+type Price struct {
+	raw int64
+}
+
+// ParsePrice parses exact decimal text into a Price.
+//
+// Negative input is rejected, as are malformed text, excess precision, and
+// out-of-range values. Nothing is silently rounded.
+func ParsePrice(s string) (Price, error) {
+	raw, err := fixed.Parse(s)
+	if err != nil {
+		return Price{}, wrapFixedErr(err)
+	}
+	if raw < 0 {
+		return Price{}, ErrNegative
+	}
+	return Price{raw: raw}, nil
+}
+
+// MustParsePrice is like ParsePrice but panics on error.
+//
+// It is intended for programmer-controlled constants, fixtures, and tests,
+// not for parsing external or market input.
+func MustParsePrice(s string) Price {
+	p, err := ParsePrice(s)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+// PriceFromScaled constructs a Price directly from a raw value already scaled
+// by 1e8.
+//
+// This is a narrowly scoped escape hatch for trusted internal code,
+// persistence reconstruction, and tests that exercise representation
+// boundaries directly. Ordinary callers should use ParsePrice.
+//
+// PriceFromScaled rejects a negative raw value, matching ParsePrice, since a
+// deserialized Price is still subject to the same domain invariant.
+func PriceFromScaled(raw int64) (Price, error) {
+	if raw < 0 {
+		return Price{}, ErrNegative
+	}
+	return Price{raw: raw}, nil
+}
+
+// Scaled returns the raw value backing p, scaled by 1e8.
+func (p Price) Scaled() int64 {
+	return p.raw
+}
+
+// String returns p formatted as canonical decimal text.
+func (p Price) String() string {
+	return fixed.Format(p.raw)
+}
+
+// IsZero reports whether p is exactly zero.
+func (p Price) IsZero() bool {
+	return p.raw == 0
+}
+
+// Cmp compares p and o, returning -1, 0, or +1.
+func (p Price) Cmp(o Price) int {
+	return fixed.Cmp(p.raw, o.raw)
+}
+
+// Equal reports whether p and o are the exact same value.
+func (p Price) Equal(o Price) bool {
+	return p.raw == o.raw
+}
+
+// Add returns p+o using checked arithmetic.
+func (p Price) Add(o Price) (Price, error) {
+	raw, err := fixed.Add(p.raw, o.raw)
+	if err != nil {
+		return Price{}, wrapFixedErr(err)
+	}
+	return Price{raw: raw}, nil
+}
+
+// Sub returns p-o using checked arithmetic.
+//
+// Sub reports ErrNegative if the true difference would be negative: Price
+// has no signed counterpart. Callers that need a signed difference between
+// two prices should use a dedicated signed type rather than relax this one.
+func (p Price) Sub(o Price) (Price, error) {
+	raw, err := fixed.Sub(p.raw, o.raw)
+	if err != nil {
+		return Price{}, wrapFixedErr(err)
+	}
+	if raw < 0 {
+		return Price{}, ErrNegative
+	}
+	return Price{raw: raw}, nil
+}
+
+// MulRate returns p*r, rounded to nearest with ties to even.
+//
+// MulRate reports ErrNegative if r is negative enough to make the result
+// negative.
+func (p Price) MulRate(r Rate) (Price, error) {
+	raw, err := fixed.MulScaled(p.raw, r.raw, fixed.RoundHalfEven)
+	if err != nil {
+		return Price{}, wrapFixedErr(err)
+	}
+	if raw < 0 {
+		return Price{}, ErrNegative
+	}
+	return Price{raw: raw}, nil
+}
+
+// Div returns p/o as a dimensionless Rate, rounded to nearest with ties to
+// even.
+//
+// Div reports ErrDivideByZero when o is zero.
+func (p Price) Div(o Price) (Rate, error) {
+	raw, err := fixed.DivScaled(p.raw, o.raw, fixed.RoundHalfEven)
+	if err != nil {
+		return Rate{}, wrapFixedErr(err)
+	}
+	return Rate{raw: raw}, nil
+}

--- a/num/price_test.go
+++ b/num/price_test.go
@@ -1,0 +1,145 @@
+package num
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePrice(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr error
+	}{
+		{name: "zero", in: "0", want: "0"},
+		{name: "typical FX price", in: "1.08473", want: "1.08473"},
+		{name: "typical equity price", in: "123.45", want: "123.45"},
+		{name: "high priced instrument", in: "92233720368.54775807", want: "92233720368.54775807"},
+		{name: "one quantum", in: "0.00000001", want: "0.00000001"},
+
+		{name: "negative rejected", in: "-1.00", wantErr: ErrNegative},
+		{name: "negative quantum rejected", in: "-0.00000001", wantErr: ErrNegative},
+		{name: "malformed", in: "abc", wantErr: ErrSyntax},
+		{name: "excess precision", in: "1.123456789", wantErr: ErrPrecision},
+		{name: "out of range", in: "999999999999999999", wantErr: ErrRange},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePrice(tt.in)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Equal(t, Price{}, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}
+
+func TestMustParsePrice(t *testing.T) {
+	assert.Equal(t, "1.5", MustParsePrice("1.5").String())
+	assert.Panics(t, func() { MustParsePrice("-1") })
+}
+
+func TestPriceFromScaled(t *testing.T) {
+	p, err := PriceFromScaled(108_473_000)
+	require.NoError(t, err)
+	assert.Equal(t, "1.08473", p.String())
+	assert.Equal(t, int64(108_473_000), p.Scaled())
+
+	_, err = PriceFromScaled(-1)
+	require.ErrorIs(t, err, ErrNegative)
+}
+
+func TestPriceZeroValueIsValidZero(t *testing.T) {
+	var p Price
+	assert.True(t, p.IsZero())
+	assert.Equal(t, "0", p.String())
+}
+
+func TestPriceComparison(t *testing.T) {
+	low := MustParsePrice("1.00")
+	high := MustParsePrice("2.00")
+
+	assert.Equal(t, -1, low.Cmp(high))
+	assert.Equal(t, 1, high.Cmp(low))
+	assert.Equal(t, 0, low.Cmp(low))
+	assert.True(t, low.Equal(MustParsePrice("1.00")))
+	assert.False(t, low.Equal(high))
+}
+
+func TestPriceAddSub(t *testing.T) {
+	a := MustParsePrice("1.50")
+	b := MustParsePrice("0.50")
+
+	sum, err := a.Add(b)
+	require.NoError(t, err)
+	assert.Equal(t, "2", sum.String())
+
+	diff, err := a.Sub(b)
+	require.NoError(t, err)
+	assert.Equal(t, "1", diff.String())
+}
+
+func TestPriceSubRejectsNegativeResult(t *testing.T) {
+	a := MustParsePrice("1.00")
+	b := MustParsePrice("2.00")
+
+	_, err := a.Sub(b)
+	require.ErrorIs(t, err, ErrNegative)
+}
+
+func TestPriceSubExactlyZeroIsValid(t *testing.T) {
+	a := MustParsePrice("1.00")
+	diff, err := a.Sub(a)
+	require.NoError(t, err)
+	assert.True(t, diff.IsZero())
+}
+
+func TestPriceAddOverflow(t *testing.T) {
+	max, err := PriceFromScaled(math.MaxInt64)
+	require.NoError(t, err)
+	one := MustParsePrice("0.00000001")
+
+	_, err = max.Add(one)
+	require.ErrorIs(t, err, ErrOverflow)
+}
+
+func TestPriceMulRate(t *testing.T) {
+	// Realistic markup: a 1.08473 price scaled by a 1.05 rate.
+	price := MustParsePrice("1.08473")
+	rate := MustParseRate("1.05")
+
+	got, err := price.MulRate(rate)
+	require.NoError(t, err)
+	assert.Equal(t, "1.1389665", got.String())
+}
+
+func TestPriceMulRateRejectsNegativeResult(t *testing.T) {
+	price := MustParsePrice("1.00")
+	rate := MustParseRate("-0.5")
+
+	_, err := price.MulRate(rate)
+	require.ErrorIs(t, err, ErrNegative)
+}
+
+func TestPriceDiv(t *testing.T) {
+	a := MustParsePrice("1.08473")
+	b := MustParsePrice("1.08000")
+
+	got, err := a.Div(b)
+	require.NoError(t, err)
+	assert.Equal(t, "1.00437963", got.String())
+}
+
+func TestPriceDivByZero(t *testing.T) {
+	a := MustParsePrice("1.00")
+	_, err := a.Div(Price{})
+	require.ErrorIs(t, err, ErrDivideByZero)
+}

--- a/num/price_test.go
+++ b/num/price_test.go
@@ -47,16 +47,6 @@ func TestMustParsePrice(t *testing.T) {
 	assert.Panics(t, func() { MustParsePrice("-1") })
 }
 
-func TestPriceFromScaled(t *testing.T) {
-	p, err := PriceFromScaled(108_473_000)
-	require.NoError(t, err)
-	assert.Equal(t, "1.08473", p.String())
-	assert.Equal(t, int64(108_473_000), p.Scaled())
-
-	_, err = PriceFromScaled(-1)
-	require.ErrorIs(t, err, ErrNegative)
-}
-
 func TestPriceZeroValueIsValidZero(t *testing.T) {
 	var p Price
 	assert.True(t, p.IsZero())
@@ -103,11 +93,12 @@ func TestPriceSubExactlyZeroIsValid(t *testing.T) {
 }
 
 func TestPriceAddOverflow(t *testing.T) {
-	max, err := PriceFromScaled(math.MaxInt64)
-	require.NoError(t, err)
+	// Price{raw: ...} is a representation-boundary test construction, not a
+	// public API: num exports no raw-scaled constructor. See doc.go.
+	max := Price{raw: math.MaxInt64}
 	one := MustParsePrice("0.00000001")
 
-	_, err = max.Add(one)
+	_, err := max.Add(one)
 	require.ErrorIs(t, err, ErrOverflow)
 }
 

--- a/num/quantity.go
+++ b/num/quantity.go
@@ -1,0 +1,141 @@
+package num
+
+import "github.com/rustyeddy/trader/num/internal/fixed"
+
+// Quantity represents an authoritative order or position size.
+//
+// Quantity is backed by a scaled int64 at the common 1e8 scale (ADR-004).
+// Public values are non-negative; direction is represented by order side,
+// never by the sign of a quantity. Zero is representable and valid for states
+// such as a flat position or a fully closed lot; order construction will
+// eventually require a quantity greater than zero, but that is an order-level
+// rule, not a representation rule.
+//
+// Quantity increment, minimum order size, maximum order size, and
+// integral-only requirements are instrument or broker rules and are not
+// enforced here. The supported whole-unit range tops out at approximately
+// 92,233,720,368 — see ADR-004 for why that boundary was accepted rather than
+// widened for extreme high-supply-token cases.
+//
+// The zero value of Quantity is the exact value 0 and is valid.
+type Quantity struct {
+	raw int64
+}
+
+// ParseQuantity parses exact decimal text into a Quantity.
+//
+// Negative input is rejected, as are malformed text, excess precision, and
+// out-of-range values. Nothing is silently rounded or truncated.
+func ParseQuantity(s string) (Quantity, error) {
+	raw, err := fixed.Parse(s)
+	if err != nil {
+		return Quantity{}, wrapFixedErr(err)
+	}
+	if raw < 0 {
+		return Quantity{}, ErrNegative
+	}
+	return Quantity{raw: raw}, nil
+}
+
+// MustParseQuantity is like ParseQuantity but panics on error.
+//
+// It is intended for programmer-controlled constants, fixtures, and tests,
+// not for parsing external or market input.
+func MustParseQuantity(s string) Quantity {
+	q, err := ParseQuantity(s)
+	if err != nil {
+		panic(err)
+	}
+	return q
+}
+
+// QuantityFromScaled constructs a Quantity directly from a raw value already
+// scaled by 1e8.
+//
+// This is a narrowly scoped escape hatch for trusted internal code,
+// persistence reconstruction, and tests that exercise representation
+// boundaries directly. Ordinary callers should use ParseQuantity.
+func QuantityFromScaled(raw int64) (Quantity, error) {
+	if raw < 0 {
+		return Quantity{}, ErrNegative
+	}
+	return Quantity{raw: raw}, nil
+}
+
+// Scaled returns the raw value backing q, scaled by 1e8.
+func (q Quantity) Scaled() int64 {
+	return q.raw
+}
+
+// String returns q formatted as canonical decimal text.
+func (q Quantity) String() string {
+	return fixed.Format(q.raw)
+}
+
+// IsZero reports whether q is exactly zero.
+func (q Quantity) IsZero() bool {
+	return q.raw == 0
+}
+
+// Cmp compares q and o, returning -1, 0, or +1.
+func (q Quantity) Cmp(o Quantity) int {
+	return fixed.Cmp(q.raw, o.raw)
+}
+
+// Equal reports whether q and o are the exact same value.
+func (q Quantity) Equal(o Quantity) bool {
+	return q.raw == o.raw
+}
+
+// Add returns q+o using checked arithmetic.
+func (q Quantity) Add(o Quantity) (Quantity, error) {
+	raw, err := fixed.Add(q.raw, o.raw)
+	if err != nil {
+		return Quantity{}, wrapFixedErr(err)
+	}
+	return Quantity{raw: raw}, nil
+}
+
+// Sub returns q-o using checked arithmetic.
+//
+// Sub reports ErrNegative if the true difference would be negative: public
+// Quantity values are never negative. Reducing a position below zero is a
+// domain error to be reported at the position/order boundary, not a case for
+// this type to represent.
+func (q Quantity) Sub(o Quantity) (Quantity, error) {
+	raw, err := fixed.Sub(q.raw, o.raw)
+	if err != nil {
+		return Quantity{}, wrapFixedErr(err)
+	}
+	if raw < 0 {
+		return Quantity{}, ErrNegative
+	}
+	return Quantity{raw: raw}, nil
+}
+
+// MulRate returns q*r, rounded to nearest with ties to even.
+//
+// MulRate reports ErrNegative if r is negative enough to make the result
+// negative.
+func (q Quantity) MulRate(r Rate) (Quantity, error) {
+	raw, err := fixed.MulScaled(q.raw, r.raw, fixed.RoundHalfEven)
+	if err != nil {
+		return Quantity{}, wrapFixedErr(err)
+	}
+	if raw < 0 {
+		return Quantity{}, ErrNegative
+	}
+	return Quantity{raw: raw}, nil
+}
+
+// Div returns q/o as a dimensionless Rate, rounded to nearest with ties to
+// even.
+//
+// Div reports ErrDivideByZero when o is zero.
+func (q Quantity) Div(o Quantity) (Rate, error) {
+	raw, err := fixed.DivScaled(q.raw, o.raw, fixed.RoundHalfEven)
+	if err != nil {
+		return Rate{}, wrapFixedErr(err)
+	}
+	return Rate{raw: raw}, nil
+}

--- a/num/quantity.go
+++ b/num/quantity.go
@@ -49,24 +49,6 @@ func MustParseQuantity(s string) Quantity {
 	return q
 }
 
-// QuantityFromScaled constructs a Quantity directly from a raw value already
-// scaled by 1e8.
-//
-// This is a narrowly scoped escape hatch for trusted internal code,
-// persistence reconstruction, and tests that exercise representation
-// boundaries directly. Ordinary callers should use ParseQuantity.
-func QuantityFromScaled(raw int64) (Quantity, error) {
-	if raw < 0 {
-		return Quantity{}, ErrNegative
-	}
-	return Quantity{raw: raw}, nil
-}
-
-// Scaled returns the raw value backing q, scaled by 1e8.
-func (q Quantity) Scaled() int64 {
-	return q.raw
-}
-
 // String returns q formatted as canonical decimal text.
 func (q Quantity) String() string {
 	return fixed.Format(q.raw)

--- a/num/quantity_test.go
+++ b/num/quantity_test.go
@@ -1,0 +1,143 @@
+package num
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseQuantity(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr error
+	}{
+		{name: "zero", in: "0", want: "0"},
+		{name: "whole shares", in: "1000", want: "1000"},
+		{name: "fractional equity", in: "0.5", want: "0.5"},
+		{name: "fractional crypto", in: "0.00000001", want: "0.00000001"},
+		{name: "maximum representable", in: "92233720368.54775807", want: "92233720368.54775807"},
+
+		{name: "negative rejected", in: "-1", wantErr: ErrNegative},
+		{name: "malformed", in: "abc", wantErr: ErrSyntax},
+		{name: "excess precision", in: "1.123456789", wantErr: ErrPrecision},
+		{name: "out of range", in: "999999999999999999", wantErr: ErrRange},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseQuantity(tt.in)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Equal(t, Quantity{}, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}
+
+func TestMustParseQuantity(t *testing.T) {
+	assert.Equal(t, "5", MustParseQuantity("5").String())
+	assert.Panics(t, func() { MustParseQuantity("-1") })
+}
+
+func TestQuantityFromScaled(t *testing.T) {
+	q, err := QuantityFromScaled(1000 * 100_000_000)
+	require.NoError(t, err)
+	assert.Equal(t, "1000", q.String())
+
+	_, err = QuantityFromScaled(-1)
+	require.ErrorIs(t, err, ErrNegative)
+}
+
+func TestQuantityZeroValueIsValidZero(t *testing.T) {
+	var q Quantity
+	assert.True(t, q.IsZero())
+	assert.Equal(t, "0", q.String())
+}
+
+func TestQuantityComparison(t *testing.T) {
+	low := MustParseQuantity("10")
+	high := MustParseQuantity("20")
+
+	assert.Equal(t, -1, low.Cmp(high))
+	assert.Equal(t, 1, high.Cmp(low))
+	assert.Equal(t, 0, low.Cmp(low))
+	assert.True(t, low.Equal(MustParseQuantity("10")))
+	assert.False(t, low.Equal(high))
+}
+
+func TestQuantityAddSub(t *testing.T) {
+	a := MustParseQuantity("100")
+	b := MustParseQuantity("40")
+
+	sum, err := a.Add(b)
+	require.NoError(t, err)
+	assert.Equal(t, "140", sum.String())
+
+	diff, err := a.Sub(b)
+	require.NoError(t, err)
+	assert.Equal(t, "60", diff.String())
+}
+
+func TestQuantitySubRejectsNegativeResult(t *testing.T) {
+	a := MustParseQuantity("10")
+	b := MustParseQuantity("20")
+
+	_, err := a.Sub(b)
+	require.ErrorIs(t, err, ErrNegative)
+}
+
+func TestQuantitySubToExactlyZeroIsValid(t *testing.T) {
+	a := MustParseQuantity("10")
+	diff, err := a.Sub(a)
+	require.NoError(t, err)
+	assert.True(t, diff.IsZero())
+}
+
+func TestQuantityAddOverflow(t *testing.T) {
+	max, err := QuantityFromScaled(math.MaxInt64)
+	require.NoError(t, err)
+	one := MustParseQuantity("0.00000001")
+
+	_, err = max.Add(one)
+	require.ErrorIs(t, err, ErrOverflow)
+}
+
+func TestQuantityMulRate(t *testing.T) {
+	// Realistic financing-rate application: 1000 units at a 0.005 rate.
+	qty := MustParseQuantity("1000")
+	rate := MustParseRate("0.005")
+
+	got, err := qty.MulRate(rate)
+	require.NoError(t, err)
+	assert.Equal(t, "5", got.String())
+}
+
+func TestQuantityMulRateRejectsNegativeResult(t *testing.T) {
+	qty := MustParseQuantity("100")
+	rate := MustParseRate("-0.5")
+
+	_, err := qty.MulRate(rate)
+	require.ErrorIs(t, err, ErrNegative)
+}
+
+func TestQuantityDiv(t *testing.T) {
+	a := MustParseQuantity("100")
+	b := MustParseQuantity("3")
+
+	got, err := a.Div(b)
+	require.NoError(t, err)
+	assert.Equal(t, "33.33333333", got.String())
+}
+
+func TestQuantityDivByZero(t *testing.T) {
+	a := MustParseQuantity("1")
+	_, err := a.Div(Quantity{})
+	require.ErrorIs(t, err, ErrDivideByZero)
+}

--- a/num/quantity_test.go
+++ b/num/quantity_test.go
@@ -46,15 +46,6 @@ func TestMustParseQuantity(t *testing.T) {
 	assert.Panics(t, func() { MustParseQuantity("-1") })
 }
 
-func TestQuantityFromScaled(t *testing.T) {
-	q, err := QuantityFromScaled(1000 * 100_000_000)
-	require.NoError(t, err)
-	assert.Equal(t, "1000", q.String())
-
-	_, err = QuantityFromScaled(-1)
-	require.ErrorIs(t, err, ErrNegative)
-}
-
 func TestQuantityZeroValueIsValidZero(t *testing.T) {
 	var q Quantity
 	assert.True(t, q.IsZero())
@@ -101,11 +92,12 @@ func TestQuantitySubToExactlyZeroIsValid(t *testing.T) {
 }
 
 func TestQuantityAddOverflow(t *testing.T) {
-	max, err := QuantityFromScaled(math.MaxInt64)
-	require.NoError(t, err)
+	// Quantity{raw: ...} is a representation-boundary test construction, not
+	// a public API: num exports no raw-scaled constructor. See doc.go.
+	max := Quantity{raw: math.MaxInt64}
 	one := MustParseQuantity("0.00000001")
 
-	_, err = max.Add(one)
+	_, err := max.Add(one)
 	require.ErrorIs(t, err, ErrOverflow)
 }
 

--- a/num/rate.go
+++ b/num/rate.go
@@ -44,25 +44,6 @@ func MustParseRate(s string) Rate {
 	return r
 }
 
-// RateFromScaled constructs a Rate directly from a raw value already scaled by
-// 1e8.
-//
-// This is a narrowly scoped escape hatch for trusted internal code,
-// persistence reconstruction, and tests that exercise representation
-// boundaries directly.  Ordinary callers should use ParseRate.
-func RateFromScaled(raw int64) Rate {
-	return Rate{raw: raw}
-}
-
-// Scaled returns the raw value backing r, scaled by 1e8.
-//
-// This exposes the same representation detail as RateFromScaled and exists
-// for the same narrowly scoped callers: persistence, encoding, and
-// representation-boundary tests.
-func (r Rate) Scaled() int64 {
-	return r.raw
-}
-
 // String returns r formatted as canonical decimal text.
 func (r Rate) String() string {
 	return fixed.Format(r.raw)

--- a/num/rate.go
+++ b/num/rate.go
@@ -1,0 +1,154 @@
+package num
+
+import "github.com/rustyeddy/trader/num/internal/fixed"
+
+// Rate is Trader's foundational exact dimensionless numeric type.
+//
+// Rate is signed and backed by a scaled int64 at the common 1e8 scale (ADR-004).
+// It represents percentages, financing rates, conversion rates, ratios,
+// bounded oscillators, and any other dimensionless quantity.  Zero validity
+// and semantic bounds depend on use; Rate itself imposes none.  Domain
+// packages that need direction, bounds, or a specific interpretation should
+// introduce a semantic wrapper around Rate rather than weaken this type — see
+// the package doc comment for why Percent and Ratio are deferred rather than
+// added here.
+//
+// The zero value of Rate is the exact value 0 and is valid.
+type Rate struct {
+	raw int64
+}
+
+// ParseRate parses exact decimal text into a Rate.
+//
+// See the package doc comment and ADR-004 for the accepted grammar: an
+// optional sign, decimal digits, and up to eight fraction digits.  Malformed
+// input, excess precision, and out-of-range values are rejected; nothing is
+// silently rounded.
+func ParseRate(s string) (Rate, error) {
+	raw, err := fixed.Parse(s)
+	if err != nil {
+		return Rate{}, wrapFixedErr(err)
+	}
+	return Rate{raw: raw}, nil
+}
+
+// MustParseRate is like ParseRate but panics on error.
+//
+// It is intended for programmer-controlled constants, fixtures, and tests,
+// not for parsing external or market input.
+func MustParseRate(s string) Rate {
+	r, err := ParseRate(s)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// RateFromScaled constructs a Rate directly from a raw value already scaled by
+// 1e8.
+//
+// This is a narrowly scoped escape hatch for trusted internal code,
+// persistence reconstruction, and tests that exercise representation
+// boundaries directly.  Ordinary callers should use ParseRate.
+func RateFromScaled(raw int64) Rate {
+	return Rate{raw: raw}
+}
+
+// Scaled returns the raw value backing r, scaled by 1e8.
+//
+// This exposes the same representation detail as RateFromScaled and exists
+// for the same narrowly scoped callers: persistence, encoding, and
+// representation-boundary tests.
+func (r Rate) Scaled() int64 {
+	return r.raw
+}
+
+// String returns r formatted as canonical decimal text.
+func (r Rate) String() string {
+	return fixed.Format(r.raw)
+}
+
+// IsZero reports whether r is exactly zero.
+func (r Rate) IsZero() bool {
+	return r.raw == 0
+}
+
+// Sign returns -1, 0, or +1 according to the sign of r.
+func (r Rate) Sign() int {
+	return fixed.Sign(r.raw)
+}
+
+// Cmp compares r and o, returning -1, 0, or +1.
+func (r Rate) Cmp(o Rate) int {
+	return fixed.Cmp(r.raw, o.raw)
+}
+
+// Equal reports whether r and o are the exact same value.
+func (r Rate) Equal(o Rate) bool {
+	return r.raw == o.raw
+}
+
+// Add returns r+o using checked arithmetic.
+func (r Rate) Add(o Rate) (Rate, error) {
+	raw, err := fixed.Add(r.raw, o.raw)
+	if err != nil {
+		return Rate{}, wrapFixedErr(err)
+	}
+	return Rate{raw: raw}, nil
+}
+
+// Sub returns r-o using checked arithmetic.
+func (r Rate) Sub(o Rate) (Rate, error) {
+	raw, err := fixed.Sub(r.raw, o.raw)
+	if err != nil {
+		return Rate{}, wrapFixedErr(err)
+	}
+	return Rate{raw: raw}, nil
+}
+
+// Neg returns -r.
+//
+// Neg rejects the one Rate whose negation is not representable: the value
+// backed by math.MinInt64.
+func (r Rate) Neg() (Rate, error) {
+	raw, err := fixed.Neg(r.raw)
+	if err != nil {
+		return Rate{}, wrapFixedErr(err)
+	}
+	return Rate{raw: raw}, nil
+}
+
+// Abs returns the absolute value of r.
+//
+// Abs rejects the one Rate whose absolute value is not representable: the
+// value backed by math.MinInt64.
+func (r Rate) Abs() (Rate, error) {
+	raw, err := fixed.Abs(r.raw)
+	if err != nil {
+		return Rate{}, wrapFixedErr(err)
+	}
+	return Rate{raw: raw}, nil
+}
+
+// MulRate returns r*o, rounded to nearest with ties to even.
+//
+// The product is computed with a widened intermediate before the common scale
+// is restored, per ADR-004; it is never computed as raw*raw.
+func (r Rate) MulRate(o Rate) (Rate, error) {
+	raw, err := fixed.MulScaled(r.raw, o.raw, fixed.RoundHalfEven)
+	if err != nil {
+		return Rate{}, wrapFixedErr(err)
+	}
+	return Rate{raw: raw}, nil
+}
+
+// DivRate returns r/o, rounded to nearest with ties to even.
+//
+// DivRate reports ErrDivideByZero when o is zero.
+func (r Rate) DivRate(o Rate) (Rate, error) {
+	raw, err := fixed.DivScaled(r.raw, o.raw, fixed.RoundHalfEven)
+	if err != nil {
+		return Rate{}, wrapFixedErr(err)
+	}
+	return Rate{raw: raw}, nil
+}

--- a/num/rate_test.go
+++ b/num/rate_test.go
@@ -54,12 +54,6 @@ func TestRateZeroValueIsValidZero(t *testing.T) {
 	assert.Equal(t, 0, r.Sign())
 }
 
-func TestRateFromScaledAndScaled(t *testing.T) {
-	r := RateFromScaled(105_000_000)
-	assert.Equal(t, "1.05", r.String())
-	assert.Equal(t, int64(105_000_000), r.Scaled())
-}
-
 func TestRateComparison(t *testing.T) {
 	low := MustParseRate("1.00")
 	high := MustParseRate("2.00")
@@ -93,19 +87,21 @@ func TestRateArithmetic(t *testing.T) {
 }
 
 func TestRateArithmeticOverflow(t *testing.T) {
-	max := RateFromScaled(math.MaxInt64)
+	// Rate{raw: ...} is a representation-boundary test construction, not a
+	// public API: num exports no raw-scaled constructor. See doc.go.
+	max := Rate{raw: math.MaxInt64}
 	one := MustParseRate("0.00000001")
 
 	_, err := max.Add(one)
 	require.ErrorIs(t, err, ErrOverflow)
 
-	min := RateFromScaled(math.MinInt64)
+	min := Rate{raw: math.MinInt64}
 	_, err = min.Sub(one)
 	require.ErrorIs(t, err, ErrUnderflow)
 }
 
 func TestRateNegAbsMinInt64(t *testing.T) {
-	min := RateFromScaled(math.MinInt64)
+	min := Rate{raw: math.MinInt64}
 
 	_, err := min.Neg()
 	require.ErrorIs(t, err, ErrNotRepresentable)

--- a/num/rate_test.go
+++ b/num/rate_test.go
@@ -1,0 +1,134 @@
+package num
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRate(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr error
+	}{
+		{name: "zero", in: "0", want: "0"},
+		{name: "positive", in: "1.05", want: "1.05"},
+		{name: "negative", in: "-0.005", want: "-0.005"},
+		{name: "full precision", in: "0.00000001", want: "0.00000001"},
+		{name: "minimum representable", in: "-92233720368.54775808", want: "-92233720368.54775808"},
+		{name: "maximum representable", in: "92233720368.54775807", want: "92233720368.54775807"},
+
+		{name: "malformed", in: "abc", wantErr: ErrSyntax},
+		{name: "empty", in: "", wantErr: ErrSyntax},
+		{name: "excess precision", in: "1.123456789", wantErr: ErrPrecision},
+		{name: "out of range", in: "999999999999999999", wantErr: ErrRange},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRate(tt.in)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Equal(t, Rate{}, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}
+
+func TestMustParseRate(t *testing.T) {
+	assert.Equal(t, "1.5", MustParseRate("1.5").String())
+	assert.Panics(t, func() { MustParseRate("not a rate") })
+}
+
+func TestRateZeroValueIsValidZero(t *testing.T) {
+	var r Rate
+	assert.True(t, r.IsZero())
+	assert.Equal(t, "0", r.String())
+	assert.Equal(t, 0, r.Sign())
+}
+
+func TestRateFromScaledAndScaled(t *testing.T) {
+	r := RateFromScaled(105_000_000)
+	assert.Equal(t, "1.05", r.String())
+	assert.Equal(t, int64(105_000_000), r.Scaled())
+}
+
+func TestRateComparison(t *testing.T) {
+	low := MustParseRate("1.00")
+	high := MustParseRate("2.00")
+
+	assert.Equal(t, -1, low.Cmp(high))
+	assert.Equal(t, 1, high.Cmp(low))
+	assert.Equal(t, 0, low.Cmp(low))
+	assert.True(t, low.Equal(MustParseRate("1.00")))
+	assert.False(t, low.Equal(high))
+}
+
+func TestRateArithmetic(t *testing.T) {
+	a := MustParseRate("1.5")
+	b := MustParseRate("0.5")
+
+	sum, err := a.Add(b)
+	require.NoError(t, err)
+	assert.Equal(t, "2", sum.String())
+
+	diff, err := a.Sub(b)
+	require.NoError(t, err)
+	assert.Equal(t, "1", diff.String())
+
+	neg, err := a.Neg()
+	require.NoError(t, err)
+	assert.Equal(t, "-1.5", neg.String())
+
+	abs, err := neg.Abs()
+	require.NoError(t, err)
+	assert.Equal(t, "1.5", abs.String())
+}
+
+func TestRateArithmeticOverflow(t *testing.T) {
+	max := RateFromScaled(math.MaxInt64)
+	one := MustParseRate("0.00000001")
+
+	_, err := max.Add(one)
+	require.ErrorIs(t, err, ErrOverflow)
+
+	min := RateFromScaled(math.MinInt64)
+	_, err = min.Sub(one)
+	require.ErrorIs(t, err, ErrUnderflow)
+}
+
+func TestRateNegAbsMinInt64(t *testing.T) {
+	min := RateFromScaled(math.MinInt64)
+
+	_, err := min.Neg()
+	require.ErrorIs(t, err, ErrNotRepresentable)
+
+	_, err = min.Abs()
+	require.ErrorIs(t, err, ErrNotRepresentable)
+}
+
+func TestRateMulDiv(t *testing.T) {
+	a := MustParseRate("1.05")
+	b := MustParseRate("2.00")
+
+	product, err := a.MulRate(b)
+	require.NoError(t, err)
+	assert.Equal(t, "2.1", product.String())
+
+	quotient, err := b.DivRate(a)
+	require.NoError(t, err)
+	assert.Equal(t, "1.9047619", quotient.String())
+}
+
+func TestRateDivByZero(t *testing.T) {
+	a := MustParseRate("1.00")
+	_, err := a.DivRate(Rate{})
+	require.ErrorIs(t, err, ErrDivideByZero)
+}


### PR DESCRIPTION
## Summary

Clean-room implementation of Trader's exact foundational numeric types per ADR-004:

- `num/internal/fixed`: private scaled-integer representation kernel — common 1e8 scale, checked int64 add/sub/neg/abs with explicit `MinInt64` rejection, widened 128-bit signed multiplication/division, all four ADR-004 rounding policies, exact decimal parse/format with no `float64` anywhere in the path.
- `num.Rate`, `num.Price`, `num.Quantity`, `num.Currency`, `num.Money` — semantic types built on the kernel. `Price`/`Quantity` are non-negative by construction; `Money` requires an explicit `Currency` and rejects cross-currency arithmetic; `Currency` validates structurally only (3–5 uppercase ASCII letters), with no embedded ISO-4217/crypto registry.
- Text and JSON encoding for all five types. `Price`/`Quantity`/`Rate` serialize as canonical decimal strings; `Money`'s JSON form is `{"amount":"...","currency":"..."}`, its text form is the distinct `"123.45 USD"` canonical string.
- Architecture enforcement tests: an AST-based scan rejecting any `float32`/`float64` under `num`, and a second, redundant check (on top of Go's `internal/` visibility) that no package outside `num` imports `num/internal/fixed`.

Each commit is coherent and leaves the test suite green; 8 commits total.

## Why

Authoritative prices, quantities, money, and rates must not depend on binary floating-point approximation, and must be exact across backtest, paper, and live paths. See `docs/arch/adr-004-exact-numeric-representation.org` and issue #22.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./num/...` — clean
- [x] `gofmt -l num/` — clean
- [x] `go test -race ./num/...` — clean
- [x] `make check` — clean except two **pre-existing** failures in `test/internal/numericstudy` and `test/internal/quantitystudy` (unguarded generated-table markers referencing the frozen ADR-004 doc); confirmed identical on `main` prior to this branch, unrelated to #22, left untouched
- [x] Table-driven tests covering zero/positive/negative/boundary/`MinInt64`/overflow/underflow/div-by-zero/cross-currency/rounding-midpoint cases for every operation
- [x] 6 fuzz targets (`FuzzFormatParse`, `FuzzParseFormat`, `FuzzAddSub`, `FuzzMulDivScaled`, `FuzzPriceJSONRoundTrip`, `FuzzMoneyTextRoundTrip`), each run locally for 10–15s with no failures

## Documentation

- `num/doc.go` documents the `num` / `num/internal/fixed` boundary, the context-free-vs-context-dependent arithmetic split, and why `Percent`/`Ratio` are deferred.
- Per-type doc comments explain zero/negative-value policy and intentionally absent operations (e.g. no implicit currency conversion, no public `Rounding` selector yet).

## Intentionally deferred (not in scope for #22)

- `Percent`/`Ratio` semantic wrappers
- Public `num.Rounding` API (kernel supports all 4 policies; only half-even is exposed until a caller needs to select one)
- Database persistence adapters (scaled constructors are in place to support this later)
- Currency registry (ISO-4217/crypto) — explicitly kept out of `num` per architecture decision; owned by future instrument/venue packages
- CI matrix expansion for cross-platform determinism coverage

Issue: #22