### PR TITLE
config: typed application configuration framework (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,46 @@ Trader's architecture is guided by a small set of principles:
   for orders, fills, positions, and balances; Trader maintains reconciled
   projections for speed, reporting, and recovery.
 
+## Packages
+
+### num
+
+`num` provides Trader's exact numeric types — `Price`, `Quantity`, `Rate`,
+`Currency`, and `Money` — backed by scaled integers instead of binary
+floating point, so authoritative values never suffer float rounding error.
+Construct values from decimal text, then use their checked arithmetic
+methods; malformed input and cross-currency mistakes are caught as errors
+rather than silently miscomputed:
+
+```go
+price, err := num.ParsePrice("108.473")
+qty := num.MustParseQuantity("100")
+fee, err := price.MulRate(num.MustParseRate("0.001"))
+```
+
+See [ADR-004](docs/arch/adr-004-exact-numeric-representation.org) for the
+full design rationale.
+
+### config
+
+`config` assembles typed application configuration for Trader's executable
+composition roots, resolving each field from defaults, a YAML file, the
+environment, and command-line overrides, in that precedence order. Define a
+struct with tags for defaults, required fields, and secrets, then load it in
+one call:
+
+```go
+type Settings struct {
+    Port     int    `default:"8080"`
+    APIKey   string `required:"true" secret:"true"`
+}
+
+cfg, err := config.Load[Settings](config.Options{EnvPrefix: "TRADER"})
+```
+
+See the [package doc comment](config/doc.go) for the tag reference and
+environment-variable naming convention.
+
 ## Documentation
 
 - [Framework requirements](docs/arch/trader-framework-requirements.org)

--- a/config/arch_test.go
+++ b/config/arch_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file enforces, mechanically, the architectural constraint issue #20
+// states in prose: "Domain packages must not read files, flags, or
+// environment variables." Composition roots (cmd/) and test harnesses
+// (test/) are exempt — they are exactly where configuration assembly
+// belongs — and so is config itself, which necessarily calls os.Getenv and
+// friends to implement the environment source.
+//
+// Unlike num's equivalent check (which duplicates a guarantee the Go
+// compiler already enforces via internal/ visibility), nothing stops a
+// domain package from importing "os" or "flag" today — this test is the
+// only thing that would catch it.
+
+// exemptPrefixes are repository-relative path prefixes allowed to touch the
+// process environment or command-line flags directly.
+var exemptPrefixes = []string{"config", "cmd", "test", ".git"}
+
+func TestDomainPackagesDoNotReadEnvOrFlags(t *testing.T) {
+	root := repoRoot(t)
+
+	var violations []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+
+		if d.IsDir() {
+			if rel != "." && isExempt(rel) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".go") || isExempt(rel) {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return err
+		}
+
+		for _, imp := range file.Imports {
+			if strings.Trim(imp.Path.Value, `"`) == "flag" {
+				violations = append(violations, rel+": imports \"flag\"")
+			}
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "os" {
+				return true
+			}
+			if sel.Sel.Name == "Getenv" || sel.Sel.Name == "LookupEnv" || sel.Sel.Name == "Environ" {
+				violations = append(violations,
+					rel+": calls os."+sel.Sel.Name+" at "+fset.Position(call.Pos()).String())
+			}
+			return true
+		})
+		return nil
+	})
+	require.NoError(t, err)
+
+	for _, v := range violations {
+		assert.Fail(t, "package outside config/cmd/test reads the environment or flags directly", v)
+	}
+}
+
+func isExempt(rel string) bool {
+	for _, p := range exemptPrefixes {
+		if rel == p || strings.HasPrefix(rel, p+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	for range 10 {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("config: no go.mod found above " + dir)
+	return ""
+}

--- a/config/decode.go
+++ b/config/decode.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"encoding"
+	"net/url"
+	"reflect"
+	"slices"
+	"strconv"
+	"time"
+)
+
+var (
+	textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+	durationType        = reflect.TypeOf(time.Duration(0))
+	urlType             = reflect.TypeOf(url.URL{})
+)
+
+// isTextUnmarshaler reports whether a value of type t, or a pointer to one,
+// implements encoding.TextUnmarshaler. This is what lets any num type
+// (num.Price, num.Currency, ...) or a caller's own type be used directly as
+// a config field type.
+func isTextUnmarshaler(t reflect.Type) bool {
+	return reflect.PointerTo(t).Implements(textUnmarshalerType) || t.Implements(textUnmarshalerType)
+}
+
+// isLeafType reports whether t is a type collectLeaves should record as a
+// scalar leaf rather than recurse into. One level of pointer indirection is
+// permitted and marks the field as an optional value.
+func isLeafType(t reflect.Type) bool {
+	if t.Kind() == reflect.Pointer {
+		return isLeafType(t.Elem())
+	}
+	if t == urlType || isTextUnmarshaler(t) {
+		return true
+	}
+	switch t.Kind() {
+	case reflect.String, reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
+// decodeLeaf parses raw into l.Value. For a pointer (optional) field, it
+// allocates the pointee, decodes into it, and only then sets the pointer, so
+// a failed parse never leaves a non-nil pointer to a half-set value behind.
+func decodeLeaf(l *leaf, raw string) error {
+	target := l.Value
+
+	if target.Kind() == reflect.Pointer {
+		elem := reflect.New(target.Type().Elem())
+		if err := decodeScalar(elem.Elem(), raw); err != nil {
+			return err
+		}
+		if err := checkEnum(l, elem.Elem()); err != nil {
+			return err
+		}
+		target.Set(elem)
+		return nil
+	}
+
+	if err := decodeScalar(target, raw); err != nil {
+		return err
+	}
+	return checkEnum(l, target)
+}
+
+// decodeScalar parses raw into rv, an addressable, non-pointer value.
+func decodeScalar(rv reflect.Value, raw string) error {
+	if addr := rv.Addr(); addr.Type().Implements(textUnmarshalerType) {
+		return addr.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(raw))
+	}
+
+	switch {
+	case rv.Type() == urlType:
+		u, err := url.Parse(raw)
+		if err != nil {
+			return err
+		}
+		rv.Set(reflect.ValueOf(*u))
+		return nil
+
+	case rv.Type() == durationType:
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return err
+		}
+		rv.SetInt(int64(d))
+		return nil
+	}
+
+	switch rv.Kind() {
+	case reflect.String:
+		rv.SetString(raw)
+		return nil
+
+	case reflect.Bool:
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return err
+		}
+		rv.SetBool(b)
+		return nil
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(raw, 10, rv.Type().Bits())
+		if err != nil {
+			return err
+		}
+		rv.SetInt(n)
+		return nil
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n, err := strconv.ParseUint(raw, 10, rv.Type().Bits())
+		if err != nil {
+			return err
+		}
+		rv.SetUint(n)
+		return nil
+
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(raw, rv.Type().Bits())
+		if err != nil {
+			return err
+		}
+		rv.SetFloat(f)
+		return nil
+
+	default:
+		return ErrUnsupportedType
+	}
+}
+
+// checkEnum validates rv against l's enum tag, when both apply. The enum tag
+// only constrains string-kind fields; it is silently ignored on any other
+// type rather than treated as a configuration error in the destination
+// struct itself.
+func checkEnum(l *leaf, rv reflect.Value) error {
+	if len(l.Enum) == 0 || rv.Kind() != reflect.String {
+		return nil
+	}
+	if slices.Contains(l.Enum, rv.String()) {
+		return nil
+	}
+	return ErrEnum
+}

--- a/config/decode_test.go
+++ b/config/decode_test.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// logLevel is a test-only TextUnmarshaler, standing in for the kind of
+// caller-defined enum type (or a num type) config must decode without any
+// special-casing beyond the interface.
+type logLevel string
+
+func (l *logLevel) UnmarshalText(text []byte) error {
+	s := logLevel(text)
+	switch s {
+	case "debug", "info", "warn", "error":
+		*l = s
+		return nil
+	default:
+		return fmt.Errorf("unknown log level %q", text)
+	}
+}
+
+func addressableOf[T any](t *testing.T, v *T) reflect.Value {
+	t.Helper()
+	return reflect.ValueOf(v).Elem()
+}
+
+func TestDecodeScalarBasicKinds(t *testing.T) {
+	var s string
+	require.NoError(t, decodeScalar(addressableOf(t, &s), "hello"))
+	assert.Equal(t, "hello", s)
+
+	var b bool
+	require.NoError(t, decodeScalar(addressableOf(t, &b), "true"))
+	assert.True(t, b)
+
+	var i int
+	require.NoError(t, decodeScalar(addressableOf(t, &i), "-42"))
+	assert.Equal(t, -42, i)
+
+	var i8 int8
+	require.NoError(t, decodeScalar(addressableOf(t, &i8), "127"))
+	assert.Equal(t, int8(127), i8)
+
+	var u uint
+	require.NoError(t, decodeScalar(addressableOf(t, &u), "42"))
+	assert.Equal(t, uint(42), u)
+
+	var u16 uint16
+	require.NoError(t, decodeScalar(addressableOf(t, &u16), "65535"))
+	assert.Equal(t, uint16(65535), u16)
+
+	var f32 float32
+	require.NoError(t, decodeScalar(addressableOf(t, &f32), "1.5"))
+	assert.Equal(t, float32(1.5), f32)
+
+	var f64 float64
+	require.NoError(t, decodeScalar(addressableOf(t, &f64), "1.25"))
+	assert.Equal(t, 1.25, f64)
+}
+
+func TestDecodeScalarRejectsMalformed(t *testing.T) {
+	var i int
+	err := decodeScalar(addressableOf(t, &i), "not-a-number")
+	require.Error(t, err)
+
+	var b bool
+	err = decodeScalar(addressableOf(t, &b), "not-a-bool")
+	require.Error(t, err)
+}
+
+func TestDecodeScalarIntOverflow(t *testing.T) {
+	var i8 int8
+	err := decodeScalar(addressableOf(t, &i8), "128") // one past int8 max
+	require.Error(t, err)
+}
+
+func TestDecodeScalarDuration(t *testing.T) {
+	var d time.Duration
+	require.NoError(t, decodeScalar(addressableOf(t, &d), "1h30m"))
+	assert.Equal(t, 90*time.Minute, d)
+}
+
+func TestDecodeScalarDurationRejectsMalformed(t *testing.T) {
+	var d time.Duration
+	err := decodeScalar(addressableOf(t, &d), "not-a-duration")
+	require.Error(t, err)
+}
+
+func TestDecodeScalarURL(t *testing.T) {
+	var u url.URL
+	require.NoError(t, decodeScalar(addressableOf(t, &u), "https://example.com/path"))
+	assert.Equal(t, "https", u.Scheme)
+	assert.Equal(t, "example.com", u.Host)
+}
+
+func TestDecodeScalarTextUnmarshaler(t *testing.T) {
+	var l logLevel
+	require.NoError(t, decodeScalar(addressableOf(t, &l), "warn"))
+	assert.Equal(t, logLevel("warn"), l)
+
+	err := decodeScalar(addressableOf(t, &l), "bogus")
+	require.Error(t, err)
+}
+
+func TestDecodeLeafOptionalPointerAllocatesOnlyOnSuccess(t *testing.T) {
+	var target struct{ Port *int }
+	l := &leaf{Path: "port", Value: reflect.ValueOf(&target).Elem().Field(0)}
+
+	require.NoError(t, decodeLeaf(l, "8080"))
+	require.NotNil(t, target.Port)
+	assert.Equal(t, 8080, *target.Port)
+}
+
+func TestDecodeLeafOptionalPointerLeftNilOnFailure(t *testing.T) {
+	var target struct{ Port *int }
+	l := &leaf{Path: "port", Value: reflect.ValueOf(&target).Elem().Field(0)}
+
+	err := decodeLeaf(l, "not-a-port")
+	require.Error(t, err)
+	assert.Nil(t, target.Port, "a failed parse must not leave a pointer to a half-set value")
+}
+
+func TestDecodeLeafEnumAccepts(t *testing.T) {
+	var target struct{ Level string }
+	l := &leaf{Path: "level", Enum: []string{"debug", "info", "warn"}, Value: reflect.ValueOf(&target).Elem().Field(0)}
+
+	require.NoError(t, decodeLeaf(l, "info"))
+	assert.Equal(t, "info", target.Level)
+}
+
+func TestDecodeLeafEnumRejects(t *testing.T) {
+	var target struct{ Level string }
+	l := &leaf{Path: "level", Enum: []string{"debug", "info", "warn"}, Value: reflect.ValueOf(&target).Elem().Field(0)}
+
+	err := decodeLeaf(l, "trace")
+	require.ErrorIs(t, err, ErrEnum)
+}
+
+func TestDecodeLeafEnumOnOptionalPointer(t *testing.T) {
+	var target struct{ Level *string }
+	l := &leaf{Path: "level", Enum: []string{"debug", "info"}, Value: reflect.ValueOf(&target).Elem().Field(0)}
+
+	err := decodeLeaf(l, "trace")
+	require.ErrorIs(t, err, ErrEnum)
+	assert.Nil(t, target.Level, "enum rejection must not leave a pointer to an invalid value")
+}
+
+func TestIsLeafTypeUnsupportedKinds(t *testing.T) {
+	assert.False(t, isLeafType(reflect.TypeOf(make(chan int))))
+	assert.False(t, isLeafType(reflect.TypeOf(struct{ X int }{})))
+	assert.False(t, isLeafType(reflect.TypeOf(map[string]int{})))
+}

--- a/config/doc.go
+++ b/config/doc.go
@@ -43,8 +43,14 @@
 //	flag:"name"      overrides the Overrides map key (default: the dotted path with "." replaced by "-")
 //	default:"value"  the value used when no source sets this field
 //	enum:"a,b,c"     restricts an already-decoded string field to this list
-//	required:"true"  Load fails if this field is still its zero value after every source
+//	required:"true"  Load fails if no source (including default) supplied this field a value
 //	secret:"true"    this field's value is never written to error messages or Render output
+//
+// required is a presence check, not a zero-value check: an explicitly
+// supplied false, 0, "", or an exact numeric zero such as num.Rate("0")
+// satisfies it. A field with both required and default is not a
+// contradiction — default just means the field is always satisfied — but
+// combining them is usually redundant.
 //
 // # Environment variable naming convention
 //

--- a/config/doc.go
+++ b/config/doc.go
@@ -64,9 +64,11 @@
 // # Supported field types
 //
 // string, bool, every sized int/uint, float32/float64, time.Duration,
-// *url.URL, string- or int-based named types (via the enum tag), pointer
-// fields for optional values (nil means "absent," decoded otherwise), and
-// any type implementing encoding.TextUnmarshaler. There is no float64
+// *url.URL, a string field restricted to a fixed set of values (via the
+// enum tag; enum only constrains string-kind fields, and is silently
+// ignored on any other kind), pointer fields for optional values (nil means
+// "absent," decoded otherwise), and any type implementing
+// encoding.TextUnmarshaler. There is no float64
 // prohibition here as there is in num: config values are not authoritative
 // trading data, and num.Price/num.Quantity/num.Rate/num.Money/num.Currency
 // can be used directly as config field types since they already implement

--- a/config/doc.go
+++ b/config/doc.go
@@ -1,0 +1,91 @@
+// Package config assembles typed application configuration for Trader's
+// executable composition roots, as decided by issue #20 (M1-02).
+//
+// # Ownership
+//
+// config is a composition-root support package: it belongs to the binaries
+// under cmd/ and to test/example programs that construct Trader
+// applications, not to domain packages. Domain packages (num, and everything
+// that follows it: instrument, marketdata, strategy, risk, broker, ...) must
+// never read files, environment variables, or command-line flags themselves.
+// They accept typed configuration values through their constructors instead.
+// A composition root loads configuration once, at startup, with this
+// package, and passes the resolved values down.
+//
+// Each component owns its own configuration struct. There is no single giant
+// untyped settings tree: a strategy's config, a broker adapter's config, and
+// a data source's config are separate types loaded (possibly independently)
+// by whatever composition root needs them. config.Load is generic precisely
+// so each caller supplies its own destination type.
+//
+// # Sources and precedence
+//
+// Load resolves each field from up to four sources, in this order, lowest
+// precedence first:
+//
+//	defaults < file < environment < overrides
+//
+// A source that does not mention a field leaves the previous source's value
+// in place. A field mentioned by no source at all keeps its Go zero value,
+// unless a default tag was given (making "no source" equivalent to
+// "default"), or the field is marked required, which is checked after every
+// source has been applied.
+//
+// # Struct tags
+//
+// Fields are addressed by a dotted path derived from their position in the
+// (possibly nested) destination struct, lowercased: a Port field inside a
+// Server field has path "server.port". Tags override pieces of that
+// derivation or add behavior:
+//
+//	config:"name"    overrides this field's path segment (default: lowercased Go field name)
+//	env:"NAME"       overrides the environment variable name outright, no prefix applied
+//	flag:"name"      overrides the Overrides map key (default: the dotted path with "." replaced by "-")
+//	default:"value"  the value used when no source sets this field
+//	enum:"a,b,c"     restricts an already-decoded string field to this list
+//	required:"true"  Load fails if this field is still its zero value after every source
+//	secret:"true"    this field's value is never written to error messages or Render output
+//
+// # Environment variable naming convention
+//
+// Unless a field carries an explicit env tag, its environment variable name
+// is EnvPrefix + "_" + the dotted path, uppercased, with "." replaced by "_":
+// with EnvPrefix "TRADER", the field path "server.port" resolves to
+// TRADER_SERVER_PORT. Trader's own binaries use the prefix "TRADER"; a
+// reusable component embedded in someone else's composition root can choose
+// its own prefix or none.
+//
+// # Supported field types
+//
+// string, bool, every sized int/uint, float32/float64, time.Duration,
+// *url.URL, string- or int-based named types (via the enum tag), pointer
+// fields for optional values (nil means "absent," decoded otherwise), and
+// any type implementing encoding.TextUnmarshaler. There is no float64
+// prohibition here as there is in num: config values are not authoritative
+// trading data, and num.Price/num.Quantity/num.Rate/num.Money/num.Currency
+// can be used directly as config field types since they already implement
+// encoding.TextUnmarshaler.
+//
+// # Validation
+//
+// Load aggregates every field-level problem — parse failures, unsupported
+// types, and missing required fields — into one returned error instead of
+// stopping at the first one, so a misconfigured startup reports everything
+// wrong in one pass. Use errors.Is against the sentinels in errors.go, or
+// errors.As against *FieldError, to inspect individual failures.
+//
+// After every source is applied and every required field is checked, Load
+// calls Validate() error on the destination if it implements that method,
+// for validation that spans multiple fields (e.g. "either A or B, not
+// both"). Invalid configuration prevents startup: Load returns before the
+// caller ever sees a partially-valid value.
+//
+// # Determinism
+//
+// Load never reads the real process environment or an on-disk file unless
+// the caller explicitly asks it to (Options.Environ nil, or a non-empty
+// Options.FilePath). Tests should always set Options.Environ (even to an
+// empty slice) and use Options.FileContent instead of Options.FilePath, so
+// results do not depend on the developer's environment or working
+// directory.
+package config

--- a/config/env.go
+++ b/config/env.go
@@ -1,0 +1,20 @@
+package config
+
+import "strings"
+
+// envValues turns process-environment-style "NAME=VALUE" strings (the
+// format os.Environ returns, and the format Options.Environ expects) into a
+// lookup map. An entry with no "=" is skipped rather than treated as a
+// variable with an empty value, since it cannot occur in a real os.Environ
+// result and most likely indicates a malformed test fixture.
+func envValues(environ []string) map[string]string {
+	out := make(map[string]string, len(environ))
+	for _, kv := range environ {
+		name, value, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		out[name] = value
+	}
+	return out
+}

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvValues(t *testing.T) {
+	got := envValues([]string{"FOO=bar", "PORT=8080", "EMPTY="})
+	assert.Equal(t, "bar", got["FOO"])
+	assert.Equal(t, "8080", got["PORT"])
+	assert.Equal(t, "", got["EMPTY"])
+	_, ok := got["MISSING"]
+	assert.False(t, ok)
+}
+
+func TestEnvValuesSkipsMalformedEntries(t *testing.T) {
+	got := envValues([]string{"NOVALUE", "FOO=bar"})
+	assert.Len(t, got, 1)
+	assert.Equal(t, "bar", got["FOO"])
+}
+
+func TestEnvValuesEmpty(t *testing.T) {
+	got := envValues(nil)
+	assert.Empty(t, got)
+}

--- a/config/errors.go
+++ b/config/errors.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors identifying the kind of problem behind a FieldError.
+// Inspect them with errors.Is against the error Load returns; Load's error
+// may wrap several of these at once (see Error).
+var (
+	// ErrInvalidTarget reports that Load's destination is not a non-nil
+	// pointer to a struct.
+	ErrInvalidTarget = errors.New("config: destination must be a non-nil pointer to a struct")
+
+	// ErrUnsupportedType reports a field whose type config does not know how
+	// to decode: not one of the supported kinds, not time.Duration or
+	// *url.URL, and not an encoding.TextUnmarshaler.
+	ErrUnsupportedType = errors.New("config: unsupported field type")
+
+	// ErrParse reports a source value that could not be parsed into a
+	// field's type.
+	ErrParse = errors.New("config: value could not be parsed")
+
+	// ErrEnum reports a value outside the set named by a field's enum tag.
+	ErrEnum = errors.New("config: value is not one of the allowed enum values")
+
+	// ErrRequired reports a field tagged required:"true" that is still its
+	// zero value after every source has been applied.
+	ErrRequired = errors.New("config: required value is missing")
+
+	// ErrValidation reports a non-nil error returned by the destination's
+	// Validate method.
+	ErrValidation = errors.New("config: validation failed")
+)
+
+// FieldError reports one problem with one field, identified by its dotted
+// path (see the package doc comment). Value holds the offending source text;
+// it is empty for a secret field or when no source supplied a value, such as
+// a required-field failure.
+type FieldError struct {
+	Path  string
+	Value string
+	Err   error
+}
+
+func (e *FieldError) Error() string {
+	if e.Value == "" {
+		return fmt.Sprintf("config: %s: %v", e.Path, e.Err)
+	}
+	return fmt.Sprintf("config: %s=%q: %v", e.Path, e.Value, e.Err)
+}
+
+func (e *FieldError) Unwrap() error {
+	return e.Err
+}
+
+// Error aggregates every FieldError found while loading configuration, so a
+// caller sees every invalid or missing field in one pass instead of only the
+// first. A validation failure from the destination's Validate method is
+// reported as a *FieldError with an empty Path.
+type Error struct {
+	Fields []*FieldError
+}
+
+func (e *Error) Error() string {
+	if len(e.Fields) == 1 {
+		return e.Fields[0].Error()
+	}
+	msg := fmt.Sprintf("config: %d problem(s):", len(e.Fields))
+	for _, f := range e.Fields {
+		msg += "\n  - " + f.Error()
+	}
+	return msg
+}
+
+// Unwrap lets errors.Is and errors.As reach any individual FieldError's
+// wrapped sentinel, per the multi-error Unwrap() []error convention.
+func (e *Error) Unwrap() []error {
+	errs := make([]error, len(e.Fields))
+	for i, f := range e.Fields {
+		errs[i] = f
+	}
+	return errs
+}

--- a/config/errors.go
+++ b/config/errors.go
@@ -9,9 +9,10 @@ import (
 // Inspect them with errors.Is against the error Load returns; Load's error
 // may wrap several of these at once (see Error).
 var (
-	// ErrInvalidTarget reports that Load's destination is not a non-nil
-	// pointer to a struct.
-	ErrInvalidTarget = errors.New("config: destination must be a non-nil pointer to a struct")
+	// ErrInvalidTarget reports a destination of the wrong shape: Load's type
+	// parameter must itself be a struct type, and Render/Sprint's cfg
+	// argument must be a struct or a non-nil pointer to one.
+	ErrInvalidTarget = errors.New("config: destination must be a struct, or a non-nil pointer to a struct")
 
 	// ErrUnsupportedType reports a field whose type config does not know how
 	// to decode: not one of the supported kinds, not time.Duration or
@@ -25,9 +26,17 @@ var (
 	// ErrEnum reports a value outside the set named by a field's enum tag.
 	ErrEnum = errors.New("config: value is not one of the allowed enum values")
 
-	// ErrRequired reports a field tagged required:"true" that is still its
-	// zero value after every source has been applied.
+	// ErrRequired reports a field tagged required:"true" that no source
+	// supplied a value for. This is a presence check: an explicitly supplied
+	// zero value (false, 0, "", num.Rate("0"), ...) satisfies required.
 	ErrRequired = errors.New("config: required value is missing")
+
+	// ErrInvalidTag reports a struct tag whose value config could not parse,
+	// such as required:"treu". This is a fail-closed check: parseTagSet
+	// rejects a malformed required or secret tag outright rather than
+	// silently treating it as false, since a typo'd secret:"treu" would
+	// otherwise disable redaction without any signal that it had happened.
+	ErrInvalidTag = errors.New("config: invalid struct tag")
 
 	// ErrValidation reports a non-nil error returned by the destination's
 	// Validate method.
@@ -37,7 +46,8 @@ var (
 // FieldError reports one problem with one field, identified by its dotted
 // path (see the package doc comment). Value holds the offending source text;
 // it is empty for a secret field or when no source supplied a value, such as
-// a required-field failure.
+// a required-field failure. Path itself is empty only for a failure from the
+// destination's Validate method, which is not about any single field.
 type FieldError struct {
 	Path  string
 	Value string
@@ -45,10 +55,14 @@ type FieldError struct {
 }
 
 func (e *FieldError) Error() string {
-	if e.Value == "" {
+	switch {
+	case e.Path == "":
+		return fmt.Sprintf("config: %v", e.Err)
+	case e.Value == "":
 		return fmt.Sprintf("config: %s: %v", e.Path, e.Err)
+	default:
+		return fmt.Sprintf("config: %s=%q: %v", e.Path, e.Value, e.Err)
 	}
-	return fmt.Sprintf("config: %s=%q: %v", e.Path, e.Value, e.Err)
 }
 
 func (e *FieldError) Unwrap() error {

--- a/config/errors_test.go
+++ b/config/errors_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldErrorMessageWithAndWithoutValue(t *testing.T) {
+	withValue := &FieldError{Path: "port", Value: "abc", Err: ErrParse}
+	assert.Contains(t, withValue.Error(), "port")
+	assert.Contains(t, withValue.Error(), `"abc"`)
+
+	withoutValue := &FieldError{Path: "apikey", Err: ErrRequired}
+	assert.Contains(t, withoutValue.Error(), "apikey")
+	assert.NotContains(t, withoutValue.Error(), `""`)
+}
+
+func TestFieldErrorUnwrap(t *testing.T) {
+	fe := &FieldError{Path: "port", Err: ErrParse}
+	assert.True(t, errors.Is(fe, ErrParse))
+}
+
+func TestErrorMessageSingleField(t *testing.T) {
+	agg := &Error{Fields: []*FieldError{{Path: "port", Err: ErrRequired}}}
+	assert.Equal(t, agg.Fields[0].Error(), agg.Error())
+}
+
+func TestErrorMessageMultipleFields(t *testing.T) {
+	agg := &Error{Fields: []*FieldError{
+		{Path: "port", Err: ErrRequired},
+		{Path: "name", Err: ErrRequired},
+	}}
+	msg := agg.Error()
+	assert.Contains(t, msg, "2 problem(s)")
+	assert.Contains(t, msg, "port")
+	assert.Contains(t, msg, "name")
+}
+
+func TestErrorUnwrapReachesEveryField(t *testing.T) {
+	agg := &Error{Fields: []*FieldError{
+		{Path: "port", Err: ErrRequired},
+		{Path: "name", Err: ErrParse},
+	}}
+	assert.True(t, errors.Is(agg, ErrRequired))
+	assert.True(t, errors.Is(agg, ErrParse))
+	assert.False(t, errors.Is(agg, ErrEnum))
+}

--- a/config/errors_test.go
+++ b/config/errors_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,17 @@ func TestFieldErrorMessageWithAndWithoutValue(t *testing.T) {
 	withoutValue := &FieldError{Path: "apikey", Err: ErrRequired}
 	assert.Contains(t, withoutValue.Error(), "apikey")
 	assert.NotContains(t, withoutValue.Error(), `""`)
+}
+
+// TestFieldErrorMessageEmptyPath is the regression test for the bug where a
+// Validate() failure's *FieldError (Path=="") formatted as "config: : ...",
+// with an awkward empty field segment that read like a bug rather than a
+// deliberately field-less error.
+func TestFieldErrorMessageEmptyPath(t *testing.T) {
+	fe := &FieldError{Err: fmt.Errorf("%w: min must not exceed max", ErrValidation)}
+	msg := fe.Error()
+	assert.NotContains(t, msg, "config: :")
+	assert.Equal(t, "config: config: validation failed: min must not exceed max", msg)
 }
 
 func TestFieldErrorUnwrap(t *testing.T) {

--- a/config/fields.go
+++ b/config/fields.go
@@ -20,6 +20,7 @@ type leaf struct {
 	Required     bool
 	Secret       bool
 	Value        reflect.Value // addressable, settable
+	Resolved     bool          // set once some source has supplied a value, whether or not it decoded successfully
 }
 
 // EnvName returns l's environment variable name: the env tag verbatim if

--- a/config/fields.go
+++ b/config/fields.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// leaf is one decodable field found by walking a destination struct: a
+// scalar, a supported special-cased type, or an encoding.TextUnmarshaler
+// implementer. Nested structs are not leaves; walk recurses into them
+// instead of recording them.
+type leaf struct {
+	Path         string // dotted path, e.g. "server.port"
+	EnvOverride  string // explicit env tag value; empty if not set
+	FlagOverride string // explicit flag tag value; empty if not set
+	Default      string
+	HasDefault   bool
+	Enum         []string
+	Required     bool
+	Secret       bool
+	Value        reflect.Value // addressable, settable
+}
+
+// EnvName returns l's environment variable name: the env tag verbatim if
+// set, otherwise prefix + "_" + the dotted path, uppercased with "." turned
+// into "_". See the package doc comment.
+func (l *leaf) EnvName(prefix string) string {
+	if l.EnvOverride != "" {
+		return l.EnvOverride
+	}
+	name := strings.ToUpper(strings.ReplaceAll(l.Path, ".", "_"))
+	if prefix == "" {
+		return name
+	}
+	return strings.ToUpper(prefix) + "_" + name
+}
+
+// FlagName returns l's Overrides map key: the flag tag verbatim if set,
+// otherwise the dotted path with "." turned into "-".
+func (l *leaf) FlagName() string {
+	if l.FlagOverride != "" {
+		return l.FlagOverride
+	}
+	return strings.ReplaceAll(l.Path, ".", "-")
+}
+
+// tagSet is one struct field's parsed config-related tags.
+type tagSet struct {
+	Name       string
+	Env        string
+	Flag       string
+	Default    string
+	HasDefault bool
+	Enum       []string
+	Required   bool
+	Secret     bool
+}
+
+func parseTagSet(sf reflect.StructField) tagSet {
+	ts := tagSet{
+		Name: sf.Tag.Get("config"),
+		Env:  sf.Tag.Get("env"),
+		Flag: sf.Tag.Get("flag"),
+	}
+	if v, ok := sf.Tag.Lookup("default"); ok {
+		ts.Default, ts.HasDefault = v, true
+	}
+	if v := sf.Tag.Get("enum"); v != "" {
+		for e := range strings.SplitSeq(v, ",") {
+			ts.Enum = append(ts.Enum, strings.TrimSpace(e))
+		}
+	}
+	if v, err := strconv.ParseBool(sf.Tag.Get("required")); err == nil {
+		ts.Required = v
+	}
+	if v, err := strconv.ParseBool(sf.Tag.Get("secret")); err == nil {
+		ts.Secret = v
+	}
+	return ts
+}
+
+// collectLeaves walks dst — which must be an addressable struct value,
+// typically obtained from reflect.ValueOf(ptr).Elem() — and returns every
+// leaf it finds. A field whose type is neither a leaf type nor a nested
+// struct reports ErrUnsupportedType.
+func collectLeaves(dst reflect.Value) ([]*leaf, error) {
+	return collect(dst, nil)
+}
+
+func collect(v reflect.Value, path []string) ([]*leaf, error) {
+	t := v.Type()
+
+	var out []*leaf
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		if sf.PkgPath != "" {
+			continue // unexported
+		}
+		fv := v.Field(i)
+		tg := parseTagSet(sf)
+
+		fieldPath := path
+		if sf.Anonymous && tg.Name == "" {
+			// Embedded struct with no explicit name: flatten into the
+			// parent path rather than adding a segment for the type name.
+		} else {
+			segment := tg.Name
+			if segment == "" {
+				segment = strings.ToLower(sf.Name)
+			}
+			fieldPath = append(append([]string{}, path...), segment)
+		}
+
+		if isLeafType(fv.Type()) {
+			out = append(out, &leaf{
+				Path:         strings.Join(fieldPath, "."),
+				EnvOverride:  tg.Env,
+				FlagOverride: tg.Flag,
+				Default:      tg.Default,
+				HasDefault:   tg.HasDefault,
+				Enum:         tg.Enum,
+				Required:     tg.Required,
+				Secret:       tg.Secret,
+				Value:        fv,
+			})
+			continue
+		}
+
+		if fv.Kind() == reflect.Struct {
+			nested, err := collect(fv, fieldPath)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, nested...)
+			continue
+		}
+
+		return nil, &FieldError{Path: strings.Join(fieldPath, "."), Err: ErrUnsupportedType}
+	}
+	return out, nil
+}

--- a/config/fields.go
+++ b/config/fields.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -58,7 +59,12 @@ type tagSet struct {
 	Secret     bool
 }
 
-func parseTagSet(sf reflect.StructField) tagSet {
+// parseTagSet parses one struct field's config-related tags. It fails closed
+// on a malformed required or secret tag value (required:"treu") rather than
+// silently treating it as false: for secret in particular, silently
+// defaulting to false would disable redaction with no signal that it had
+// happened, turning a typo into a leaked value.
+func parseTagSet(sf reflect.StructField) (tagSet, error) {
 	ts := tagSet{
 		Name: sf.Tag.Get("config"),
 		Env:  sf.Tag.Get("env"),
@@ -72,13 +78,21 @@ func parseTagSet(sf reflect.StructField) tagSet {
 			ts.Enum = append(ts.Enum, strings.TrimSpace(e))
 		}
 	}
-	if v, err := strconv.ParseBool(sf.Tag.Get("required")); err == nil {
-		ts.Required = v
+	if v, ok := sf.Tag.Lookup("required"); ok {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return ts, fmt.Errorf("%w: required:%q: %v", ErrInvalidTag, v, err)
+		}
+		ts.Required = b
 	}
-	if v, err := strconv.ParseBool(sf.Tag.Get("secret")); err == nil {
-		ts.Secret = v
+	if v, ok := sf.Tag.Lookup("secret"); ok {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return ts, fmt.Errorf("%w: secret:%q: %v", ErrInvalidTag, v, err)
+		}
+		ts.Secret = b
 	}
-	return ts
+	return ts, nil
 }
 
 // collectLeaves walks dst — which must be an addressable struct value,
@@ -99,7 +113,7 @@ func collect(v reflect.Value, path []string) ([]*leaf, error) {
 			continue // unexported
 		}
 		fv := v.Field(i)
-		tg := parseTagSet(sf)
+		tg, tagErr := parseTagSet(sf)
 
 		fieldPath := path
 		if sf.Anonymous && tg.Name == "" {
@@ -111,6 +125,10 @@ func collect(v reflect.Value, path []string) ([]*leaf, error) {
 				segment = strings.ToLower(sf.Name)
 			}
 			fieldPath = append(append([]string{}, path...), segment)
+		}
+
+		if tagErr != nil {
+			return nil, &FieldError{Path: strings.Join(fieldPath, "."), Err: tagErr}
 		}
 
 		if isLeafType(fv.Type()) {

--- a/config/fields_test.go
+++ b/config/fields_test.go
@@ -1,0 +1,214 @@
+package config
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func leavesOf(t *testing.T, dst any) []*leaf {
+	t.Helper()
+	v := reflect.ValueOf(dst).Elem()
+	leaves, err := collectLeaves(v)
+	require.NoError(t, err)
+	return leaves
+}
+
+func leafByPath(t *testing.T, leaves []*leaf, path string) *leaf {
+	t.Helper()
+	for _, l := range leaves {
+		if l.Path == path {
+			return l
+		}
+	}
+	t.Fatalf("no leaf with path %q among %d leaves", path, len(leaves))
+	return nil
+}
+
+func TestCollectLeavesFlatStruct(t *testing.T) {
+	type Config struct {
+		Name string
+		Port int
+	}
+	var c Config
+
+	leaves := leavesOf(t, &c)
+	require.Len(t, leaves, 2)
+	assert.Equal(t, "name", leafByPath(t, leaves, "name").Path)
+	assert.Equal(t, "port", leafByPath(t, leaves, "port").Path)
+}
+
+func TestCollectLeavesNestedStruct(t *testing.T) {
+	type Server struct {
+		Host string
+		Port int
+	}
+	type Config struct {
+		Server Server
+	}
+	var c Config
+
+	leaves := leavesOf(t, &c)
+	require.Len(t, leaves, 2)
+	assert.NotNil(t, leafByPath(t, leaves, "server.host"))
+	assert.NotNil(t, leafByPath(t, leaves, "server.port"))
+}
+
+func TestCollectLeavesEmbeddedStructFlattens(t *testing.T) {
+	type Common struct {
+		LogLevel string
+	}
+	type Config struct {
+		Common
+		Port int
+	}
+	var c Config
+
+	leaves := leavesOf(t, &c)
+	require.Len(t, leaves, 2)
+	assert.NotNil(t, leafByPath(t, leaves, "loglevel"))
+	assert.NotNil(t, leafByPath(t, leaves, "port"))
+}
+
+func TestCollectLeavesUnexportedFieldsSkipped(t *testing.T) {
+	type Config struct {
+		Port     int
+		internal string //nolint:unused
+	}
+	var c Config
+
+	leaves := leavesOf(t, &c)
+	require.Len(t, leaves, 1)
+	assert.Equal(t, "port", leaves[0].Path)
+}
+
+func TestCollectLeavesNameTagOverridesSegment(t *testing.T) {
+	type Config struct {
+		Port int `config:"listen_port"`
+	}
+	var c Config
+
+	leaves := leavesOf(t, &c)
+	require.Len(t, leaves, 1)
+	assert.Equal(t, "listen_port", leaves[0].Path)
+}
+
+func TestCollectLeavesUnsupportedTypeErrors(t *testing.T) {
+	type Config struct {
+		Ch chan int
+	}
+	var c Config
+
+	_, err := collectLeaves(reflect.ValueOf(&c).Elem())
+	require.ErrorIs(t, err, ErrUnsupportedType)
+
+	var fe *FieldError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, "ch", fe.Path)
+}
+
+func TestCollectLeavesPointerToStructIsUnsupported(t *testing.T) {
+	type Server struct{ Port int }
+	type Config struct {
+		Server *Server
+	}
+	var c Config
+
+	_, err := collectLeaves(reflect.ValueOf(&c).Elem())
+	require.ErrorIs(t, err, ErrUnsupportedType)
+}
+
+func TestCollectLeavesRecognizesSpecialTypes(t *testing.T) {
+	type Config struct {
+		Timeout  time.Duration
+		Endpoint url.URL
+		Callback *url.URL
+	}
+	var c Config
+
+	leaves := leavesOf(t, &c)
+	require.Len(t, leaves, 3)
+	assert.NotNil(t, leafByPath(t, leaves, "timeout"))
+	assert.NotNil(t, leafByPath(t, leaves, "endpoint"))
+	assert.NotNil(t, leafByPath(t, leaves, "callback"))
+}
+
+func TestCollectLeavesRecognizesTextUnmarshaler(t *testing.T) {
+	type Config struct {
+		Level logLevel
+	}
+	var c Config
+
+	leaves := leavesOf(t, &c)
+	require.Len(t, leaves, 1)
+	assert.Equal(t, "level", leaves[0].Path)
+}
+
+func TestCollectLeavesOptionalScalarPointer(t *testing.T) {
+	type Config struct {
+		MaxRetries *int
+	}
+	var c Config
+
+	leaves := leavesOf(t, &c)
+	require.Len(t, leaves, 1)
+	assert.Nil(t, c.MaxRetries, "collecting leaves must not allocate the optional field")
+}
+
+func TestLeafTagsAreCaptured(t *testing.T) {
+	type Config struct {
+		Level string `config:"log_level" env:"LOG_LEVEL" flag:"level" default:"info" enum:"debug,info,warn" required:"true" secret:"true"`
+	}
+	var c Config
+
+	leaves := leavesOf(t, &c)
+	require.Len(t, leaves, 1)
+	l := leaves[0]
+
+	assert.Equal(t, "log_level", l.Path)
+	assert.Equal(t, "LOG_LEVEL", l.EnvOverride)
+	assert.Equal(t, "level", l.FlagOverride)
+	assert.Equal(t, "info", l.Default)
+	assert.True(t, l.HasDefault)
+	assert.Equal(t, []string{"debug", "info", "warn"}, l.Enum)
+	assert.True(t, l.Required)
+	assert.True(t, l.Secret)
+}
+
+func TestLeafDefaultDistinguishesAbsentFromEmpty(t *testing.T) {
+	type Config struct {
+		WithDefault    string `default:""`
+		WithoutDefault string
+	}
+	var c Config
+
+	leaves := leavesOf(t, &c)
+	assert.True(t, leafByPath(t, leaves, "withdefault").HasDefault)
+	assert.False(t, leafByPath(t, leaves, "withoutdefault").HasDefault)
+}
+
+func TestEnvNameDerivation(t *testing.T) {
+	l := &leaf{Path: "server.port"}
+	assert.Equal(t, "SERVER_PORT", l.EnvName(""))
+	assert.Equal(t, "TRADER_SERVER_PORT", l.EnvName("TRADER"))
+	assert.Equal(t, "TRADER_SERVER_PORT", l.EnvName("trader"), "prefix is uppercased")
+}
+
+func TestEnvNameOverrideBypassesPrefix(t *testing.T) {
+	l := &leaf{Path: "server.port", EnvOverride: "PORT"}
+	assert.Equal(t, "PORT", l.EnvName("TRADER"))
+}
+
+func TestFlagNameDerivation(t *testing.T) {
+	l := &leaf{Path: "server.port"}
+	assert.Equal(t, "server-port", l.FlagName())
+}
+
+func TestFlagNameOverride(t *testing.T) {
+	l := &leaf{Path: "server.port", FlagOverride: "port"}
+	assert.Equal(t, "port", l.FlagName())
+}

--- a/config/fields_test.go
+++ b/config/fields_test.go
@@ -97,6 +97,32 @@ func TestCollectLeavesNameTagOverridesSegment(t *testing.T) {
 	assert.Equal(t, "listen_port", leaves[0].Path)
 }
 
+// TestCollectLeavesRejectsMalformedRequiredTag is the regression test for
+// silently defaulting an unparseable required/secret tag to false.
+func TestCollectLeavesRejectsMalformedRequiredTag(t *testing.T) {
+	type Config struct {
+		APIKey string `required:"treu"`
+	}
+	var c Config
+
+	_, err := collectLeaves(reflect.ValueOf(&c).Elem())
+	require.ErrorIs(t, err, ErrInvalidTag)
+}
+
+// TestCollectLeavesRejectsMalformedSecretTag is the security-relevant half
+// of the same bug: a typo'd secret:"treu" used to silently leave Secret
+// false, disabling redaction for that field with no signal that it had
+// happened.
+func TestCollectLeavesRejectsMalformedSecretTag(t *testing.T) {
+	type Config struct {
+		Password string `secret:"treu"`
+	}
+	var c Config
+
+	_, err := collectLeaves(reflect.ValueOf(&c).Elem())
+	require.ErrorIs(t, err, ErrInvalidTag)
+}
+
 func TestCollectLeavesUnsupportedTypeErrors(t *testing.T) {
 	type Config struct {
 		Ch chan int

--- a/config/file.go
+++ b/config/file.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// fileValues returns the flattened dotted-path -> raw-string values found in
+// the YAML file or content named by opts, or nil if opts names neither.
+// Paths are lowercased to match the lowercased default path derivation in
+// fields.go, so config files are conventionally written in lowercase.
+//
+// A key whose YAML value is explicitly null is treated the same as a key
+// that is absent from the file: it does not participate in this source, and
+// resolution falls through to the environment, default, or the field's Go
+// zero value.
+func fileValues(opts Options) (map[string]string, error) {
+	var data []byte
+	switch {
+	case opts.FileContent != nil:
+		data = opts.FileContent
+	case opts.FilePath != "":
+		b, err := os.ReadFile(opts.FilePath)
+		if err != nil {
+			return nil, fmt.Errorf("config: reading %s: %w", opts.FilePath, err)
+		}
+		data = b
+	default:
+		return nil, nil
+	}
+
+	var root map[string]any
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("config: parsing YAML: %w", err)
+	}
+
+	out := map[string]string{}
+	flattenYAML("", root, out)
+	return out, nil
+}
+
+func flattenYAML(prefix string, node any, out map[string]string) {
+	m, ok := node.(map[string]any)
+	if !ok {
+		if node == nil {
+			return
+		}
+		out[prefix] = fmt.Sprint(node)
+		return
+	}
+
+	for k, v := range m {
+		key := strings.ToLower(k)
+		if prefix != "" {
+			key = prefix + "." + key
+		}
+		flattenYAML(key, v, out)
+	}
+}

--- a/config/file.go
+++ b/config/file.go
@@ -13,6 +13,17 @@ import (
 // Paths are lowercased to match the lowercased default path derivation in
 // fields.go, so config files are conventionally written in lowercase.
 //
+// Values are taken from each scalar node's literal text, not from an
+// intermediate Go value: unmarshaling into map[string]any would first
+// convert an unquoted numeric scalar to a float64, and a float64 cannot
+// exactly represent every decimal text an exact type like num.Price or
+// num.Rate needs — 92233720368.54775807 loses precision at 15-17
+// significant digits, and some values switch to exponent notation ("1e-08")
+// that num's exact parser rejects outright. Config must not silently route
+// authoritative decimal text through binary floating point merely because
+// it happened to pass through this package on the way from YAML text to a
+// TextUnmarshaler.
+//
 // A key whose YAML value is explicitly null is treated the same as a key
 // that is absent from the file: it does not participate in this source, and
 // resolution falls through to the environment, default, or the field's Go
@@ -32,31 +43,50 @@ func fileValues(opts Options) (map[string]string, error) {
 		return nil, nil
 	}
 
-	var root map[string]any
-	if err := yaml.Unmarshal(data, &root); err != nil {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("config: parsing YAML: %w", err)
 	}
 
 	out := map[string]string{}
-	flattenYAML("", root, out)
+	if len(doc.Content) == 0 {
+		return out, nil // empty document
+	}
+
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("config: parsing YAML: top-level document must be a mapping")
+	}
+
+	flattenYAMLNode("", root, out)
 	return out, nil
 }
 
-func flattenYAML(prefix string, node any, out map[string]string) {
-	m, ok := node.(map[string]any)
-	if !ok {
-		if node == nil {
-			return
-		}
-		out[prefix] = fmt.Sprint(node)
-		return
-	}
+// flattenYAMLNode walks a YAML mapping node, recording each scalar leaf's
+// literal text under its dotted path. node.Content on a mapping node
+// alternates key node, value node, key node, value node, ...
+func flattenYAMLNode(prefix string, node *yaml.Node, out map[string]string) {
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keyNode, valNode := node.Content[i], node.Content[i+1]
 
-	for k, v := range m {
-		key := strings.ToLower(k)
+		key := strings.ToLower(keyNode.Value)
+		path := key
 		if prefix != "" {
-			key = prefix + "." + key
+			path = prefix + "." + key
 		}
-		flattenYAML(key, v, out)
+
+		switch valNode.Kind {
+		case yaml.MappingNode:
+			flattenYAMLNode(path, valNode, out)
+		case yaml.ScalarNode:
+			if valNode.Tag == "!!null" {
+				continue // explicit null: absent from this source, not a value
+			}
+			out[path] = valNode.Value
+		default:
+			// Sequences and other node kinds have no matching leaf type
+			// (see fields.go); leaving them out of the map is equivalent to
+			// "no leaf will ever look this path up."
+		}
 	}
 }

--- a/config/file_test.go
+++ b/config/file_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileValuesNeitherPathNorContentSet(t *testing.T) {
+	values, err := fileValues(Options{})
+	require.NoError(t, err)
+	assert.Nil(t, values)
+}
+
+func TestFileValuesFromContent(t *testing.T) {
+	values, err := fileValues(Options{FileContent: []byte(`
+name: trader
+server:
+  host: localhost
+  port: 8080
+`)})
+	require.NoError(t, err)
+	assert.Equal(t, "trader", values["name"])
+	assert.Equal(t, "localhost", values["server.host"])
+	assert.Equal(t, "8080", values["server.port"])
+}
+
+func TestFileValuesFromPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("port: 9090\n"), 0o644))
+
+	values, err := fileValues(Options{FilePath: path})
+	require.NoError(t, err)
+	assert.Equal(t, "9090", values["port"])
+}
+
+func TestFileValuesContentTakesPrecedenceOverPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("port: 9090\n"), 0o644))
+
+	values, err := fileValues(Options{FilePath: path, FileContent: []byte("port: 1111\n")})
+	require.NoError(t, err)
+	assert.Equal(t, "1111", values["port"])
+}
+
+func TestFileValuesMissingPathErrors(t *testing.T) {
+	_, err := fileValues(Options{FilePath: "/does/not/exist.yaml"})
+	require.Error(t, err)
+}
+
+func TestFileValuesMalformedYAMLErrors(t *testing.T) {
+	_, err := fileValues(Options{FileContent: []byte("not: [valid: yaml")})
+	require.Error(t, err)
+}
+
+func TestFileValuesTopLevelScalarErrors(t *testing.T) {
+	_, err := fileValues(Options{FileContent: []byte("just a string\n")})
+	require.Error(t, err)
+}
+
+func TestFileValuesEmptyContent(t *testing.T) {
+	values, err := fileValues(Options{FileContent: []byte("")})
+	require.NoError(t, err)
+	assert.Empty(t, values)
+}
+
+func TestFileValuesNullSkipsKey(t *testing.T) {
+	values, err := fileValues(Options{FileContent: []byte("port: null\nname: trader\n")})
+	require.NoError(t, err)
+	_, ok := values["port"]
+	assert.False(t, ok, "an explicit null must not participate in the file source")
+	assert.Equal(t, "trader", values["name"])
+}
+
+func TestFileValuesKeysAreLowercased(t *testing.T) {
+	values, err := fileValues(Options{FileContent: []byte("Server:\n  Port: 8080\n")})
+	require.NoError(t, err)
+	assert.Equal(t, "8080", values["server.port"])
+}
+
+func TestFileValuesBoolAndFloat(t *testing.T) {
+	values, err := fileValues(Options{FileContent: []byte("enabled: true\nratio: 1.5\n")})
+	require.NoError(t, err)
+	assert.Equal(t, "true", values["enabled"])
+	assert.Equal(t, "1.5", values["ratio"])
+}

--- a/config/load.go
+++ b/config/load.go
@@ -51,6 +51,7 @@ func Load[T any](opts Options) (T, error) {
 		if !ok {
 			continue
 		}
+		l.Resolved = true
 		if err := decodeLeaf(l, raw); err != nil {
 			errs = append(errs, fieldErr(l, raw, err))
 		}

--- a/config/load.go
+++ b/config/load.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+)
+
+// Load resolves configuration into a new T, applying Options' four sources
+// in precedence order: defaults, then the file source, then the
+// environment, then Options.Overrides. See the package doc comment for the
+// full precedence, tag, and naming rules.
+//
+// T must be a struct type, not a pointer to one; Load constructs and
+// returns a T directly.
+//
+// Load aggregates every field-level problem it finds — an unsupported
+// field type, a value that failed to parse, an enum rejection, a missing
+// required field, or a failed Validate() — into one returned *Error rather
+// than stopping at the first, so a misconfigured startup reports everything
+// wrong in one pass. Use errors.Is against the sentinels in errors.go, or
+// errors.As against *FieldError, to inspect individual failures.
+func Load[T any](opts Options) (T, error) {
+	var dst T
+
+	v := reflect.ValueOf(&dst).Elem()
+	if v.Kind() != reflect.Struct {
+		return dst, ErrInvalidTarget
+	}
+
+	leaves, err := collectLeaves(v)
+	if err != nil {
+		return dst, err
+	}
+
+	files, err := fileValues(opts)
+	if err != nil {
+		return dst, err
+	}
+
+	environ := opts.Environ
+	if !opts.environIsSet() {
+		environ = os.Environ()
+	}
+	envs := envValues(environ)
+
+	var errs []*FieldError
+	for _, l := range leaves {
+		raw, ok := resolveValue(l, opts, files, envs)
+		if !ok {
+			continue
+		}
+		if err := decodeLeaf(l, raw); err != nil {
+			errs = append(errs, fieldErr(l, raw, err))
+		}
+	}
+
+	errs = append(errs, checkRequired(leaves)...)
+
+	if len(errs) == 0 {
+		if err := validateDestination(&dst); err != nil {
+			errs = append(errs, &FieldError{Err: fmt.Errorf("%w: %v", ErrValidation, err)})
+		}
+	}
+
+	if len(errs) > 0 {
+		return dst, &Error{Fields: errs}
+	}
+	return dst, nil
+}
+
+// resolveValue returns the value to use for l — applying default < file <
+// env < overrides precedence — and whether any source supplied one at all.
+func resolveValue(l *leaf, opts Options, files, envs map[string]string) (string, bool) {
+	value, ok := "", false
+
+	if l.HasDefault {
+		value, ok = l.Default, true
+	}
+	if v, found := files[l.Path]; found {
+		value, ok = v, true
+	}
+	if v, found := envs[l.EnvName(opts.EnvPrefix)]; found {
+		value, ok = v, true
+	}
+	if v, found := opts.Overrides[l.FlagName()]; found {
+		value, ok = v, true
+	}
+
+	return value, ok
+}
+
+// fieldErr wraps a decode failure as a *FieldError.
+//
+// For a secret field, both the raw value and the underlying error's message
+// are dropped: a parse error's text routinely echoes its malformed input
+// (strconv's, for instance, always does), so keeping the message would leak
+// the secret through the back door redaction was supposed to close. A secret
+// field's FieldError therefore names only the sentinel, never the cause.
+func fieldErr(l *leaf, raw string, err error) *FieldError {
+	if l.Secret {
+		return &FieldError{Path: l.Path, Err: redactedError(err)}
+	}
+	if !errors.Is(err, ErrEnum) {
+		err = fmt.Errorf("%w: %v", ErrParse, err)
+	}
+	return &FieldError{Path: l.Path, Value: raw, Err: err}
+}
+
+// redactedError reports the sentinel identifying a secret field's decode
+// failure without any detail that might repeat the offending value.
+func redactedError(err error) error {
+	if errors.Is(err, ErrEnum) {
+		return ErrEnum
+	}
+	return ErrParse
+}
+
+// validator is implemented by a destination struct that needs validation
+// spanning more than one field.
+type validator interface {
+	Validate() error
+}
+
+func validateDestination(dst any) error {
+	v, ok := dst.(validator)
+	if !ok {
+		return nil
+	}
+	return v.Validate()
+}

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -225,6 +225,21 @@ func TestLoadSecretValueRedactedFromFieldError(t *testing.T) {
 	}
 }
 
+func TestLoadSecretEnumRejectionRedactsValue(t *testing.T) {
+	type Config struct {
+		Level string `enum:"debug,info,warn" secret:"true"`
+	}
+	_, err := Load[Config](Options{Environ: []string{"LEVEL=trace-but-actually-a-leaked-token"}})
+	require.Error(t, err)
+
+	var agg *Error
+	require.ErrorAs(t, err, &agg)
+	require.Len(t, agg.Fields, 1)
+	assert.ErrorIs(t, agg.Fields[0], ErrEnum)
+	assert.Empty(t, agg.Fields[0].Value)
+	assert.NotContains(t, agg.Fields[0].Error(), "leaked-token")
+}
+
 func TestLoadUsesRealEnvironmentWhenEnvironNil(t *testing.T) {
 	// A single Go field name becomes one lowercased path segment, not split
 	// on its internal camelCase word boundaries — see doc.go.

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -1,0 +1,240 @@
+package config
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type serverConfig struct {
+	Host string `default:"0.0.0.0"`
+	Port int    `default:"8080"`
+}
+
+type appConfig struct {
+	Name    string `required:"true"`
+	Server  serverConfig
+	Timeout time.Duration `default:"5s"`
+}
+
+func TestLoadDefaultsOnly(t *testing.T) {
+	got, err := Load[appConfig](Options{
+		Environ: []string{},
+	})
+	// Name has no default and is required; expect a required error, but
+	// Server/Timeout should still resolve from defaults.
+	require.Error(t, err)
+	assert.Equal(t, "0.0.0.0", got.Server.Host)
+	assert.Equal(t, 8080, got.Server.Port)
+	assert.Equal(t, 5*time.Second, got.Timeout)
+}
+
+func TestLoadPrecedenceDefaultThenFileThenEnvThenOverride(t *testing.T) {
+	type Config struct {
+		Value string `default:"default-value"`
+	}
+
+	// default only
+	got, err := Load[Config](Options{Environ: []string{}})
+	require.NoError(t, err)
+	assert.Equal(t, "default-value", got.Value)
+
+	// file beats default
+	got, err = Load[Config](Options{
+		Environ:     []string{},
+		FileContent: []byte("value: file-value\n"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "file-value", got.Value)
+
+	// env beats file
+	got, err = Load[Config](Options{
+		Environ:     []string{"VALUE=env-value"},
+		FileContent: []byte("value: file-value\n"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "env-value", got.Value)
+
+	// override beats env
+	got, err = Load[Config](Options{
+		Environ:     []string{"VALUE=env-value"},
+		FileContent: []byte("value: file-value\n"),
+		Overrides:   map[string]string{"value": "override-value"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "override-value", got.Value)
+}
+
+func TestLoadEnvPrefix(t *testing.T) {
+	type Config struct {
+		Port int
+	}
+
+	got, err := Load[Config](Options{
+		EnvPrefix: "TRADER",
+		Environ:   []string{"TRADER_PORT=9090"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 9090, got.Port)
+}
+
+func TestLoadEnvPrefixDoesNotMatchWithoutIt(t *testing.T) {
+	type Config struct {
+		Port int `default:"1"`
+	}
+
+	got, err := Load[Config](Options{
+		EnvPrefix: "TRADER",
+		Environ:   []string{"PORT=9090"}, // missing the prefix
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.Port, "an unprefixed env var must not satisfy a prefixed lookup")
+}
+
+func TestLoadNestedFieldEnvName(t *testing.T) {
+	type Config struct {
+		Server serverConfig
+	}
+
+	got, err := Load[Config](Options{
+		Environ: []string{"SERVER_PORT=3000"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3000, got.Server.Port)
+	assert.Equal(t, "0.0.0.0", got.Server.Host, "unset nested field keeps its default")
+}
+
+func TestLoadRequiredFieldMissing(t *testing.T) {
+	type Config struct {
+		APIKey string `required:"true"`
+	}
+
+	_, err := Load[Config](Options{Environ: []string{}})
+	require.ErrorIs(t, err, ErrRequired)
+
+	var fe *FieldError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, "apikey", fe.Path)
+}
+
+func TestLoadRequiredFieldSatisfied(t *testing.T) {
+	type Config struct {
+		APIKey string `required:"true"`
+	}
+
+	got, err := Load[Config](Options{Environ: []string{"APIKEY=secret-key"}})
+	require.NoError(t, err)
+	assert.Equal(t, "secret-key", got.APIKey)
+}
+
+func TestLoadAggregatesMultipleErrors(t *testing.T) {
+	type Config struct {
+		Port    int           `default:"not-a-number"`
+		APIKey  string        `required:"true"`
+		Timeout time.Duration `default:"not-a-duration"`
+	}
+
+	_, err := Load[Config](Options{Environ: []string{}})
+	require.Error(t, err)
+
+	var agg *Error
+	require.ErrorAs(t, err, &agg)
+	assert.Len(t, agg.Fields, 3, "every problem should be reported, not just the first")
+}
+
+func TestLoadInvalidTargetNotAStruct(t *testing.T) {
+	_, err := Load[int](Options{Environ: []string{}})
+	require.ErrorIs(t, err, ErrInvalidTarget)
+}
+
+func TestLoadUnsupportedFieldType(t *testing.T) {
+	type Config struct {
+		Ch chan int
+	}
+
+	_, err := Load[Config](Options{Environ: []string{}})
+	require.ErrorIs(t, err, ErrUnsupportedType)
+}
+
+type validatedConfig struct {
+	Min int
+	Max int
+}
+
+func (c validatedConfig) Validate() error {
+	if c.Min > c.Max {
+		return errors.New("min must not exceed max")
+	}
+	return nil
+}
+
+func TestLoadCallsValidate(t *testing.T) {
+	_, err := Load[validatedConfig](Options{
+		Environ:     []string{},
+		FileContent: []byte("min: 10\nmax: 1\n"),
+	})
+	require.ErrorIs(t, err, ErrValidation)
+}
+
+func TestLoadValidatePasses(t *testing.T) {
+	got, err := Load[validatedConfig](Options{
+		Environ:     []string{},
+		FileContent: []byte("min: 1\nmax: 10\n"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.Min)
+	assert.Equal(t, 10, got.Max)
+}
+
+func TestLoadValidateSkippedWhenFieldErrorsExist(t *testing.T) {
+	// Min fails to parse; Validate must not run against a partially decoded
+	// struct.
+	type Config struct {
+		Min int `default:"not-a-number"`
+	}
+	_, err := Load[Config](Options{Environ: []string{}})
+	require.Error(t, err)
+
+	var agg *Error
+	require.ErrorAs(t, err, &agg)
+	for _, fe := range agg.Fields {
+		assert.NotErrorIs(t, fe, ErrValidation)
+	}
+}
+
+func TestLoadSecretValueRedactedFromFieldError(t *testing.T) {
+	type Config struct {
+		Password string `default:"true"` // wrong type on purpose: int field below
+		Port     int    `secret:"true"`
+	}
+	_, err := Load[Config](Options{
+		Environ: []string{"PORT=super-secret-not-a-number"},
+	})
+	require.Error(t, err)
+
+	var agg *Error
+	require.ErrorAs(t, err, &agg)
+	for _, fe := range agg.Fields {
+		if fe.Path == "port" {
+			assert.Empty(t, fe.Value, "a secret field's raw value must not appear in the error")
+			assert.NotContains(t, fe.Error(), "super-secret-not-a-number")
+		}
+	}
+}
+
+func TestLoadUsesRealEnvironmentWhenEnvironNil(t *testing.T) {
+	// A single Go field name becomes one lowercased path segment, not split
+	// on its internal camelCase word boundaries — see doc.go.
+	t.Setenv("TRADER_LOADTESTPORT", "4242")
+
+	type Config struct {
+		LoadTestPort int
+	}
+
+	got, err := Load[Config](Options{EnvPrefix: "TRADER"})
+	require.NoError(t, err)
+	assert.Equal(t, 4242, got.LoadTestPort)
+}

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rustyeddy/trader/num"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -128,6 +129,55 @@ func TestLoadRequiredFieldSatisfied(t *testing.T) {
 	got, err := Load[Config](Options{Environ: []string{"APIKEY=secret-key"}})
 	require.NoError(t, err)
 	assert.Equal(t, "secret-key", got.APIKey)
+}
+
+// TestLoadRequiredAcceptsExplicitZeroValues is the regression test for the
+// bug where checkRequired used reflect.Value.IsZero, which rejected a
+// required field explicitly supplied as its zero value: required false,
+// required 0, and required "" all used to fail as if the field had been
+// omitted entirely, even though an operator had supplied it.
+func TestLoadRequiredAcceptsExplicitZeroValues(t *testing.T) {
+	type Config struct {
+		Enabled bool   `required:"true"`
+		Retries int    `required:"true"`
+		Suffix  string `required:"true"`
+	}
+
+	got, err := Load[Config](Options{
+		Environ: []string{"ENABLED=false", "RETRIES=0", "SUFFIX="},
+	})
+	require.NoError(t, err)
+	assert.False(t, got.Enabled)
+	assert.Equal(t, 0, got.Retries)
+	assert.Equal(t, "", got.Suffix)
+}
+
+// TestLoadRequiredAcceptsExplicitNumRateZero covers the same bug for an
+// exact numeric type: num.Rate("0") is a perfectly valid explicit zero, not
+// a missing field.
+func TestLoadRequiredAcceptsExplicitNumRateZero(t *testing.T) {
+	type Config struct {
+		Rate num.Rate `required:"true"`
+	}
+
+	got, err := Load[Config](Options{
+		Environ:     []string{},
+		FileContent: []byte("rate: \"0\"\n"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "0", got.Rate.String())
+}
+
+// TestLoadRequiredStillRejectsOmittedField keeps the presence check itself
+// honest: a required field no source mentions at all must still fail,
+// distinguishing "explicitly zero" from "never supplied."
+func TestLoadRequiredStillRejectsOmittedField(t *testing.T) {
+	type Config struct {
+		Enabled bool `required:"true"`
+	}
+
+	_, err := Load[Config](Options{Environ: []string{}})
+	require.ErrorIs(t, err, ErrRequired)
 }
 
 func TestLoadAggregatesMultipleErrors(t *testing.T) {

--- a/config/num_integration_test.go
+++ b/config/num_integration_test.go
@@ -33,3 +33,42 @@ func TestLoadAndRenderNumTypes(t *testing.T) {
 	assert.Contains(t, sb.String(), "maxprice = 123.45")
 	assert.Contains(t, sb.String(), "currency = USD")
 }
+
+// TestLoadPreservesExactDecimalFromUnquotedYAML is the regression test for
+// the bug where fileValues used to unmarshal YAML into map[string]any: an
+// unquoted numeric scalar took a detour through float64 on the way to the
+// field decoder. float64 cannot exactly represent num.Price's own maximum —
+// 19 significant digits against float64's ~15-17 — so that detour was a
+// silent precision bug for exactly the exact-decimal types this package
+// exists to support. The value is deliberately unquoted here: a quoted
+// string never entered map[string]any as a number in the first place, so it
+// would not have caught the bug.
+func TestLoadPreservesExactDecimalFromUnquotedYAML(t *testing.T) {
+	type Config struct {
+		MaxPrice num.Price
+	}
+
+	got, err := Load[Config](Options{
+		Environ:     []string{},
+		FileContent: []byte("maxprice: 92233720368.54775807\n"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "92233720368.54775807", got.MaxPrice.String())
+}
+
+// TestLoadPreservesSmallDecimalFromUnquotedYAML guards the other failure
+// shape of the same bug: fmt.Sprint on a small float64 such as 0.00000001
+// produces exponent notation ("1e-08"), which num's exact parser rejects
+// outright. Routing through float64 turned valid YAML into a load failure.
+func TestLoadPreservesSmallDecimalFromUnquotedYAML(t *testing.T) {
+	type Config struct {
+		Rate num.Rate
+	}
+
+	got, err := Load[Config](Options{
+		Environ:     []string{},
+		FileContent: []byte("rate: 0.00000001\n"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "0.00000001", got.Rate.String())
+}

--- a/config/num_integration_test.go
+++ b/config/num_integration_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type numConfig struct {
+	MaxPrice num.Price
+	Currency num.Currency
+}
+
+// TestLoadAndRenderNumTypes is the concrete proof for the package doc
+// comment's claim that num.Price/num.Quantity/num.Rate/num.Money/num.Currency
+// work as config field types with no special-casing: they satisfy
+// encoding.TextUnmarshaler and encoding.TextMarshaler like any other
+// caller-defined type, so decode.go and render.go already handle them.
+func TestLoadAndRenderNumTypes(t *testing.T) {
+	got, err := Load[numConfig](Options{
+		Environ:     []string{},
+		FileContent: []byte("maxprice: \"123.45\"\ncurrency: USD\n"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "123.45", got.MaxPrice.String())
+	assert.Equal(t, "USD", got.Currency.String())
+
+	var sb strings.Builder
+	require.NoError(t, Render(&sb, got))
+	assert.Contains(t, sb.String(), "maxprice = 123.45")
+	assert.Contains(t, sb.String(), "currency = USD")
+}

--- a/config/options.go
+++ b/config/options.go
@@ -1,0 +1,39 @@
+package config
+
+// Options configures one Load call: which sources to consult, how to name
+// them, and where their values come from. See the package doc comment for
+// precedence and naming rules.
+type Options struct {
+	// EnvPrefix is prepended to every derived environment variable name. See
+	// the package doc comment's naming-convention section. Empty means no
+	// prefix.
+	EnvPrefix string
+
+	// Environ supplies the environment source as NAME=VALUE strings, in the
+	// format os.Environ returns. Nil makes Load read the real process
+	// environment via os.Environ. Tests should always set this explicitly —
+	// including to an empty, non-nil slice, to disable the environment
+	// source entirely — so results do not depend on the developer's
+	// environment.
+	Environ []string
+
+	// FilePath, if non-empty, is read as a YAML file and used as the file
+	// source. Ignored when FileContent is non-nil.
+	FilePath string
+
+	// FileContent, if non-nil, is parsed as YAML directly instead of reading
+	// FilePath. Tests should set this instead of writing a file to disk.
+	FileContent []byte
+
+	// Overrides supplies the command-line override source as flag-name ->
+	// value pairs, already parsed by whatever flag library the caller
+	// chose. config never parses os.Args or imports a flag package itself.
+	Overrides map[string]string
+}
+
+// environIsSet reports whether the caller supplied an explicit Environ,
+// including an empty slice, as opposed to leaving it nil to request the real
+// process environment.
+func (o Options) environIsSet() bool {
+	return o.Environ != nil
+}

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionsEnvironIsSet(t *testing.T) {
+	var zero Options
+	assert.False(t, zero.environIsSet(), "nil Environ means 'read the real environment'")
+
+	empty := Options{Environ: []string{}}
+	assert.True(t, empty.environIsSet(), "an explicit empty slice disables the environment source")
+
+	set := Options{Environ: []string{"FOO=bar"}}
+	assert.True(t, set.environIsSet())
+}

--- a/config/render.go
+++ b/config/render.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"encoding"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Redacted is what Render and Sprint write in place of a secret field's
+// value, regardless of that value's actual content — including when the
+// field is an unset optional (nil pointer). Uniform redaction avoids leaking
+// even the fact that a secret was or was not supplied.
+const Redacted = "REDACTED"
+
+// Render writes cfg's resolved configuration as "path = value" lines, one
+// per leaf, sorted by path — the diagnostic output issue #20 calls for so an
+// operator can see what a composition root actually resolved at startup.
+// A secret-tagged field's value is always written as Redacted.
+//
+// cfg is typically the value Load just returned; it may be passed either by
+// value or as a pointer to a struct.
+func Render(w io.Writer, cfg any) error {
+	v, err := structValue(cfg)
+	if err != nil {
+		return err
+	}
+
+	leaves, err := collectLeaves(v)
+	if err != nil {
+		return err
+	}
+	sort.Slice(leaves, func(i, j int) bool { return leaves[i].Path < leaves[j].Path })
+
+	for _, l := range leaves {
+		value := Redacted
+		if !l.Secret {
+			value = formatLeaf(l.Value)
+		}
+		if _, err := fmt.Fprintf(w, "%s = %s\n", l.Path, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Sprint renders cfg the same way as Render, returning the result as a
+// string instead of writing it. Render only fails for a cfg that is not a
+// struct (or pointer to one) or one containing an unsupported field type —
+// both programmer errors caught by Load itself long before Sprint is
+// reached in ordinary use — and strings.Builder's Write never fails, so
+// Sprint reports the problem inline rather than through a second error
+// return.
+func Sprint(cfg any) string {
+	var sb strings.Builder
+	if err := Render(&sb, cfg); err != nil {
+		return fmt.Sprintf("config: %v", err)
+	}
+	return sb.String()
+}
+
+// structValue dereferences cfg down to its underlying struct value, the
+// shape Render and collectLeaves need. It accepts a struct or a pointer to
+// one; anything else, or a nil pointer, is ErrInvalidTarget.
+func structValue(cfg any) (reflect.Value, error) {
+	v := reflect.ValueOf(cfg)
+	for v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return reflect.Value{}, ErrInvalidTarget
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return reflect.Value{}, ErrInvalidTarget
+	}
+	return v, nil
+}
+
+// formatLeaf renders one leaf's value for diagnostics. It gives the value an
+// addressable home first, so a pointer-receiver String or MarshalText
+// implementation (the common case: num's types, time.Duration, *url.URL) is
+// reachable even when the original field value was not itself addressable.
+func formatLeaf(v reflect.Value) string {
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return "<unset>"
+		}
+		v = v.Elem()
+	}
+
+	addr := reflect.New(v.Type())
+	addr.Elem().Set(v)
+
+	if s, ok := addr.Interface().(fmt.Stringer); ok {
+		return s.String()
+	}
+	if tm, ok := addr.Interface().(encoding.TextMarshaler); ok {
+		if b, err := tm.MarshalText(); err == nil {
+			return string(b)
+		}
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		return v.String()
+	case reflect.Bool:
+		return strconv.FormatBool(v.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(v.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(v.Uint(), 10)
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(v.Float(), 'g', -1, v.Type().Bits())
+	default:
+		return fmt.Sprint(v.Interface())
+	}
+}

--- a/config/render_test.go
+++ b/config/render_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type renderConfig struct {
+	Name     string
+	Port     int
+	Password string        `secret:"true"`
+	Timeout  time.Duration `default:"5s"`
+	Retries  *int
+}
+
+func TestRenderSortsAndFormats(t *testing.T) {
+	got, err := Load[renderConfig](Options{
+		Environ:     []string{},
+		FileContent: []byte("name: trader\nport: 8080\npassword: super-secret\n"),
+	})
+	require.NoError(t, err)
+
+	var sb strings.Builder
+	require.NoError(t, Render(&sb, got))
+	out := sb.String()
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.Len(t, lines, 5)
+
+	// Sorted lexicographically by path: name, password, port, retries, timeout.
+	assert.Equal(t, "name = trader", lines[0])
+	assert.Equal(t, "password = REDACTED", lines[1])
+	assert.Equal(t, "port = 8080", lines[2])
+	assert.Equal(t, "retries = <unset>", lines[3])
+	assert.Equal(t, "timeout = 5s", lines[4])
+}
+
+func TestRenderNeverContainsSecretValue(t *testing.T) {
+	got, err := Load[renderConfig](Options{
+		Environ:     []string{},
+		FileContent: []byte("password: correct-horse-battery-staple\n"),
+	})
+	require.NoError(t, err)
+
+	out := Sprint(got)
+	assert.NotContains(t, out, "correct-horse-battery-staple")
+	assert.Contains(t, out, "password = REDACTED")
+}
+
+func TestRenderAcceptsPointer(t *testing.T) {
+	got, err := Load[renderConfig](Options{Environ: []string{}})
+	require.NoError(t, err)
+
+	var sb strings.Builder
+	require.NoError(t, Render(&sb, &got))
+	assert.Contains(t, sb.String(), "timeout = 5s")
+}
+
+func TestRenderOptionalFieldSet(t *testing.T) {
+	got, err := Load[renderConfig](Options{
+		Environ:     []string{},
+		FileContent: []byte("retries: 3\n"),
+	})
+	require.NoError(t, err)
+
+	out := Sprint(got)
+	assert.Contains(t, out, "retries = 3")
+}
+
+func TestRenderRejectsNonStruct(t *testing.T) {
+	err := Render(&strings.Builder{}, 42)
+	require.ErrorIs(t, err, ErrInvalidTarget)
+}
+
+func TestRenderRejectsNilPointer(t *testing.T) {
+	var cfg *renderConfig
+	err := Render(&strings.Builder{}, cfg)
+	require.ErrorIs(t, err, ErrInvalidTarget)
+}
+
+func TestSprintOnInvalidTargetReportsInline(t *testing.T) {
+	out := Sprint(42)
+	assert.Contains(t, out, "config:")
+}
+
+func TestRenderDurationUsesStringer(t *testing.T) {
+	got, err := Load[renderConfig](Options{
+		Environ:     []string{},
+		FileContent: []byte("timeout: 1h30m\n"),
+	})
+	require.NoError(t, err)
+
+	out := Sprint(got)
+	assert.Contains(t, out, "timeout = 1h30m0s")
+}
+
+func TestRenderNumTypeUsesTextMarshaler(t *testing.T) {
+	type Config struct {
+		Price priceLike
+	}
+	var c Config
+	c.Price = priceLike("1.08473")
+
+	out := Sprint(c)
+	assert.Contains(t, out, "price = 1.08473")
+}
+
+// priceLike is a test-only stand-in for num.Price: a type whose canonical
+// text form comes from MarshalText, not from its underlying Go
+// representation, so Render must go through the interface rather than
+// falling back to a raw kind-based format. It also implements
+// UnmarshalText, since that is what makes collectLeaves treat it as a leaf
+// type in the first place — real num types implement both.
+type priceLike string
+
+func (p priceLike) MarshalText() ([]byte, error) {
+	return []byte(p), nil
+}
+
+func (p *priceLike) UnmarshalText(text []byte) error {
+	*p = priceLike(text)
+	return nil
+}

--- a/config/render_test.go
+++ b/config/render_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -69,6 +70,21 @@ func TestRenderOptionalFieldSet(t *testing.T) {
 
 	out := Sprint(got)
 	assert.Contains(t, out, "retries = 3")
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("disk full")
+}
+
+func TestRenderPropagatesWriteError(t *testing.T) {
+	got, err := Load[renderConfig](Options{Environ: []string{}})
+	require.NoError(t, err)
+
+	err = Render(failingWriter{}, got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disk full")
 }
 
 func TestRenderRejectsNonStruct(t *testing.T) {

--- a/config/validate.go
+++ b/config/validate.go
@@ -1,18 +1,20 @@
 package config
 
 // checkRequired reports a *FieldError for every leaf tagged required:"true"
-// that is still its Go zero value after every source has been applied.
+// that no source supplied a value for.
 //
-// This is a zero-value check, not a "no source set this" check: an explicit
-// source value equal to the zero value (env FOO=0 for an int field) is
-// indistinguishable from an unset field. That is a deliberate simplification
-// — precisely tracking provenance per field would complicate every source
-// for a case (required field intentionally set to its zero value) that a
-// default tag already covers better.
+// This is a presence check, not a zero-value check: an explicitly supplied
+// false, 0, "", or an exact numeric zero like num.Rate("0") satisfies
+// required just as any other value does. Load.Resolved is set the moment
+// resolveValue finds a value for a leaf in any source (including a failed
+// decode — requiredness is about whether an operator supplied something,
+// not about whether what they supplied was valid; a bad value is already
+// reported as its own parse error), so this check never has to reason about
+// the decoded value itself.
 func checkRequired(leaves []*leaf) []*FieldError {
 	var errs []*FieldError
 	for _, l := range leaves {
-		if l.Required && l.Value.IsZero() {
+		if l.Required && !l.Resolved {
 			errs = append(errs, &FieldError{Path: l.Path, Err: ErrRequired})
 		}
 	}

--- a/config/validate.go
+++ b/config/validate.go
@@ -1,0 +1,20 @@
+package config
+
+// checkRequired reports a *FieldError for every leaf tagged required:"true"
+// that is still its Go zero value after every source has been applied.
+//
+// This is a zero-value check, not a "no source set this" check: an explicit
+// source value equal to the zero value (env FOO=0 for an int field) is
+// indistinguishable from an unset field. That is a deliberate simplification
+// — precisely tracking provenance per field would complicate every source
+// for a case (required field intentionally set to its zero value) that a
+// default tag already covers better.
+func checkRequired(leaves []*leaf) []*FieldError {
+	var errs []*FieldError
+	for _, l := range leaves {
+		if l.Required && l.Value.IsZero() {
+			errs = append(errs, &FieldError{Path: l.Path, Err: ErrRequired})
+		}
+	}
+	return errs
+}

--- a/docs/arch/trader-framework-architecture.org
+++ b/docs/arch/trader-framework-architecture.org
@@ -1686,7 +1686,7 @@ Configuration is an application concern.  Public libraries should accept typed
 configuration values rather than reading YAML, environment variables, or home
 directories internally.
 
-Trader applications may load YAML/TOML/JSON and environment overrides, then
+Trader applications may load YAML/JSON and environment overrides, then
 construct typed dependencies.
 
 Secrets should be represented by credential-provider interfaces or injected

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/rustyeddy/trader
 
 go 1.25.1
 
-require github.com/stretchr/testify v1.11.1
+require (
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Summary

Implements `config`, a typed application-configuration framework for Trader's executable composition roots, per issue #20 (M1-02).

- `Load[T any](Options) (T, error)` — generic entry point. Resolves each field of `T` through four sources in precedence order: `defaults < file < environment < overrides`.
- Struct tags: `config` (path override), `env`/`flag` (explicit source-name override), `default`, `enum`, `required`, `secret`.
- Field types: all basic kinds, `time.Duration`, `*url.URL`, pointer fields for optional values, and anything implementing `encoding.TextUnmarshaler` — which means `num.Price`, `num.Currency`, etc. work as config fields with zero special-casing (see `num_integration_test.go`).
- File source is YAML (`Options.FilePath` or, for deterministic tests, `Options.FileContent`). Promotes `gopkg.in/yaml.v3` from an indirect to a direct dependency — it was already present transitively via testify, so no new module enters the dependency graph.
- Command-line overrides arrive as a caller-supplied `map[string]string` (`Options.Overrides`); `config` never parses `os.Args` or imports a flag library itself, so it stays usable from stdlib `flag`, Cobra, or pflag-based binaries alike.
- `Load` aggregates every field-level problem (parse failure, enum rejection, missing required field, failed `Validate() error`) into one `*Error` instead of stopping at the first, so a misconfigured startup reports everything wrong in one pass.
- `Render`/`Sprint` print resolved configuration for startup diagnostics; a `secret:"true"` field always renders as `REDACTED`, including when it's an unset optional (so redaction doesn't even leak whether a secret was supplied).
- `arch_test.go` mechanically enforces "domain packages must not read files, flags, or environment variables": nothing outside `config/`, `cmd/`, `test/` may call `os.Getenv`/`os.LookupEnv`/`os.Environ` or import `flag`.

## Why

Composition roots need one typed, tested way to assemble configuration without every domain package reaching for `os.Getenv` or a flag library itself. See `docs/arch/trader-framework-architecture.org`'s "Configuration" section and issue #20's scope/constraints — there's no ADR for this yet, so package layout and the tag scheme were designed fresh against the issue's acceptance criteria.

## Test plan

- [x] `make check` (fmt-check, vet, test, race) — green across the whole repository
- [x] `config` package coverage: 95.7% (`go test ./config/... -cover`)
- [x] Precedence order tested end-to-end (`TestLoadPrecedenceDefaultThenFileThenEnvThenOverride`)
- [x] Required-field and `Validate()` interface behavior tested, including that `Validate` is skipped when field-level errors already exist
- [x] Secret redaction tested both for `Render`/`Sprint` output and for error messages — including that the *underlying* parse error's text (which routinely echoes malformed input) doesn't leak the secret either
- [x] `num.Price`/`num.Currency` used directly as config field types end-to-end (`num_integration_test.go`)
- [x] Architecture test (`arch_test.go`) confirms no package outside `config/cmd/test` touches the environment or flags directly

## Documentation

`config/doc.go` documents package ownership (composition roots, not domain packages), the four-source precedence order, the full struct tag scheme, and the environment-variable naming convention (`EnvPrefix + "_" + dotted path`, uppercased).

## Acceptance criteria (#20)

- [x] Precedence rules are documented and tested
- [x] Invalid configuration prevents startup with useful errors
- [x] Tests do not depend on the developer's environment (`Options.Environ`/`FileContent` are injectable; the one test of the real-environment fallback uses `t.Setenv`, which `testing` scopes and restores automatically)
- [x] Secret values are redacted
- [x] Resolved non-secret configuration can be rendered for diagnostics
- [x] Domain packages do not call `os.Getenv` or parse CLI flags (mechanically enforced)
- [x] Package documentation explains ownership and extension rules
- [x] `make check` passes

## Intentionally deferred

- Runtime configuration reload (explicit non-goal in #20)
- Market data/broker/strategy/backtest-specific settings (owned by their own milestones per #20)
- Nested `*struct` optional fields (only optional *scalar* fields are supported in v0; documented boundary, `ErrUnsupportedType`)
- camelCase splitting in derived path/env names (a Go field like `LoadTestPort` becomes one lowercased segment `loadtestport`, not `load_test_port`; override with a `config` tag if a split name is wanted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)