### PR TITLE
docs: add missing quantitystudy table markers to ADR-004

### DIFF
--- a/docs/arch/adr-004-exact-numeric-representation.org
+++ b/docs/arch/adr-004-exact-numeric-representation.org
@@ -714,7 +714,7 @@ than the scale holds; =RANGE= marks one exceeding =int64= at that scale:
 ** Quantity precision/range frontier
 
 No scaled =int64= holds both the finest and the largest quantity in the
-pressure matrix:
+representation matrix above:
 
 # BEGIN quantitystudy:frontier
 | Scale | Smallest unit |   Max whole units | Holds 1 satoshi | Holds 1e12 units |

--- a/docs/arch/adr-004-exact-numeric-representation.org
+++ b/docs/arch/adr-004-exact-numeric-representation.org
@@ -686,6 +686,76 @@ quantities, across every candidate scale:
 | SHIB 1e12 units | 1,000,000,000,000 |        n/a |      n/a | 9,223,372x | 922,337x |
 # END numericstudy:notional-all
 
+** Quantity representation matrix
+
+Representative quantities stored at each candidate scale, from
+=test/internal/quantitystudy=.  =PRECISION= marks a value needing more decimals
+than the scale holds; =RANGE= marks one exceeding =int64= at that scale:
+
+# BEGIN quantitystudy:quantity-matrix
+| Class    | Symbol  |      Quantity | Dec | Integral |                 1e6 |               1e7 |                1e8 |                 1e9 |
+|----------+---------+---------------+-----+----------+---------------------+-------------------+--------------------+---------------------|
+| FX       | EUR/USD |             1 |   0 | no       |             1000000 |          10000000 |          100000000 |          1000000000 |
+| FX       | EUR/USD |         10000 |   0 | no       |         10000000000 |      100000000000 |      1000000000000 |      10000000000000 |
+| FX       | EUR/USD |      10000000 |   0 | no       |      10000000000000 |   100000000000000 |   1000000000000000 |   10000000000000000 |
+| FX       | EUR/USD |    1000000000 |   0 | no       |    1000000000000000 | 10000000000000000 | 100000000000000000 | 1000000000000000000 |
+| Equity   | SPY     |             1 |   0 | no       |             1000000 |          10000000 |          100000000 |          1000000000 |
+| Equity   | SPY     |           0.5 |   1 | no       |              500000 |           5000000 |           50000000 |           500000000 |
+| Equity   | SPY     |      0.000001 |   6 | no       |                   1 |                10 |                100 |                1000 |
+| Futures  | ES      |             1 |   0 | yes      |             1000000 |          10000000 |          100000000 |          1000000000 |
+| Futures  | ES      |             3 |   0 | yes      |             3000000 |          30000000 |          300000000 |          3000000000 |
+| Futures  | ES      |         10000 |   0 | yes      |         10000000000 |      100000000000 |      1000000000000 |      10000000000000 |
+| Crypto   | BTC     |             1 |   0 | no       |             1000000 |          10000000 |          100000000 |          1000000000 |
+| Crypto   | BTC     |    0.00000001 |   8 | no       |           PRECISION |         PRECISION |                  1 |                  10 |
+| Token    | SHIB    | 1000000000000 |   0 | no       | 1000000000000000000 |             RANGE |              RANGE |               RANGE |
+| Boundary | ZERO    |             0 |   0 | no       |                   0 |                 0 |                  0 |                   0 |
+# END quantitystudy:quantity-matrix
+
+** Quantity precision/range frontier
+
+No scaled =int64= holds both the finest and the largest quantity in the
+pressure matrix:
+
+# BEGIN quantitystudy:frontier
+| Scale | Smallest unit |   Max whole units | Holds 1 satoshi | Holds 1e12 units |
+|-------+---------------+-------------------+-----------------+------------------|
+| 1e6   |      0.000001 | 9,223,372,036,854 | no              | yes              |
+| 1e7   |     0.0000001 |   922,337,203,685 | no              | no               |
+| 1e8   |    0.00000001 |    92,233,720,368 | yes             | no               |
+| 1e9   |   0.000000001 |     9,223,372,036 | yes             | no               |
+# END quantitystudy:frontier
+
+** Quantity instrument rules
+
+Representation scale is separate from what instrument rules permit trading:
+
+# BEGIN quantitystudy:instrument-rules
+| Symbol  |  Increment |  Minimum |   Maximum | Integral only |
+|---------+------------+----------+-----------+---------------|
+| EUR/USD |          1 |        1 | 100000000 | no            |
+| SPY     |   0.000001 | 0.000001 |         — | no            |
+| ES      |          1 |        1 |     10000 | yes           |
+| BTC     | 0.00000001 |   0.0001 |         — | no            |
+| SHIB    |          1 |     1000 |         — | no            |
+# END quantitystudy:instrument-rules
+
+** Price x Quantity notional intermediates
+
+With =Price= at =1e8= and =Quantity= scaled too, =Price x Quantity= is
+double-scaled, so the intermediate overflows =int64= before the descaling
+divide at every candidate scale:
+
+# BEGIN quantitystudy:notional
+| Case            |           Price |      Quantity |      1e6 |      1e7 |      1e8 |      1e9 |
+|-----------------+-----------------+---------------+----------+----------+----------+----------|
+| BRK.A block     |       750000.00 |         10000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| FX 10M notional |         1.08473 |      10000000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| FX 1B notional  |         1.08473 |    1000000000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| BTC 1k coins    | 150000.12345678 |          1000 | OVERFLOW | OVERFLOW | OVERFLOW | OVERFLOW |
+| SPY fractional  |          700.12 |           0.5 |     263x |      26x |       2x | OVERFLOW |
+| SHIB 1e12 units |      0.00000001 | 1000000000000 |       9x |      n/a |      n/a |      n/a |
+# END quantitystudy:notional
+
 * Consequences
 
 ** Positive consequences


### PR DESCRIPTION
## Summary

- `test/internal/quantitystudy`'s `TestGeneratedTables` was failing on `main` because `docs/arch/adr-004-exact-numeric-representation.org` had zero `quantitystudy:` marker regions. #52 fixed the same problem for `numericstudy` but didn't touch `quantitystudy`.
- Added a "Quantity representation matrix" section (mirroring the existing numericstudy section) with marker pairs for all four fragments the package generates: `quantity-matrix`, `frontier`, `instrument-rules`, `notional`.
- Ran `go test ./test/internal/quantitystudy/ -run TestGeneratedTables -update` to fill the regions from the generator. Content matches `test/internal/quantitystudy/README.md` exactly, so nothing was invented — it's the same evidence already checked into the study's own README, now also embedded in the ADR it feeds.

## Why

`TestGeneratedTables` is a drift guard: it fails loudly, by design, when a study's generated tables aren't embedded anywhere in the doc they're meant to keep honest. The ADR was frozen before this study's tables were added to it, so the guard had nothing to check against and failed.

## Test plan

- [x] `go test ./test/internal/quantitystudy/... -v` — all pass, including `TestGeneratedTables` and `TestEveryFragmentIsUsed`
- [x] `make check` (fmt-check, vet, test, race) — fully green on this branch
- [x] Diffed the newly-generated ADR tables against `test/internal/quantitystudy/README.md` — identical content

🤖 Generated with [Claude Code](https://claude.com/claude-code)