### PR TITLE
num/internal/fixed: unexport Scale, Places, MinRaw, MaxRaw

### DIFF
--- a/num/internal/fixed/checked.go
+++ b/num/internal/fixed/checked.go
@@ -13,13 +13,13 @@ package fixed
 // Add returns a+b, or an error if the true sum falls outside int64.
 //
 // The bound is rearranged rather than computed, so no intermediate ever wraps:
-// a+b exceeds MaxRaw exactly when a > MaxRaw-b, and MaxRaw-b is itself
+// a+b exceeds maxRaw exactly when a > maxRaw-b, and maxRaw-b is itself
 // representable whenever b is positive.
 func Add(a, b int64) (int64, error) {
-	if b > 0 && a > MaxRaw-b {
+	if b > 0 && a > maxRaw-b {
 		return 0, ErrOverflow
 	}
-	if b < 0 && a < MinRaw-b {
+	if b < 0 && a < minRaw-b {
 		return 0, ErrUnderflow
 	}
 	return a + b, nil
@@ -28,12 +28,12 @@ func Add(a, b int64) (int64, error) {
 // Sub returns a-b, or an error if the true difference falls outside int64.
 //
 // Sub is implemented directly rather than as Add(a, -b) because b may be
-// MinRaw, which cannot be negated.
+// minRaw, which cannot be negated.
 func Sub(a, b int64) (int64, error) {
-	if b < 0 && a > MaxRaw+b {
+	if b < 0 && a > maxRaw+b {
 		return 0, ErrOverflow
 	}
-	if b > 0 && a < MinRaw+b {
+	if b > 0 && a < minRaw+b {
 		return 0, ErrUnderflow
 	}
 	return a - b, nil
@@ -41,10 +41,10 @@ func Sub(a, b int64) (int64, error) {
 
 // Neg returns -a.
 //
-// MinRaw is rejected: its positive counterpart is not representable in signed
+// minRaw is rejected: its positive counterpart is not representable in signed
 // int64, so negating it would wrap back to itself.
 func Neg(a int64) (int64, error) {
-	if a == MinRaw {
+	if a == minRaw {
 		return 0, ErrNotRepresentable
 	}
 	return -a, nil
@@ -52,9 +52,9 @@ func Neg(a int64) (int64, error) {
 
 // Abs returns the absolute value of a.
 //
-// MinRaw is rejected for the same reason as Neg.
+// minRaw is rejected for the same reason as Neg.
 func Abs(a int64) (int64, error) {
-	if a == MinRaw {
+	if a == minRaw {
 		return 0, ErrNotRepresentable
 	}
 	if a < 0 {

--- a/num/internal/fixed/checked_test.go
+++ b/num/internal/fixed/checked_test.go
@@ -15,17 +15,17 @@ func TestAdd(t *testing.T) {
 		wantErr error
 	}{
 		{name: "zero and zero", a: 0, b: 0, want: 0},
-		{name: "positive and positive", a: 3 * Scale, b: 4 * Scale, want: 7 * Scale},
-		{name: "positive and negative", a: 3 * Scale, b: -4 * Scale, want: -1 * Scale},
-		{name: "negative and negative", a: -3 * Scale, b: -4 * Scale, want: -7 * Scale},
+		{name: "positive and positive", a: 3 * scale, b: 4 * scale, want: 7 * scale},
+		{name: "positive and negative", a: 3 * scale, b: -4 * scale, want: -1 * scale},
+		{name: "negative and negative", a: -3 * scale, b: -4 * scale, want: -7 * scale},
 		{name: "quantum granularity", a: 1, b: 2, want: 3},
-		{name: "cancels to zero", a: MinRaw, b: MaxRaw, want: -1},
-		{name: "reaches maximum exactly", a: MaxRaw - 1, b: 1, want: MaxRaw},
-		{name: "reaches minimum exactly", a: MinRaw + 1, b: -1, want: MinRaw},
-		{name: "overflows past maximum", a: MaxRaw, b: 1, wantErr: ErrOverflow},
-		{name: "overflows from two large positives", a: MaxRaw, b: MaxRaw, wantErr: ErrOverflow},
-		{name: "underflows past minimum", a: MinRaw, b: -1, wantErr: ErrUnderflow},
-		{name: "underflows from two large negatives", a: MinRaw, b: MinRaw, wantErr: ErrUnderflow},
+		{name: "cancels to zero", a: minRaw, b: maxRaw, want: -1},
+		{name: "reaches maximum exactly", a: maxRaw - 1, b: 1, want: maxRaw},
+		{name: "reaches minimum exactly", a: minRaw + 1, b: -1, want: minRaw},
+		{name: "overflows past maximum", a: maxRaw, b: 1, wantErr: ErrOverflow},
+		{name: "overflows from two large positives", a: maxRaw, b: maxRaw, wantErr: ErrOverflow},
+		{name: "underflows past minimum", a: minRaw, b: -1, wantErr: ErrUnderflow},
+		{name: "underflows from two large negatives", a: minRaw, b: minRaw, wantErr: ErrUnderflow},
 	}
 
 	for _, tt := range tests {
@@ -50,16 +50,16 @@ func TestSub(t *testing.T) {
 		wantErr error
 	}{
 		{name: "zero and zero", a: 0, b: 0, want: 0},
-		{name: "positive difference", a: 7 * Scale, b: 4 * Scale, want: 3 * Scale},
-		{name: "negative difference", a: 4 * Scale, b: 7 * Scale, want: -3 * Scale},
-		{name: "subtracting a negative", a: 4 * Scale, b: -3 * Scale, want: 7 * Scale},
-		{name: "subtracting the minimum from zero overflows", a: 0, b: MinRaw, wantErr: ErrOverflow},
-		{name: "reaches maximum exactly", a: 0, b: -MaxRaw, want: MaxRaw},
-		{name: "reaches minimum exactly", a: -1, b: MaxRaw, want: MinRaw},
-		{name: "overflows past maximum", a: MaxRaw, b: -1, wantErr: ErrOverflow},
-		{name: "underflows past minimum", a: MinRaw, b: 1, wantErr: ErrUnderflow},
-		{name: "underflows from opposite extremes", a: MinRaw, b: MaxRaw, wantErr: ErrUnderflow},
-		{name: "extremes cancel", a: MinRaw, b: MinRaw, want: 0},
+		{name: "positive difference", a: 7 * scale, b: 4 * scale, want: 3 * scale},
+		{name: "negative difference", a: 4 * scale, b: 7 * scale, want: -3 * scale},
+		{name: "subtracting a negative", a: 4 * scale, b: -3 * scale, want: 7 * scale},
+		{name: "subtracting the minimum from zero overflows", a: 0, b: minRaw, wantErr: ErrOverflow},
+		{name: "reaches maximum exactly", a: 0, b: -maxRaw, want: maxRaw},
+		{name: "reaches minimum exactly", a: -1, b: maxRaw, want: minRaw},
+		{name: "overflows past maximum", a: maxRaw, b: -1, wantErr: ErrOverflow},
+		{name: "underflows past minimum", a: minRaw, b: 1, wantErr: ErrUnderflow},
+		{name: "underflows from opposite extremes", a: minRaw, b: maxRaw, wantErr: ErrUnderflow},
+		{name: "extremes cancel", a: minRaw, b: minRaw, want: 0},
 	}
 
 	for _, tt := range tests {
@@ -82,7 +82,7 @@ func TestSub(t *testing.T) {
 // range.  Native wrapping would satisfy neither.
 func TestAddSubNeverWrap(t *testing.T) {
 	operands := []int64{
-		MinRaw, MinRaw + 1, -Scale, -1, 0, 1, Scale, MaxRaw - 1, MaxRaw,
+		minRaw, minRaw + 1, -scale, -1, 0, 1, scale, maxRaw - 1, maxRaw,
 	}
 
 	for _, a := range operands {
@@ -105,10 +105,10 @@ func TestNeg(t *testing.T) {
 		wantErr error
 	}{
 		{name: "zero stays zero", in: 0, want: 0},
-		{name: "positive becomes negative", in: 5 * Scale, want: -5 * Scale},
-		{name: "negative becomes positive", in: -5 * Scale, want: 5 * Scale},
-		{name: "maximum is negatable", in: MaxRaw, want: -MaxRaw},
-		{name: "minimum is not representable", in: MinRaw, wantErr: ErrNotRepresentable},
+		{name: "positive becomes negative", in: 5 * scale, want: -5 * scale},
+		{name: "negative becomes positive", in: -5 * scale, want: 5 * scale},
+		{name: "maximum is negatable", in: maxRaw, want: -maxRaw},
+		{name: "minimum is not representable", in: minRaw, wantErr: ErrNotRepresentable},
 	}
 
 	for _, tt := range tests {
@@ -132,11 +132,11 @@ func TestAbs(t *testing.T) {
 		wantErr error
 	}{
 		{name: "zero stays zero", in: 0, want: 0},
-		{name: "positive is unchanged", in: 5 * Scale, want: 5 * Scale},
-		{name: "negative is inverted", in: -5 * Scale, want: 5 * Scale},
-		{name: "maximum is unchanged", in: MaxRaw, want: MaxRaw},
-		{name: "minimum plus one is representable", in: MinRaw + 1, want: MaxRaw},
-		{name: "minimum is not representable", in: MinRaw, wantErr: ErrNotRepresentable},
+		{name: "positive is unchanged", in: 5 * scale, want: 5 * scale},
+		{name: "negative is inverted", in: -5 * scale, want: 5 * scale},
+		{name: "maximum is unchanged", in: maxRaw, want: maxRaw},
+		{name: "minimum plus one is representable", in: minRaw + 1, want: maxRaw},
+		{name: "minimum is not representable", in: minRaw, wantErr: ErrNotRepresentable},
 	}
 
 	for _, tt := range tests {
@@ -153,15 +153,15 @@ func TestAbs(t *testing.T) {
 }
 
 func TestSignAndCmp(t *testing.T) {
-	assert.Equal(t, -1, Sign(MinRaw))
+	assert.Equal(t, -1, Sign(minRaw))
 	assert.Equal(t, -1, Sign(-1))
 	assert.Equal(t, 0, Sign(0))
 	assert.Equal(t, 1, Sign(1))
-	assert.Equal(t, 1, Sign(MaxRaw))
+	assert.Equal(t, 1, Sign(maxRaw))
 
-	assert.Equal(t, -1, Cmp(MinRaw, MaxRaw))
+	assert.Equal(t, -1, Cmp(minRaw, maxRaw))
 	assert.Equal(t, 0, Cmp(0, 0))
-	assert.Equal(t, 0, Cmp(MinRaw, MinRaw))
-	assert.Equal(t, 1, Cmp(MaxRaw, MinRaw))
+	assert.Equal(t, 0, Cmp(minRaw, minRaw))
+	assert.Equal(t, 1, Cmp(maxRaw, minRaw))
 	assert.Equal(t, 1, Cmp(1, 0))
 }

--- a/num/internal/fixed/decimal.go
+++ b/num/internal/fixed/decimal.go
@@ -24,13 +24,14 @@ import "math"
 //   - exponent notation, which an adapter must expand first;
 //   - grouping separators, currency symbols, and locale-dependent forms;
 //   - leading, trailing, or embedded whitespace;
-//   - significant precision beyond the eight supported decimal places;
+//   - significant precision beyond what the places constant supports;
 //   - values outside the representable scaled range.
 //
-// Trailing zeros beyond the eighth place are accepted because dropping them
-// is exact and requires no rounding; ADR-004 allows readers to accept
-// equivalent exact forms.  A non-zero digit beyond the eighth place reports
-// ErrPrecision, since honouring it would require discarding information.
+// Trailing zeros beyond the places constant's digit count are accepted
+// because dropping them is exact and requires no rounding; ADR-004 allows
+// readers to accept equivalent exact forms.  A non-zero digit past that
+// point reports ErrPrecision, since honouring it would require discarding
+// information.
 //
 // The full signed range is parsable, including the most negative value.  The
 // magnitude is accumulated unsigned and the sign applied only at the end, so

--- a/num/internal/fixed/decimal.go
+++ b/num/internal/fixed/decimal.go
@@ -24,13 +24,13 @@ import "math"
 //   - exponent notation, which an adapter must expand first;
 //   - grouping separators, currency symbols, and locale-dependent forms;
 //   - leading, trailing, or embedded whitespace;
-//   - significant precision beyond Places decimal places;
+//   - significant precision beyond the eight supported decimal places;
 //   - values outside the representable scaled range.
 //
-// Trailing zeros beyond Places are accepted because dropping them is exact and
-// requires no rounding; ADR-004 allows readers to accept equivalent exact
-// forms.  A non-zero digit beyond Places reports ErrPrecision, since honouring
-// it would require discarding information.
+// Trailing zeros beyond the eighth place are accepted because dropping them
+// is exact and requires no rounding; ADR-004 allows readers to accept
+// equivalent exact forms.  A non-zero digit beyond the eighth place reports
+// ErrPrecision, since honouring it would require discarding information.
 //
 // The full signed range is parsable, including the most negative value.  The
 // magnitude is accumulated unsigned and the sign applied only at the end, so
@@ -67,10 +67,10 @@ func Parse(s string) (int64, error) {
 
 	// Apply the scale to the integer part before adding the fraction, so the
 	// two halves are combined in one exactly-scaled magnitude.
-	if mag > math.MaxUint64/uint64(Scale) {
+	if mag > math.MaxUint64/uint64(scale) {
 		return 0, ErrRange
 	}
-	mag *= uint64(Scale)
+	mag *= uint64(scale)
 
 	if i < len(s) {
 		if s[i] != '.' {
@@ -80,13 +80,13 @@ func Parse(s string) (int64, error) {
 
 		start = i
 		var frac uint64
-		places := 0
+		fracDigits := 0
 		for ; i < len(s) && isDigit(s[i]); i++ {
 			d := uint64(s[i] - '0')
 			switch {
-			case places < Places:
+			case fracDigits < places:
 				frac = frac*10 + d
-				places++
+				fracDigits++
 			case d != 0:
 				return 0, ErrPrecision
 			}
@@ -100,7 +100,7 @@ func Parse(s string) (int64, error) {
 
 		// Left-align the fraction to the common scale: "0.5" contributes one
 		// place and must become 50000000, not 5.
-		for ; places < Places; places++ {
+		for ; fracDigits < places; fracDigits++ {
 			frac *= 10
 		}
 
@@ -134,8 +134,8 @@ func Format(raw int64) string {
 	}
 
 	mag := magnitude(raw)
-	whole := mag / uint64(Scale)
-	frac := mag % uint64(Scale)
+	whole := mag / uint64(scale)
+	frac := mag % uint64(scale)
 
 	// Longest possible output: sign, 11 integer digits, point, 8 fraction
 	// digits.
@@ -151,12 +151,12 @@ func Format(raw int64) string {
 
 	// Render the fraction zero-padded to the full scale, then trim the
 	// trailing zeros that padding and the scale itself introduced.
-	var digits [Places]byte
-	for i := Places - 1; i >= 0; i-- {
+	var digits [places]byte
+	for i := places - 1; i >= 0; i-- {
 		digits[i] = byte('0' + frac%10)
 		frac /= 10
 	}
-	end := Places
+	end := places
 	for end > 1 && digits[end-1] == '0' {
 		end--
 	}

--- a/num/internal/fixed/decimal_test.go
+++ b/num/internal/fixed/decimal_test.go
@@ -20,10 +20,10 @@ func TestParseValid(t *testing.T) {
 		{name: "zero with a zero fraction", in: "0.00000000", want: 0},
 		{name: "negative zero fraction is normalized", in: "-0.00000000", want: 0},
 
-		{name: "whole number", in: "1", want: Scale},
-		{name: "negative whole number", in: "-1", want: -Scale},
-		{name: "explicit plus sign", in: "+1", want: Scale},
-		{name: "leading zeros are accepted", in: "007", want: 7 * Scale},
+		{name: "whole number", in: "1", want: scale},
+		{name: "negative whole number", in: "-1", want: -scale},
+		{name: "explicit plus sign", in: "+1", want: scale},
+		{name: "leading zeros are accepted", in: "007", want: 7 * scale},
 
 		{name: "one decimal place", in: "0.5", want: 50_000_000},
 		{name: "two decimal places", in: "123.45", want: 12_345_000_000},
@@ -33,16 +33,16 @@ func TestParseValid(t *testing.T) {
 		{name: "one negative quantum", in: "-0.00000001", want: -1},
 		{name: "smallest fraction digit in each place", in: "0.00000009", want: 9},
 
-		{name: "trailing zeros are accepted", in: "1.00000000", want: Scale},
+		{name: "trailing zeros are accepted", in: "1.00000000", want: scale},
 		{name: "trailing zeros within the scale", in: "123.45000000", want: 12_345_000_000},
 		// Digits beyond the scale are accepted only when dropping them is
 		// exact; no rounding is involved.
-		{name: "zeros beyond the scale are exact", in: "1.000000000000", want: Scale},
+		{name: "zeros beyond the scale are exact", in: "1.000000000000", want: scale},
 		{name: "many zeros beyond the scale", in: "0.5000000000000000000", want: 50_000_000},
 
-		{name: "maximum representable value", in: "92233720368.54775807", want: MaxRaw},
-		{name: "minimum representable value", in: "-92233720368.54775808", want: MinRaw},
-		{name: "one above the minimum", in: "-92233720368.54775807", want: MinRaw + 1},
+		{name: "maximum representable value", in: "92233720368.54775807", want: maxRaw},
+		{name: "minimum representable value", in: "-92233720368.54775808", want: minRaw},
+		{name: "one above the minimum", in: "-92233720368.54775807", want: minRaw + 1},
 	}
 
 	for _, tt := range tests {
@@ -136,8 +136,8 @@ func TestFormat(t *testing.T) {
 		want string
 	}{
 		{name: "zero", in: 0, want: "0"},
-		{name: "whole number", in: Scale, want: "1"},
-		{name: "negative whole number", in: -Scale, want: "-1"},
+		{name: "whole number", in: scale, want: "1"},
+		{name: "negative whole number", in: -scale, want: "-1"},
 		{name: "trailing zeros are removed", in: 12_345_000_000, want: "123.45"},
 		{name: "all eight places are kept when significant", in: 112_345_678, want: "1.12345678"},
 		{name: "one quantum", in: 1, want: "0.00000001"},
@@ -145,8 +145,8 @@ func TestFormat(t *testing.T) {
 		{name: "leading fraction zeros are kept", in: 50_000_000, want: "0.5"},
 		{name: "interior zeros are kept", in: 100_000_001, want: "1.00000001"},
 		{name: "five decimal places", in: 108_473_000, want: "1.08473"},
-		{name: "maximum", in: MaxRaw, want: "92233720368.54775807"},
-		{name: "minimum", in: MinRaw, want: "-92233720368.54775808"},
+		{name: "maximum", in: maxRaw, want: "92233720368.54775807"},
+		{name: "minimum", in: minRaw, want: "-92233720368.54775808"},
 	}
 
 	for _, tt := range tests {
@@ -161,7 +161,7 @@ func TestFormat(t *testing.T) {
 // Format cannot quietly reintroduce scientific notation or padding.
 func TestFormatIsCanonical(t *testing.T) {
 	values := []int64{
-		MinRaw, MinRaw + 1, -Scale, -1, 0, 1, Scale, 12_345_000_000, MaxRaw,
+		minRaw, minRaw + 1, -scale, -1, 0, 1, scale, 12_345_000_000, maxRaw,
 	}
 
 	for _, v := range values {
@@ -177,7 +177,7 @@ func TestFormatIsCanonical(t *testing.T) {
 		if i := indexByte(out, '.'); i >= 0 {
 			assert.NotEqual(t, byte('0'), out[len(out)-1],
 				"no unnecessary trailing zeros: %q", out)
-			assert.LessOrEqual(t, len(out)-i-1, Places,
+			assert.LessOrEqual(t, len(out)-i-1, places,
 				"never more than the scale's places: %q", out)
 		}
 	}
@@ -185,9 +185,9 @@ func TestFormatIsCanonical(t *testing.T) {
 
 func TestParseFormatRoundTrip(t *testing.T) {
 	values := []int64{
-		MinRaw, MinRaw + 1, -12_345_000_000, -Scale, -1, 0, 1,
-		9, 50_000_000, Scale, 108_473_000, 112_345_678, 12_345_000_000,
-		MaxRaw - 1, MaxRaw,
+		minRaw, minRaw + 1, -12_345_000_000, -scale, -1, 0, 1,
+		9, 50_000_000, scale, 108_473_000, 112_345_678, 12_345_000_000,
+		maxRaw - 1, maxRaw,
 	}
 
 	for _, v := range values {

--- a/num/internal/fixed/errors.go
+++ b/num/internal/fixed/errors.go
@@ -20,7 +20,7 @@ var (
 
 	// ErrNotRepresentable reports an operation whose result cannot be
 	// represented even though it is within range.  Negation and absolute value
-	// of MinRaw are the canonical cases: the positive counterpart of MinInt64
+	// of minRaw are the canonical cases: the positive counterpart of MinInt64
 	// does not exist in signed int64.
 	ErrNotRepresentable = errors.New("result is not representable")
 
@@ -29,7 +29,7 @@ var (
 	// grouping separators, exponent notation, or any other malformed form.
 	ErrSyntax = errors.New("invalid decimal syntax")
 
-	// ErrPrecision reports decimal text carrying more than Places decimal
+	// ErrPrecision reports decimal text carrying more than eight decimal
 	// places.  Exact parsing never silently rounds; excess precision is an
 	// error the caller must resolve.
 	ErrPrecision = errors.New("excess decimal precision")

--- a/num/internal/fixed/errors.go
+++ b/num/internal/fixed/errors.go
@@ -29,9 +29,9 @@ var (
 	// grouping separators, exponent notation, or any other malformed form.
 	ErrSyntax = errors.New("invalid decimal syntax")
 
-	// ErrPrecision reports decimal text carrying more than eight decimal
-	// places.  Exact parsing never silently rounds; excess precision is an
-	// error the caller must resolve.
+	// ErrPrecision reports decimal text carrying more significant fraction
+	// digits than the places constant supports.  Exact parsing never
+	// silently rounds; excess precision is an error the caller must resolve.
 	ErrPrecision = errors.New("excess decimal precision")
 
 	// ErrRange reports decimal text whose value lies outside the representable

--- a/num/internal/fixed/fuzz_test.go
+++ b/num/internal/fixed/fuzz_test.go
@@ -13,8 +13,8 @@ import (
 // authoritative value could change merely by being written and read again.
 func FuzzFormatParse(f *testing.F) {
 	seeds := []int64{
-		MinRaw, MinRaw + 1, -12_345_000_000, -Scale, -9, -1, 0, 1, 9,
-		50_000_000, Scale, 108_473_000, 112_345_678, MaxRaw - 1, MaxRaw,
+		minRaw, minRaw + 1, -12_345_000_000, -scale, -9, -1, 0, 1, 9,
+		50_000_000, scale, 108_473_000, 112_345_678, maxRaw - 1, maxRaw,
 	}
 	for _, s := range seeds {
 		f.Add(s)
@@ -66,8 +66,8 @@ func FuzzParseFormat(f *testing.F) {
 // result.
 func FuzzAddSub(f *testing.F) {
 	seeds := [][2]int64{
-		{0, 0}, {1, -1}, {MaxRaw, 1}, {MinRaw, -1}, {MaxRaw, MaxRaw},
-		{MinRaw, MinRaw}, {MinRaw, MaxRaw}, {Scale, Scale},
+		{0, 0}, {1, -1}, {maxRaw, 1}, {minRaw, -1}, {maxRaw, maxRaw},
+		{minRaw, minRaw}, {minRaw, maxRaw}, {scale, scale},
 	}
 	for _, s := range seeds {
 		f.Add(s[0], s[1])
@@ -92,8 +92,8 @@ func FuzzAddSub(f *testing.F) {
 // make that exact.
 func FuzzMulDivScaled(f *testing.F) {
 	seeds := [][2]int64{
-		{0, 0}, {Scale, Scale}, {108_473_000, 105_000_000}, {MaxRaw, Scale},
-		{MinRaw, Scale}, {MaxRaw, MaxRaw}, {1, 250_000_000}, {-1, 150_000_000},
+		{0, 0}, {scale, scale}, {108_473_000, 105_000_000}, {maxRaw, scale},
+		{minRaw, scale}, {maxRaw, maxRaw}, {1, 250_000_000}, {-1, 150_000_000},
 	}
 	for _, s := range seeds {
 		f.Add(s[0], s[1])
@@ -107,7 +107,7 @@ func FuzzMulDivScaled(f *testing.F) {
 		}
 
 		// Scaling by exactly one is the identity, in both directions.
-		if b == Scale {
+		if b == scale {
 			assert.Equalf(t, a, product, "MulScaled(%d, 1) is not the identity", a)
 		}
 

--- a/num/internal/fixed/scale.go
+++ b/num/internal/fixed/scale.go
@@ -3,9 +3,9 @@
 //
 // This package is deliberately unexported outside num.  It knows nothing about
 // prices, quantities, money, or currencies; it knows only how to represent an
-// exact decimal value as a signed int64 scaled by the common scale, how to do
-// checked arithmetic on such values, and how to convert between that
-// representation and canonical decimal text.
+// exact decimal value as a signed int64 scaled by the scale constant below,
+// how to do checked arithmetic on such values, and how to convert between
+// that representation and canonical decimal text.
 //
 // The division of responsibility is:
 //

--- a/num/internal/fixed/scale.go
+++ b/num/internal/fixed/scale.go
@@ -3,9 +3,9 @@
 //
 // This package is deliberately unexported outside num.  It knows nothing about
 // prices, quantities, money, or currencies; it knows only how to represent an
-// exact decimal value as a signed int64 scaled by [Scale], how to do checked
-// arithmetic on such values, and how to convert between that representation
-// and canonical decimal text.
+// exact decimal value as a signed int64 scaled by the common scale, how to do
+// checked arithmetic on such values, and how to convert between that
+// representation and canonical decimal text.
 //
 // The division of responsibility is:
 //
@@ -22,16 +22,18 @@ package fixed
 
 import "math"
 
-// Places is the number of decimal places retained by the common scale.
-const Places = 8
+// places is the number of decimal places retained by the common scale.
+const places = 8
 
-// Scale is the common scaling factor applied to every authoritative Trader
-// numeric value.  A decimal value v is represented as the integer v*Scale.
+// scale is the common scaling factor applied to every authoritative Trader
+// numeric value.  A decimal value v is represented as the integer v*scale.
 //
 // ADR-004 fixes this at 1e8.  The scale is an internal representation detail:
 // it is not an instrument tick size, a display precision, a wire-format scale,
-// or a provider quotation convention.
-const Scale int64 = 100_000_000
+// or a provider quotation convention. Nothing outside this package needs the
+// raw scale factor itself — num's semantic types never expose it, so there is
+// no cross-package caller for this constant to serve.
+const scale int64 = 100_000_000
 
 // Representable bounds of the scaled representation, expressed as decimal
 // values rather than raw integers:
@@ -39,9 +41,9 @@ const Scale int64 = 100_000_000
 //	minimum: -92,233,720,368.54775808
 //	maximum:  92,233,720,368.54775807
 const (
-	// MinRaw is the smallest representable raw scaled value.
-	MinRaw int64 = math.MinInt64
+	// minRaw is the smallest representable raw scaled value.
+	minRaw int64 = math.MinInt64
 
-	// MaxRaw is the largest representable raw scaled value.
-	MaxRaw int64 = math.MaxInt64
+	// maxRaw is the largest representable raw scaled value.
+	maxRaw int64 = math.MaxInt64
 )

--- a/num/internal/fixed/wide.go
+++ b/num/internal/fixed/wide.go
@@ -28,7 +28,7 @@ func MulScaled(a, b int64, mode Rounding) (int64, error) {
 	if !mode.valid() {
 		return 0, ErrInvalidRounding
 	}
-	return mulDiv(a, b, Scale, mode)
+	return mulDiv(a, b, scale, mode)
 }
 
 // DivScaled returns the quotient of two raw scaled values, restored to the
@@ -43,7 +43,7 @@ func DivScaled(a, b int64, mode Rounding) (int64, error) {
 	if b == 0 {
 		return 0, ErrDivideByZero
 	}
-	return mulDiv(a, Scale, b, mode)
+	return mulDiv(a, scale, b, mode)
 }
 
 // mulDiv computes round(a*b/c) exactly, using a 128-bit intermediate product.
@@ -89,7 +89,7 @@ func mulDiv(a, b, c int64, mode Rounding) (int64, error) {
 
 // magnitude returns the absolute value of v as an unsigned integer.
 //
-// Unsigned negation is used rather than -v so that MinRaw, whose positive
+// Unsigned negation is used rather than -v so that minRaw, whose positive
 // counterpart is not a valid int64, yields its true magnitude of 2^63.
 func magnitude(v int64) uint64 {
 	u := uint64(v)
@@ -105,20 +105,20 @@ func magnitude(v int64) uint64 {
 // The negative range extends one further than the positive range, so the two
 // signs are bounded separately.
 func fromMagnitude(mag uint64, negative bool) (int64, error) {
-	const negativeLimit = uint64(1) << 63 // magnitude of MinRaw
+	const negativeLimit = uint64(1) << 63 // magnitude of minRaw
 
 	if negative {
 		switch {
 		case mag > negativeLimit:
 			return 0, ErrUnderflow
 		case mag == negativeLimit:
-			return MinRaw, nil
+			return minRaw, nil
 		default:
 			return -int64(mag), nil
 		}
 	}
 
-	if mag > uint64(MaxRaw) {
+	if mag > uint64(maxRaw) {
 		return 0, ErrOverflow
 	}
 	return int64(mag), nil

--- a/num/internal/fixed/wide_test.go
+++ b/num/internal/fixed/wide_test.go
@@ -14,34 +14,34 @@ func TestMulScaled(t *testing.T) {
 		want    int64
 		wantErr error
 	}{
-		{name: "zero times anything", a: 0, b: 5 * Scale, want: 0},
-		{name: "anything times zero", a: 5 * Scale, b: 0, want: 0},
-		{name: "identity", a: 7 * Scale, b: Scale, want: 7 * Scale},
-		{name: "negative identity", a: -7 * Scale, b: Scale, want: -7 * Scale},
-		{name: "two negatives give a positive", a: -3 * Scale, b: -4 * Scale, want: 12 * Scale},
-		{name: "mixed signs give a negative", a: -3 * Scale, b: 4 * Scale, want: -12 * Scale},
+		{name: "zero times anything", a: 0, b: 5 * scale, want: 0},
+		{name: "anything times zero", a: 5 * scale, b: 0, want: 0},
+		{name: "identity", a: 7 * scale, b: scale, want: 7 * scale},
+		{name: "negative identity", a: -7 * scale, b: scale, want: -7 * scale},
+		{name: "two negatives give a positive", a: -3 * scale, b: -4 * scale, want: 12 * scale},
+		{name: "mixed signs give a negative", a: -3 * scale, b: 4 * scale, want: -12 * scale},
 
 		// Realistic Price * Rate: 1.08473 marked up by 1.05.
 		{name: "price times rate", a: 108_473_000, b: 105_000_000, want: 113_896_650},
 
 		// Realistic Quantity * Rate: 1000 units at a 0.005 financing rate.
-		{name: "quantity times rate", a: 1000 * Scale, b: 500_000, want: 5 * Scale},
+		{name: "quantity times rate", a: 1000 * scale, b: 500_000, want: 5 * scale},
 
 		// Realistic Price * Quantity, which needs the widened intermediate:
 		// the raw product of 1.08473 and 1,000,000 units exceeds int64 by four
 		// orders of magnitude before the scale is restored.
-		{name: "price times large quantity", a: 108_473_000, b: 1_000_000 * Scale, want: 1_084_730 * Scale},
+		{name: "price times large quantity", a: 108_473_000, b: 1_000_000 * scale, want: 1_084_730 * scale},
 
 		// The full negative range is reachable; its positive counterpart is
 		// one quantum beyond the representable maximum.
-		{name: "reaches the minimum exactly", a: MinRaw, b: Scale, want: MinRaw},
-		{name: "reaches the maximum exactly", a: MaxRaw, b: Scale, want: MaxRaw},
-		{name: "negating the minimum overflows", a: MinRaw, b: -Scale, wantErr: ErrOverflow},
+		{name: "reaches the minimum exactly", a: minRaw, b: scale, want: minRaw},
+		{name: "reaches the maximum exactly", a: maxRaw, b: scale, want: maxRaw},
+		{name: "negating the minimum overflows", a: minRaw, b: -scale, wantErr: ErrOverflow},
 
-		{name: "overflows past the maximum", a: MaxRaw, b: 2 * Scale, wantErr: ErrOverflow},
-		{name: "underflows past the minimum", a: MinRaw, b: 2 * Scale, wantErr: ErrUnderflow},
-		{name: "quotient wider than 64 bits overflows", a: MaxRaw, b: MaxRaw, wantErr: ErrOverflow},
-		{name: "negative quotient wider than 64 bits underflows", a: MinRaw, b: MaxRaw, wantErr: ErrUnderflow},
+		{name: "overflows past the maximum", a: maxRaw, b: 2 * scale, wantErr: ErrOverflow},
+		{name: "underflows past the minimum", a: minRaw, b: 2 * scale, wantErr: ErrUnderflow},
+		{name: "quotient wider than 64 bits overflows", a: maxRaw, b: maxRaw, wantErr: ErrOverflow},
+		{name: "negative quotient wider than 64 bits underflows", a: minRaw, b: maxRaw, wantErr: ErrUnderflow},
 	}
 
 	for _, tt := range tests {
@@ -59,7 +59,7 @@ func TestMulScaled(t *testing.T) {
 }
 
 func TestMulScaledIsCommutative(t *testing.T) {
-	values := []int64{0, 1, -1, Scale, -Scale, 108_473_000, -250_000_000, 3 * Scale}
+	values := []int64{0, 1, -1, scale, -scale, 108_473_000, -250_000_000, 3 * scale}
 
 	for _, a := range values {
 		for _, b := range values {
@@ -78,25 +78,25 @@ func TestDivScaled(t *testing.T) {
 		want    int64
 		wantErr error
 	}{
-		{name: "zero divided by anything", a: 0, b: 5 * Scale, want: 0},
-		{name: "identity", a: 7 * Scale, b: Scale, want: 7 * Scale},
-		{name: "exact halving", a: 3 * Scale, b: 2 * Scale, want: 150_000_000},
-		{name: "negative dividend", a: -3 * Scale, b: 2 * Scale, want: -150_000_000},
-		{name: "negative divisor", a: 3 * Scale, b: -2 * Scale, want: -150_000_000},
-		{name: "two negatives give a positive", a: -3 * Scale, b: -2 * Scale, want: 150_000_000},
+		{name: "zero divided by anything", a: 0, b: 5 * scale, want: 0},
+		{name: "identity", a: 7 * scale, b: scale, want: 7 * scale},
+		{name: "exact halving", a: 3 * scale, b: 2 * scale, want: 150_000_000},
+		{name: "negative dividend", a: -3 * scale, b: 2 * scale, want: -150_000_000},
+		{name: "negative divisor", a: 3 * scale, b: -2 * scale, want: -150_000_000},
+		{name: "two negatives give a positive", a: -3 * scale, b: -2 * scale, want: 150_000_000},
 
 		// Repeating decimals must round at the last representable place, not
 		// truncate: 1/3 rounds down, 2/3 rounds up.
-		{name: "one third rounds down", a: Scale, b: 3 * Scale, want: 33_333_333},
-		{name: "two thirds rounds up", a: 2 * Scale, b: 3 * Scale, want: 66_666_667},
+		{name: "one third rounds down", a: scale, b: 3 * scale, want: 33_333_333},
+		{name: "two thirds rounds up", a: 2 * scale, b: 3 * scale, want: 66_666_667},
 
 		// Realistic Price / Price producing a Rate.
 		{name: "price ratio", a: 108_473_000, b: 108_000_000, want: 100_437_963},
 
-		{name: "divide by zero", a: 5 * Scale, b: 0, wantErr: ErrDivideByZero},
+		{name: "divide by zero", a: 5 * scale, b: 0, wantErr: ErrDivideByZero},
 		{name: "zero divided by zero", a: 0, b: 0, wantErr: ErrDivideByZero},
-		{name: "overflows past the maximum", a: MaxRaw, b: 1, wantErr: ErrOverflow},
-		{name: "underflows past the minimum", a: MinRaw, b: 1, wantErr: ErrUnderflow},
+		{name: "overflows past the maximum", a: maxRaw, b: 1, wantErr: ErrOverflow},
+		{name: "underflows past the minimum", a: minRaw, b: 1, wantErr: ErrUnderflow},
 	}
 
 	for _, tt := range tests {
@@ -195,10 +195,10 @@ func TestRoundingNeighbourhood(t *testing.T) {
 func TestUnrecognizedRoundingIsRejected(t *testing.T) {
 	const bogus Rounding = 99
 
-	_, err := MulScaled(Scale, Scale, bogus)
+	_, err := MulScaled(scale, scale, bogus)
 	require.ErrorIs(t, err, ErrInvalidRounding)
 
-	_, err = DivScaled(Scale, Scale, bogus)
+	_, err = DivScaled(scale, scale, bogus)
 	require.ErrorIs(t, err, ErrInvalidRounding)
 }
 
@@ -211,11 +211,11 @@ func TestRoundingString(t *testing.T) {
 }
 
 func TestMagnitudeHandlesTheMostNegativeValue(t *testing.T) {
-	// The magnitude of MinRaw has no int64 counterpart; representing it
+	// The magnitude of minRaw has no int64 counterpart; representing it
 	// unsigned is what lets the full negative range participate in widened
 	// arithmetic and parsing.
-	assert.Equal(t, uint64(1)<<63, magnitude(MinRaw))
-	assert.Equal(t, uint64(MaxRaw), magnitude(MaxRaw))
+	assert.Equal(t, uint64(1)<<63, magnitude(minRaw))
+	assert.Equal(t, uint64(maxRaw), magnitude(maxRaw))
 	assert.Equal(t, uint64(0), magnitude(0))
 	assert.Equal(t, uint64(1), magnitude(-1))
 }


### PR DESCRIPTION
## Summary

- Unexports four constants (`Scale`→`scale`, `Places`→`places`, `MinRaw`→`minRaw`, `MaxRaw`→`maxRaw`) in `num/internal/fixed` that had zero consumers outside the package itself.
- `Rounding`'s non-default constants (`RoundTowardZero`/`RoundDown`/`RoundUp`) and `ErrInvalidRounding` stay exported — the `Rounding` type must remain exported as a parameter type on `MulScaled`/`DivScaled`, and ADR-004 mandates all four rounding policies exist and are tested even though `num` only surfaces the default today.

## Why

Found while auditing exported surface across `num` and `config` for anything that doesn't need to be public. Since `num/internal/fixed` is already firewalled by Go's `internal/` mechanism, this isn't an API-surface risk, but there was no reason to keep these four capitalized when nothing — not `num`, not anything else — ever referenced them cross-package.

## A bug found along the way

The blind rename exposed a real, pre-existing bug: `Parse`'s fraction-parsing loop had a local variable also named `places`, which — once the package constant became lowercase too — turned `places < Places` into `places < places`, a comparison against itself that's always `false`. Renamed the local to `fracDigits` and restored the comparison against the package constant `places`. `TestParseInvalid`'s "nine significant decimal places" and "significant digit far beyond the scale" cases (which this shadowing would have broken) still pass, confirming the fix — I verified by reasoning through the logic and running fuzz targets against `Parse`/`Format` for 10s each with no new failures.

## Test plan

- [x] `make check` (fmt-check, vet, test, race) — green across the whole repository
- [x] `go test ./num/internal/fixed/... -run TestParse -v` — all pass, including the two tests that exercise the fixed-precision boundary
- [x] `FuzzFormatParse` and `FuzzParseFormat` run 10s each with no new failures
- [x] Manually grepped for any other local variable shadowing introduced by the rename (`scale`, `places`, `minRaw`, `maxRaw`) — none found

Issue: #55