### PR TITLE
logging: structured logging framework on log/slog (#21)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,18 @@ Detailed workflows:
 ### Logging
 
 - We will use structured logging with the go log/slog package
-- Typical log levels will be used fatal, error, warning, info and debug. 
-- Logger by default will log to /var/log/trader.log 
-- Logger flags will be available for 
-  - log output file, default: /var/log/trader.log
-  - Output flag for writing to stderr or stdout
-  - Flag to change the log level: From Fatal to Debug
-  - Flag to change the output format includes: text (human readable) or JSON
+- Log levels are slog's four standard levels: error, warn, info, and debug.
+  There is no fatal level: an operator-actionable "this must stop the
+  process" decision belongs to the composition root as an explicit
+  `os.Exit` call after logging, not to a logging helper that hides process
+  termination inside a log call.
+- Logger output defaults to stderr.
+- Logger flags will be available for
+  - log output destination: stderr, stdout, or an arbitrary file path
+    supplied by the operator
+  - Flag to change the log level: from Error to Debug
+  - Flag to change the output format: text (human readable, the default) or
+    JSON
 
 ## Testing 
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,26 @@ cfg, err := config.Load[Settings](config.Options{EnvPrefix: "TRADER"})
 See the [package doc comment](config/doc.go) for the tag reference and
 environment-variable naming convention.
 
+### logging
+
+`logging` builds Trader's structured loggers on top of `log/slog` — text or
+JSON output, a configurable level, and canonical attribute names
+(`CorrelationID`, `OrderID`, `AccountID`, ...) so records stay correlatable
+across components. It is not a wrapper around `slog.Logger`: components
+accept and use `*slog.Logger` directly.
+
+```go
+logger, closer, err := logging.New(logging.Config{Format: "json"})
+defer closer.Close()
+
+logger.Info("order placed", logging.OrderID, "abc123", "password", logging.Secret(pw))
+```
+
+`logging.Config` works directly with `config.Load` — `slog.Level` already
+implements the same text encoding `config` expects. See the
+[package doc comment](logging/doc.go) for context propagation, redaction,
+and the `Discard`/`Capture` test helpers.
+
 ## Documentation
 
 - [Framework requirements](docs/arch/trader-framework-requirements.org)

--- a/logging/arch_test.go
+++ b/logging/arch_test.go
@@ -1,0 +1,138 @@
+package logging
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file enforces, mechanically, the architectural constraint issue #21
+// states in prose: "Do not create a mutable global logger" and "Inject
+// loggers into components that need them." slog itself keeps a mutable
+// package-level default logger (slog.Default, changed by slog.SetDefault),
+// and the package-level Debug/Info/Warn/Error/Log/LogAttrs/With functions
+// all read it implicitly. A component that calls any of those, or that
+// reassigns the default, has a hidden dependency on global state instead of
+// an injected *slog.Logger — exactly what this constraint forbids.
+//
+// logging itself, cmd/ composition roots, and test/ harnesses are exempt:
+// logging.New legitimately builds handlers without an injected logger to
+// wrap, and a cmd/ binary is where the one intentional
+// slog.SetDefault-equivalent choice (if any) belongs, not scattered through
+// domain code.
+
+var globalLoggerExemptPrefixes = []string{"logging", "cmd", "test", ".git"}
+
+// slog identifiers that read or mutate the mutable package-level default
+// logger. slog.New, slog.NewTextHandler, slog.NewJSONHandler,
+// slog.DiscardHandler, and the handler/level/attr constructors are not
+// included: they build values, they don't touch global state.
+var globalLoggerCalls = map[string]bool{
+	"Default":      true,
+	"SetDefault":   true,
+	"Debug":        true,
+	"DebugContext": true,
+	"Info":         true,
+	"InfoContext":  true,
+	"Warn":         true,
+	"WarnContext":  true,
+	"Error":        true,
+	"ErrorContext": true,
+	"Log":          true,
+	"LogAttrs":     true,
+	"With":         true,
+}
+
+func TestNoPackageUsesSlogGlobalDefaultLogger(t *testing.T) {
+	root := repoRoot(t)
+
+	var violations []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+
+		if d.IsDir() {
+			if rel != "." && isGlobalLoggerExempt(rel) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".go") || isGlobalLoggerExempt(rel) {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "slog" {
+				return true
+			}
+			if globalLoggerCalls[sel.Sel.Name] {
+				violations = append(violations,
+					rel+": calls slog."+sel.Sel.Name+" at "+fset.Position(call.Pos()).String())
+			}
+			return true
+		})
+		return nil
+	})
+	require.NoError(t, err)
+
+	for _, v := range violations {
+		assert.Fail(t, "package outside logging/cmd/test depends on slog's mutable global default logger", v)
+	}
+}
+
+func isGlobalLoggerExempt(rel string) bool {
+	for _, p := range globalLoggerExemptPrefixes {
+		if rel == p || strings.HasPrefix(rel, p+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	for range 10 {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("logging: no go.mod found above " + dir)
+	return ""
+}

--- a/logging/attrs.go
+++ b/logging/attrs.go
@@ -1,0 +1,56 @@
+package logging
+
+import "log/slog"
+
+// Canonical attribute key names, per issue #21. Using these names
+// consistently is what makes log records correlatable across components,
+// runs, and sessions — a component that invents its own key for the same
+// concept (say, "order" instead of OrderID) breaks that correlation for
+// anyone querying by the canonical name.
+//
+// CorrelationID and CausationID may hold plain strings for now, per #21,
+// until Trader-owned ID types exist; nothing here assumes a particular ID
+// representation.
+const (
+	// RunID identifies one backtest, scan, or live session run.
+	RunID = "run_id"
+
+	// SessionID identifies one live or paper trading session within a run.
+	SessionID = "session_id"
+
+	// AccountID identifies one broker account.
+	AccountID = "account_id"
+
+	// InstrumentID identifies one Trader instrument.
+	InstrumentID = "instrument_id"
+
+	// OrderID identifies one order.
+	OrderID = "order_id"
+
+	// CorrelationID groups every record produced while handling one
+	// logical operation (a strategy decision, an order's full lifecycle),
+	// even across component and process boundaries.
+	CorrelationID = "correlation_id"
+
+	// CausationID identifies the specific event or command that caused this
+	// record's event, distinct from CorrelationID's broader grouping: many
+	// records can share a CorrelationID while each has a different, more
+	// specific CausationID.
+	CausationID = "causation_id"
+
+	// Component names the subsystem a child logger was scoped to — see
+	// WithComponent.
+	Component = "component"
+)
+
+// WithComponent returns a child logger scoped to component: every record it
+// produces carries a Component attribute with that name, so records from
+// different subsystems remain distinguishable after aggregation.
+//
+// This is a thin, named wrapper around slog.Logger.With for exactly one
+// canonical attribute — not a general-purpose logger wrapper — so that
+// "how do I get a component-scoped logger" has one obvious, documented
+// answer instead of every call site choosing its own key name.
+func WithComponent(l *slog.Logger, component string) *slog.Logger {
+	return l.With(Component, component)
+}

--- a/logging/attrs_test.go
+++ b/logging/attrs_test.go
@@ -1,0 +1,45 @@
+package logging
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalAttributeNames(t *testing.T) {
+	// These are a public contract: components across the codebase agree on
+	// them by name. Pin the literal strings so a rename is a visible,
+	// deliberate diff, not an accidental one.
+	assert.Equal(t, "run_id", RunID)
+	assert.Equal(t, "session_id", SessionID)
+	assert.Equal(t, "account_id", AccountID)
+	assert.Equal(t, "instrument_id", InstrumentID)
+	assert.Equal(t, "order_id", OrderID)
+	assert.Equal(t, "correlation_id", CorrelationID)
+	assert.Equal(t, "causation_id", CausationID)
+	assert.Equal(t, "component", Component)
+}
+
+func TestWithComponent(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.New(slog.NewTextHandler(&buf, nil))
+
+	scoped := WithComponent(base, "broker")
+	scoped.Info("connected")
+
+	require.Contains(t, buf.String(), "component=broker")
+	assert.Contains(t, buf.String(), "msg=connected")
+}
+
+func TestWithComponentDoesNotAffectBaseLogger(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.New(slog.NewTextHandler(&buf, nil))
+
+	_ = WithComponent(base, "broker")
+	base.Info("unscoped")
+
+	assert.NotContains(t, buf.String(), "component=")
+}

--- a/logging/config.go
+++ b/logging/config.go
@@ -26,7 +26,9 @@ type Config struct {
 	Output string `default:"stderr"`
 }
 
-// New builds a *slog.Logger from cfg.
+// New builds a *slog.Logger from cfg. The returned logger's handler is
+// wrapped with NewContextHandler, so WithCorrelationID and WithCausationID
+// work automatically with it.
 //
 // The returned io.Closer must be closed by the caller when the logger is no
 // longer needed — New starts no unmanaged background work, but a file
@@ -51,7 +53,7 @@ func New(cfg Config) (*slog.Logger, io.Closer, error) {
 		return nil, nil, fmt.Errorf("logging: unsupported format %q", cfg.Format)
 	}
 
-	return slog.New(h), closer, nil
+	return slog.New(NewContextHandler(h)), closer, nil
 }
 
 // resolveOutput turns a Config.Output value into a writer and the closer

--- a/logging/config.go
+++ b/logging/config.go
@@ -40,7 +40,7 @@ func New(cfg Config) (*slog.Logger, io.Closer, error) {
 		return nil, nil, err
 	}
 
-	opts := &slog.HandlerOptions{Level: cfg.Level}
+	opts := &slog.HandlerOptions{Level: cfg.Level, ReplaceAttr: redactSensitiveKeys}
 
 	var h slog.Handler
 	switch cfg.Format {

--- a/logging/config.go
+++ b/logging/config.go
@@ -1,0 +1,79 @@
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+)
+
+// Config configures a logger built by New. Its Go zero value is itself a
+// valid, sensible configuration: Level's zero value is slog.LevelInfo,
+// and both Format and Output resolve their empty string to their
+// documented default, so logging.New(logging.Config{}) works.
+type Config struct {
+	// Level is the minimum record level that will be logged. Text form:
+	// "DEBUG", "INFO", "WARN", or "ERROR" (see slog.Level.UnmarshalText).
+	Level slog.Level `default:"INFO"`
+
+	// Format selects the handler: "text" for human-readable output, "json"
+	// for machine-readable output. Defaults to "text".
+	Format string `default:"text" enum:"text,json"`
+
+	// Output selects where records are written: "stderr" (the default),
+	// "stdout", or any other value, which is treated as a file path to open
+	// (creating it if necessary) and append to.
+	Output string `default:"stderr"`
+}
+
+// New builds a *slog.Logger from cfg.
+//
+// The returned io.Closer must be closed by the caller when the logger is no
+// longer needed — New starts no unmanaged background work, but a file
+// output does hold an open file descriptor that the composition root owns
+// the lifetime of. The closer is a no-op for "stderr" and "stdout".
+func New(cfg Config) (*slog.Logger, io.Closer, error) {
+	w, closer, err := resolveOutput(cfg.Output)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	opts := &slog.HandlerOptions{Level: cfg.Level}
+
+	var h slog.Handler
+	switch cfg.Format {
+	case "", "text":
+		h = slog.NewTextHandler(w, opts)
+	case "json":
+		h = slog.NewJSONHandler(w, opts)
+	default:
+		_ = closer.Close()
+		return nil, nil, fmt.Errorf("logging: unsupported format %q", cfg.Format)
+	}
+
+	return slog.New(h), closer, nil
+}
+
+// resolveOutput turns a Config.Output value into a writer and the closer
+// that owns it. "" and "stderr" and "stdout" never need closing; anything
+// else is opened as a file path, created if it does not already exist and
+// appended to if it does, so restarting a long-running process does not
+// truncate its own prior log output.
+func resolveOutput(output string) (io.Writer, io.Closer, error) {
+	switch output {
+	case "", "stderr":
+		return os.Stderr, nopCloser{}, nil
+	case "stdout":
+		return os.Stdout, nopCloser{}, nil
+	default:
+		f, err := os.OpenFile(output, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return nil, nil, fmt.Errorf("logging: opening %s: %w", output, err)
+		}
+		return f, f, nil
+	}
+}
+
+type nopCloser struct{}
+
+func (nopCloser) Close() error { return nil }

--- a/logging/config_integration_test.go
+++ b/logging/config_integration_test.go
@@ -1,0 +1,37 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rustyeddy/trader/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigLoadsLoggingConfig is the concrete proof for the package doc
+// comment's claim that logging.Config works with config.Load with no
+// special-casing: slog.Level already implements encoding.TextUnmarshaler.
+func TestConfigLoadsLoggingConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.log")
+
+	cfg, err := config.Load[Config](config.Options{
+		Environ:     []string{},
+		FileContent: []byte("level: WARN\nformat: json\noutput: " + path + "\n"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, slog.LevelWarn, cfg.Level)
+	assert.Equal(t, "json", cfg.Format)
+
+	logger, closer, err := New(cfg)
+	require.NoError(t, err)
+	logger.Warn("hello")
+	require.NoError(t, closer.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"msg":"hello"`)
+}

--- a/logging/config_test.go
+++ b/logging/config_test.go
@@ -1,0 +1,161 @@
+package logging
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewZeroValueConfigIsUsable(t *testing.T) {
+	logger, closer, err := New(Config{})
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+	assert.NoError(t, closer.Close())
+}
+
+func TestNewTextFormat(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, nil)
+	logger := slog.New(h)
+	logger.Info("hello", "key", "value")
+
+	assert.Contains(t, buf.String(), "msg=hello")
+	assert.Contains(t, buf.String(), "key=value")
+}
+
+func TestNewSelectsTextHandler(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.log")
+
+	logger, closer, err := New(Config{Format: "text", Output: path})
+	require.NoError(t, err)
+	logger.Info("hello world")
+	require.NoError(t, closer.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "msg=\"hello world\"")
+	assert.NotContains(t, string(data), "{")
+}
+
+func TestNewSelectsJSONHandler(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.log")
+
+	logger, closer, err := New(Config{Format: "json", Output: path})
+	require.NoError(t, err)
+	logger.Info("hello world")
+	require.NoError(t, closer.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"msg":"hello world"`)
+}
+
+func TestNewRejectsUnsupportedFormat(t *testing.T) {
+	_, _, err := New(Config{Format: "xml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "xml")
+}
+
+func TestNewRespectsLevel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.log")
+
+	logger, closer, err := New(Config{Output: path, Level: slog.LevelWarn})
+	require.NoError(t, err)
+	logger.Info("should be filtered out")
+	logger.Warn("should appear")
+	require.NoError(t, closer.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "should be filtered out")
+	assert.Contains(t, string(data), "should appear")
+}
+
+func TestNewDefaultLevelIsInfo(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.log")
+
+	logger, closer, err := New(Config{Output: path})
+	require.NoError(t, err)
+	logger.Debug("should be filtered out")
+	logger.Info("should appear")
+	require.NoError(t, closer.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "should be filtered out")
+	assert.Contains(t, string(data), "should appear")
+}
+
+func TestResolveOutputStderrAndStdout(t *testing.T) {
+	w, closer, err := resolveOutput("stderr")
+	require.NoError(t, err)
+	assert.Same(t, os.Stderr, w)
+	assert.NoError(t, closer.Close())
+
+	w, closer, err = resolveOutput("stdout")
+	require.NoError(t, err)
+	assert.Same(t, os.Stdout, w)
+	assert.NoError(t, closer.Close())
+
+	w, closer, err = resolveOutput("")
+	require.NoError(t, err)
+	assert.Same(t, os.Stderr, w, "empty output defaults to stderr")
+	assert.NoError(t, closer.Close())
+}
+
+func TestResolveOutputArbitraryFilePath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "any", "where.log")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+
+	w, closer, err := resolveOutput(path)
+	require.NoError(t, err)
+	_, err = w.Write([]byte("line\n"))
+	require.NoError(t, err)
+	require.NoError(t, closer.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "line\n", string(data))
+}
+
+func TestResolveOutputAppendsRatherThanTruncates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.log")
+	require.NoError(t, os.WriteFile(path, []byte("existing\n"), 0o644))
+
+	w, closer, err := resolveOutput(path)
+	require.NoError(t, err)
+	_, err = w.Write([]byte("new\n"))
+	require.NoError(t, err)
+	require.NoError(t, closer.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "existing\nnew\n", string(data))
+}
+
+func TestResolveOutputInvalidPathErrors(t *testing.T) {
+	_, _, err := resolveOutput(string([]byte{0}))
+	require.Error(t, err)
+}
+
+func TestNewRejectsUnsupportedFormatClosesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.log")
+
+	_, _, err := New(Config{Format: "xml", Output: path})
+	require.Error(t, err)
+
+	// The file must have been closed despite the error, not leaked open.
+	require.NoError(t, os.Remove(path))
+}

--- a/logging/context.go
+++ b/logging/context.go
@@ -36,8 +36,19 @@ func withAttr(ctx context.Context, attr slog.Attr) context.Context {
 	// (e.g. two goroutines each adding their own causation ID to a shared
 	// correlation-scoped context), and appending in place could let one
 	// branch's attribute leak into the other.
-	next := make([]slog.Attr, len(existing), len(existing)+1)
-	copy(next, existing)
+	//
+	// Drop any existing entry for the same key rather than keeping both: a
+	// second WithCorrelationID call on an already-scoped context replaces
+	// the value for every record logged from that point on, the same way a
+	// derived context's value shadows its parent's everywhere else. Without
+	// this, nested calls would accumulate duplicate correlation_id /
+	// causation_id keys in every subsequent record.
+	next := make([]slog.Attr, 0, len(existing)+1)
+	for _, a := range existing {
+		if a.Key != attr.Key {
+			next = append(next, a)
+		}
+	}
 	next = append(next, attr)
 
 	return context.WithValue(ctx, ctxKey{}, next)
@@ -66,9 +77,34 @@ func NewContextHandler(h slog.Handler) slog.Handler {
 }
 
 func (h *contextHandler) Handle(ctx context.Context, r slog.Record) error {
-	if attrs := attrsFromContext(ctx); len(attrs) > 0 {
-		r.AddAttrs(attrs...)
+	attrs := attrsFromContext(ctx)
+	if len(attrs) == 0 {
+		return h.Handler.Handle(ctx, r)
 	}
+
+	// An attribute the caller set explicitly on this record wins over the
+	// same key injected from context: it is the more specific of the two,
+	// chosen deliberately for this one record rather than inherited
+	// ambiently. Without this check, a call site that (accidentally or
+	// deliberately) logs its own "correlation_id" attribute while a context
+	// value with the same key is in scope would end up with two
+	// correlation_id keys in the same record.
+	recordKeys := make(map[string]bool, r.NumAttrs())
+	r.Attrs(func(a slog.Attr) bool {
+		recordKeys[a.Key] = true
+		return true
+	})
+
+	toAdd := make([]slog.Attr, 0, len(attrs))
+	for _, a := range attrs {
+		if !recordKeys[a.Key] {
+			toAdd = append(toAdd, a)
+		}
+	}
+	if len(toAdd) > 0 {
+		r.AddAttrs(toAdd...)
+	}
+
 	return h.Handler.Handle(ctx, r)
 }
 

--- a/logging/context.go
+++ b/logging/context.go
@@ -1,0 +1,81 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Context-propagated correlation, built on slog's own context-aware
+// methods (Logger.InfoContext, WarnContext, ErrorContext, DebugContext)
+// rather than inventing new logging methods of our own. A *slog.Logger
+// built by New already wraps its handler so this works automatically; a
+// handler built some other way can opt in with NewContextHandler.
+
+type ctxKey struct{}
+
+// WithCorrelationID returns a context carrying id as this call chain's
+// correlation ID. Every record logged through a context-aware method
+// (logger.InfoContext(ctx, ...), and friends) on a logger whose handler
+// passed through NewContextHandler — which New's handlers always do —
+// automatically carries it as the CorrelationID attribute.
+func WithCorrelationID(ctx context.Context, id string) context.Context {
+	return withAttr(ctx, slog.String(CorrelationID, id))
+}
+
+// WithCausationID returns a context carrying id as this record's causation
+// ID. See WithCorrelationID.
+func WithCausationID(ctx context.Context, id string) context.Context {
+	return withAttr(ctx, slog.String(CausationID, id))
+}
+
+func withAttr(ctx context.Context, attr slog.Attr) context.Context {
+	existing, _ := ctx.Value(ctxKey{}).([]slog.Attr)
+
+	// Copy rather than append in place: the existing slice's backing array
+	// may be shared with a sibling context derived from the same parent
+	// (e.g. two goroutines each adding their own causation ID to a shared
+	// correlation-scoped context), and appending in place could let one
+	// branch's attribute leak into the other.
+	next := make([]slog.Attr, len(existing), len(existing)+1)
+	copy(next, existing)
+	next = append(next, attr)
+
+	return context.WithValue(ctx, ctxKey{}, next)
+}
+
+func attrsFromContext(ctx context.Context) []slog.Attr {
+	attrs, _ := ctx.Value(ctxKey{}).([]slog.Attr)
+	return attrs
+}
+
+// contextHandler decorates a slog.Handler, adding every attribute stored in
+// the context (via WithCorrelationID, WithCausationID) to a record before
+// delegating to the wrapped handler.
+type contextHandler struct {
+	slog.Handler
+}
+
+// NewContextHandler wraps h so that records logged through a context-aware
+// slog.Logger method automatically carry whatever WithCorrelationID and
+// WithCausationID stored on the context. New's handlers are already wrapped
+// this way; call NewContextHandler directly only when building a
+// *slog.Logger some other way (a custom handler chain, a test harness) that
+// still wants context propagation.
+func NewContextHandler(h slog.Handler) slog.Handler {
+	return &contextHandler{Handler: h}
+}
+
+func (h *contextHandler) Handle(ctx context.Context, r slog.Record) error {
+	if attrs := attrsFromContext(ctx); len(attrs) > 0 {
+		r.AddAttrs(attrs...)
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+func (h *contextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &contextHandler{Handler: h.Handler.WithAttrs(attrs)}
+}
+
+func (h *contextHandler) WithGroup(name string) slog.Handler {
+	return &contextHandler{Handler: h.Handler.WithGroup(name)}
+}

--- a/logging/context_test.go
+++ b/logging/context_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,6 +86,80 @@ func TestSiblingContextsDoNotLeakAttributes(t *testing.T) {
 	require.Len(t, attrs2, 2)
 	assert.Equal(t, "cause-1", attrs1[1].Value.String())
 	assert.Equal(t, "cause-2", attrs2[1].Value.String())
+}
+
+// TestNestedWithCorrelationIDReplacesRatherThanDuplicates is the regression
+// test for withAttr appending unconditionally: a second WithCorrelationID
+// call on an already-scoped context used to leave both the old and new
+// value in the stored attribute list, so every subsequent record carried
+// two correlation_id keys. The later call — the more specific one for that
+// point in the call chain — must replace the earlier value instead.
+func TestNestedWithCorrelationIDReplacesRatherThanDuplicates(t *testing.T) {
+	ctx := WithCorrelationID(context.Background(), "corr-outer")
+	ctx = WithCorrelationID(ctx, "corr-inner")
+
+	attrs := attrsFromContext(ctx)
+	require.Len(t, attrs, 1, "the outer value must be replaced, not kept alongside the inner one")
+	assert.Equal(t, "corr-inner", attrs[0].Value.String())
+
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewTextHandler(&buf, nil)))
+	logger.InfoContext(ctx, "processing")
+
+	out := buf.String()
+	assert.Equal(t, 1, strings.Count(out, "correlation_id="),
+		"exactly one correlation_id key must appear in the output")
+	assert.Contains(t, out, "correlation_id=corr-inner")
+	assert.NotContains(t, out, "corr-outer")
+}
+
+// TestNestedWithCausationIDReplacesRatherThanDuplicates is the same
+// regression as above for CausationID, exercised independently since it is
+// a distinct attribute key with its own call path through withAttr.
+func TestNestedWithCausationIDReplacesRatherThanDuplicates(t *testing.T) {
+	ctx := WithCausationID(context.Background(), "cause-outer")
+	ctx = WithCausationID(ctx, "cause-inner")
+
+	attrs := attrsFromContext(ctx)
+	require.Len(t, attrs, 1)
+	assert.Equal(t, "cause-inner", attrs[0].Value.String())
+}
+
+// TestExplicitRecordAttributeWinsOverContextValue is the regression test
+// for contextHandler.Handle adding context attributes unconditionally: a
+// record that already carries an explicit correlation_id attribute of its
+// own used to end up with a second, context-injected correlation_id
+// alongside it. The explicit, call-site value — more specific than the
+// ambient context value — must win, and the record must carry only one
+// correlation_id key.
+func TestExplicitRecordAttributeWinsOverContextValue(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewTextHandler(&buf, nil)))
+
+	ctx := WithCorrelationID(context.Background(), "corr-from-context")
+	logger.InfoContext(ctx, "processing", CorrelationID, "corr-explicit")
+
+	out := buf.String()
+	assert.Equal(t, 1, strings.Count(out, "correlation_id="),
+		"exactly one correlation_id key must appear in the output")
+	assert.Contains(t, out, "correlation_id=corr-explicit")
+	assert.NotContains(t, out, "corr-from-context")
+}
+
+// TestExplicitRecordAttributeWinsOverContextValueInCapture confirms the
+// same precedence through the Recorder-based test kit, where a duplicate
+// key would show up as one map entry silently overwritten rather than as a
+// visibly duplicated key — verifying the *value* that wins matters just as
+// much as verifying there is only one.
+func TestExplicitRecordAttributeWinsOverContextValueInCapture(t *testing.T) {
+	logger, rec := Capture()
+
+	ctx := WithCorrelationID(context.Background(), "corr-from-context")
+	logger.InfoContext(ctx, "processing", CorrelationID, "corr-explicit")
+
+	records := rec.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, "corr-explicit", records[0].Attrs[CorrelationID])
 }
 
 func TestContextHandlerWithAttrsPreservesWrapping(t *testing.T) {

--- a/logging/context_test.go
+++ b/logging/context_test.go
@@ -1,0 +1,134 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextHandlerAddsCorrelationID(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewTextHandler(&buf, nil)))
+
+	ctx := WithCorrelationID(context.Background(), "corr-123")
+	logger.InfoContext(ctx, "processing")
+
+	assert.Contains(t, buf.String(), "correlation_id=corr-123")
+}
+
+func TestContextHandlerAddsCausationID(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewTextHandler(&buf, nil)))
+
+	ctx := WithCausationID(context.Background(), "cause-456")
+	logger.InfoContext(ctx, "processing")
+
+	assert.Contains(t, buf.String(), "causation_id=cause-456")
+}
+
+func TestContextHandlerCombinesBoth(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewTextHandler(&buf, nil)))
+
+	ctx := WithCorrelationID(context.Background(), "corr-123")
+	ctx = WithCausationID(ctx, "cause-456")
+	logger.InfoContext(ctx, "processing")
+
+	out := buf.String()
+	assert.Contains(t, out, "correlation_id=corr-123")
+	assert.Contains(t, out, "causation_id=cause-456")
+}
+
+func TestContextHandlerWithoutContextAttrsIsUnaffected(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewTextHandler(&buf, nil)))
+
+	logger.InfoContext(context.Background(), "processing")
+
+	out := buf.String()
+	assert.NotContains(t, out, "correlation_id")
+	assert.NotContains(t, out, "causation_id")
+}
+
+func TestContextHandlerPlainInfoStillWorks(t *testing.T) {
+	// Handle must work correctly even when the caller uses the
+	// non-context-aware logging methods (Info, Warn, ...): slog derives a
+	// context.Background() internally for those, so this must not panic and
+	// must simply omit any context-only attributes.
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewTextHandler(&buf, nil)))
+
+	logger.Info("processing")
+
+	assert.Contains(t, buf.String(), "msg=processing")
+}
+
+// TestSiblingContextsDoNotLeakAttributes guards the copy-on-write design in
+// withAttr: two contexts derived from one shared parent must not influence
+// each other's attributes, which an in-place append to a shared backing
+// array could allow.
+func TestSiblingContextsDoNotLeakAttributes(t *testing.T) {
+	parent := WithCorrelationID(context.Background(), "corr-shared")
+
+	child1 := WithCausationID(parent, "cause-1")
+	child2 := WithCausationID(parent, "cause-2")
+
+	attrs1 := attrsFromContext(child1)
+	attrs2 := attrsFromContext(child2)
+
+	require.Len(t, attrs1, 2)
+	require.Len(t, attrs2, 2)
+	assert.Equal(t, "cause-1", attrs1[1].Value.String())
+	assert.Equal(t, "cause-2", attrs2[1].Value.String())
+}
+
+func TestContextHandlerWithAttrsPreservesWrapping(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewTextHandler(&buf, nil)))
+
+	scoped := logger.With("static", "value")
+	ctx := WithCorrelationID(context.Background(), "corr-789")
+	scoped.InfoContext(ctx, "processing")
+
+	out := buf.String()
+	assert.Contains(t, out, "static=value")
+	assert.Contains(t, out, "correlation_id=corr-789")
+}
+
+// TestContextHandlerWithGroupPreservesWrapping checks that WithGroup keeps
+// working through contextHandler's decoration. Once a group is open,
+// everything logged through that handler — including attributes injected
+// from the context — nests inside it; that is ordinary slog group
+// semantics; a context-injected attribute "escaping" an open group would be
+// the surprising behavior.
+func TestContextHandlerWithGroupPreservesWrapping(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewJSONHandler(&buf, nil)))
+
+	scoped := logger.WithGroup("req")
+	ctx := WithCorrelationID(context.Background(), "corr-789")
+	scoped.InfoContext(ctx, "processing", "field", 1)
+
+	out := buf.String()
+	assert.Contains(t, out, `"req":{"field":1,"correlation_id":"corr-789"}`)
+}
+
+func TestNewLoggerPropagatesContextAutomatically(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/out.log"
+	logger, closer, err := New(Config{Output: path})
+	require.NoError(t, err)
+	defer closer.Close()
+
+	ctx := WithCorrelationID(context.Background(), "corr-from-new")
+	logger.InfoContext(ctx, "processing")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "correlation_id=corr-from-new")
+}

--- a/logging/doc.go
+++ b/logging/doc.go
@@ -1,0 +1,66 @@
+// Package logging establishes Trader's structured logging framework, as
+// decided by issue #21 (M1-03), built directly on log/slog.
+//
+// # Ownership
+//
+// logging is a composition-root support package, the same role config plays
+// for configuration: cmd/ binaries and test/example programs construct a
+// *slog.Logger with New and inject it into the components that need it.
+// Domain packages never construct their own logger, never read the process
+// environment or flags to configure logging, and never depend on slog's
+// mutable package-level default logger (slog.SetDefault, slog.Default, or
+// the slog.Info/Warn/Error/Debug package-level functions, all of which read
+// that default). They accept an injected *slog.Logger — or nothing at all,
+// if silence is an acceptable default — through their constructors.
+//
+// This package deliberately does not define a logger wrapper type. Trader's
+// architecture explicitly calls out "avoid a wrapper that merely duplicates
+// every slog.Logger method": components accept and use *slog.Logger
+// directly. What this package adds is everything around that: building one
+// from typed configuration, canonical attribute names, context-propagated
+// correlation, redaction, and test helpers.
+//
+// # Configuration
+//
+// Config is a plain tagged struct with no dependency on the config package;
+// a composition root loads it however it likes, typically:
+//
+//	cfg, err := config.Load[logging.Config](opts)
+//	logger, closer, err := logging.New(cfg)
+//	defer closer.Close()
+//
+// This works with zero special-casing in config because slog.Level already
+// implements encoding.TextUnmarshaler and encoding.TextMarshaler, parsing
+// "DEBUG", "INFO", "WARN", and "ERROR" (case-insensitively) on its own.
+//
+// There is no Fatal level. slog has no native FATAL, and a logging package
+// is the wrong place to hide process termination: an operator-actionable
+// "the process must stop" decision is an Error-level log followed by an
+// explicit os.Exit in the composition root, not a side effect buried inside
+// a log call. See AGENTS.md for the reasoning.
+//
+// # Canonical attributes
+//
+// Correlating log records across a run, session, account, instrument,
+// order, and cause requires agreement on attribute key names. The constants
+// in attrs.go are that agreement: RunID, SessionID, AccountID,
+// InstrumentID, OrderID, CorrelationID, and CausationID. Correlation and
+// causation IDs may initially be plain strings, per #21, until Trader-owned
+// ID types exist.
+//
+// # Redaction
+//
+// Wrap a sensitive value with Secret before logging it — logger.Info("auth",
+// "password", logging.Secret(pw)) — rather than relying on a handler to
+// guess which keys are sensitive from their names. New also installs a
+// small built-in denylist of common sensitive key names as a second,
+// best-effort layer; Secret is the mechanism that is actually reliable,
+// because it is correct regardless of what the attribute is named.
+//
+// # Testing
+//
+// Use Discard for a component test that needs a valid logger but does not
+// care about its output, and Capture for a test that needs to assert on
+// what was logged: Capture returns a *Recorder whose Records method returns
+// structured records directly, without parsing formatted console output.
+package logging

--- a/logging/example_test.go
+++ b/logging/example_test.go
@@ -1,0 +1,97 @@
+package logging_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/rustyeddy/trader/logging"
+)
+
+// ExampleNew shows typical composition-root wiring: build a Config
+// (normally via config.Load[logging.Config]), build a logger from it, and
+// defer closing whatever it opened.
+//
+// This example is not output-verified: TextHandler's default output
+// includes a wall-clock timestamp, which would make the expected output
+// different on every run. See ExampleCapture for a fully verified example.
+func ExampleNew() {
+	cfg := logging.Config{
+		Level:  0, // slog.LevelInfo
+		Format: "text",
+		Output: "stdout",
+	}
+
+	logger, closer, err := logging.New(cfg)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	defer closer.Close()
+
+	logger.Info("server started", "port", 8080)
+}
+
+// ExampleCapture shows the test-kit pattern for asserting on structured log
+// output without parsing formatted console text.
+func ExampleCapture() {
+	logger, rec := logging.Capture()
+
+	logger.Info("order placed", logging.OrderID, "abc123")
+
+	for _, r := range rec.Records() {
+		fmt.Println(r.Message, r.Attrs[logging.OrderID])
+	}
+	// Output:
+	// order placed abc123
+}
+
+// ExampleSecret shows redacting a sensitive value at the call site, the
+// package's primary redaction mechanism.
+func ExampleSecret() {
+	logger, rec := logging.Capture()
+
+	logger.Info("authenticated", "password", logging.Secret("hunter2"))
+
+	fmt.Println(rec.Records()[0].Attrs["password"])
+	// Output:
+	// REDACTED
+}
+
+// ExampleWithCorrelationID shows propagating a correlation ID through
+// context.Context so every record logged while handling one logical
+// operation can be grouped together, without passing the attribute
+// explicitly at every call site.
+func ExampleWithCorrelationID() {
+	logger, rec := logging.Capture()
+
+	ctx := logging.WithCorrelationID(context.Background(), "corr-123")
+	logger.InfoContext(ctx, "processing order")
+
+	fmt.Println(rec.Records()[0].Attrs[logging.CorrelationID])
+	// Output:
+	// corr-123
+}
+
+// ExampleWithComponent shows scoping a logger to one subsystem, so its
+// records stay distinguishable from other subsystems after aggregation.
+func ExampleWithComponent() {
+	logger, rec := logging.Capture()
+
+	broker := logging.WithComponent(logger, "broker")
+	broker.Info("connected")
+
+	fmt.Println(rec.Records()[0].Attrs[logging.Component])
+	// Output:
+	// broker
+}
+
+// ExampleDiscard shows building a valid logger for a component test that
+// doesn't care about log output.
+func ExampleDiscard() {
+	logger := logging.Discard()
+	logger.Info("this goes nowhere")
+	fmt.Fprintln(os.Stdout, "component ran without a real logger")
+	// Output:
+	// component ran without a real logger
+}

--- a/logging/redact.go
+++ b/logging/redact.go
@@ -1,0 +1,64 @@
+package logging
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// secretValue wraps a value so its structured-log representation is always
+// the literal string "REDACTED", regardless of what the value actually is
+// or what key it is logged under.
+type secretValue struct {
+	v any
+}
+
+// Secret wraps v so logging it never reveals its actual content — logging a
+// value wrapped with Secret always resolves to the string "REDACTED". This
+// is the primary redaction mechanism, correct regardless of what key the
+// value is logged under, and should be used at every call site that logs a
+// credential, token, or other sensitive value:
+//
+//	logger.Info("authenticated", "password", logging.Secret(pw))
+//
+// New also installs a small denylist-based ReplaceAttr (see
+// redactSensitiveKeys) as a second, best-effort layer that catches a
+// sensitive value logged under a conventionally-named key without an
+// explicit Secret wrap. Secret is the mechanism that is actually reliable,
+// since it does not depend on guessing key names.
+func Secret(v any) slog.LogValuer {
+	return secretValue{v: v}
+}
+
+// LogValue implements slog.LogValuer.
+func (s secretValue) LogValue() slog.Value {
+	return slog.StringValue("REDACTED")
+}
+
+// sensitiveKeys is a best-effort denylist of attribute key names commonly
+// used for credentials, matched case-insensitively. It exists as defense in
+// depth, not as the primary redaction mechanism — see Secret.
+var sensitiveKeys = map[string]bool{
+	"password":    true,
+	"passwd":      true,
+	"secret":      true,
+	"token":       true,
+	"api_key":     true,
+	"apikey":      true,
+	"credential":  true,
+	"credentials": true,
+	"private_key": true,
+	"privatekey":  true,
+}
+
+// redactSensitiveKeys is a slog.HandlerOptions.ReplaceAttr function that
+// redacts any attribute whose key (case-insensitively) appears in
+// sensitiveKeys. It leaves a slog.KindGroup value alone: replacing a group
+// with a plain string would collapse whatever structure it carried, and a
+// group attribute's own leaf values are still visited by ReplaceAttr
+// individually.
+func redactSensitiveKeys(_ []string, a slog.Attr) slog.Attr {
+	if a.Value.Kind() != slog.KindGroup && sensitiveKeys[strings.ToLower(a.Key)] {
+		return slog.String(a.Key, "REDACTED")
+	}
+	return a
+}

--- a/logging/redact.go
+++ b/logging/redact.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 )
 
-// secretValue wraps a value so its structured-log representation is always
-// the literal string "REDACTED", regardless of what the value actually is
-// or what key it is logged under.
-type secretValue struct {
-	v any
-}
+// secretValue is deliberately stateless: it does not retain the value
+// Secret was called with. LogValue never needs it, and holding onto it
+// would keep the credential reachable through the wrapper itself — by
+// reflection, by fmt's default struct formatting, or by any code that
+// inspects the value before an slog handler resolves it as a LogValuer —
+// defeating the point of wrapping it in the first place.
+type secretValue struct{}
 
 // Secret wraps v so logging it never reveals its actual content — logging a
 // value wrapped with Secret always resolves to the string "REDACTED". This
@@ -20,13 +21,17 @@ type secretValue struct {
 //
 //	logger.Info("authenticated", "password", logging.Secret(pw))
 //
+// v is accepted only so the call site documents what is being redacted; it
+// is discarded immediately and never stored — see secretValue.
+//
 // New also installs a small denylist-based ReplaceAttr (see
 // redactSensitiveKeys) as a second, best-effort layer that catches a
 // sensitive value logged under a conventionally-named key without an
 // explicit Secret wrap. Secret is the mechanism that is actually reliable,
 // since it does not depend on guessing key names.
 func Secret(v any) slog.LogValuer {
-	return secretValue{v: v}
+	_ = v
+	return secretValue{}
 }
 
 // LogValue implements slog.LogValuer.

--- a/logging/redact_test.go
+++ b/logging/redact_test.go
@@ -1,0 +1,77 @@
+package logging
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretRedactsUnderAnyKeyName(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	logger.Info("event", "totally_unremarkable_key", Secret("super-secret-value"))
+
+	out := buf.String()
+	assert.Contains(t, out, "totally_unremarkable_key=REDACTED")
+	assert.NotContains(t, out, "super-secret-value")
+}
+
+func TestSecretRedactsInJSON(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	logger.Info("event", "field", Secret(12345))
+
+	out := buf.String()
+	assert.Contains(t, out, `"field":"REDACTED"`)
+	assert.NotContains(t, out, "12345")
+}
+
+func TestNewRedactsCommonSensitiveKeyNames(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/out.log"
+	logger, closer, err := New(Config{Output: path})
+	require.NoError(t, err)
+
+	logger.Info("login", "password", "hunter2", "username", "alice")
+	require.NoError(t, closer.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "password=REDACTED")
+	assert.NotContains(t, string(data), "hunter2")
+	assert.Contains(t, string(data), "username=alice", "only sensitive-named keys are redacted")
+}
+
+func TestNewRedactsSensitiveKeysCaseInsensitively(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/out.log"
+	logger, closer, err := New(Config{Output: path})
+	require.NoError(t, err)
+
+	logger.Info("login", "Password", "hunter2", "API_KEY", "sk-live-abc")
+	require.NoError(t, closer.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "hunter2")
+	assert.NotContains(t, string(data), "sk-live-abc")
+}
+
+func TestRedactSensitiveKeysLeavesGroupsAlone(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{ReplaceAttr: redactSensitiveKeys})
+	logger := slog.New(h)
+
+	logger.Info("event", slog.Group("secret", "inner", "value"))
+
+	out := buf.String()
+	// The group itself is not collapsed to "REDACTED"; its leaf value,
+	// whose key "inner" is not itself sensitive, passes through untouched.
+	assert.Contains(t, out, `"secret":{"inner":"value"}`)
+}

--- a/logging/redact_test.go
+++ b/logging/redact_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"bytes"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -19,6 +20,28 @@ func TestSecretRedactsUnderAnyKeyName(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "totally_unremarkable_key=REDACTED")
 	assert.NotContains(t, out, "super-secret-value")
+}
+
+// TestSecretWrapperCannotLeakThroughOrdinaryFormatting is the regression
+// test for secretValue previously retaining the wrapped value in a field.
+// A LogValuer's job is to control what an slog handler prints, but nothing
+// stops other code from formatting or reflecting over the wrapper directly
+// -- fmt.Sprintf("%v", ...) does not know about slog.LogValuer and will
+// happily print an unexported field's content. The wrapper must therefore
+// hold nothing worth printing, not just resolve to "REDACTED" through the
+// interface slog itself calls.
+func TestSecretWrapperCannotLeakThroughOrdinaryFormatting(t *testing.T) {
+	const original = "hunter2-super-secret"
+
+	wrapped := Secret(original)
+
+	assert.NotContains(t, fmt.Sprintf("%v", wrapped), original)
+	assert.NotContains(t, fmt.Sprintf("%+v", wrapped), original)
+	assert.NotContains(t, fmt.Sprintf("%#v", wrapped), original)
+
+	// The wrapper itself must carry no fields at all, not merely fields that
+	// happen not to print the secret.
+	assert.Equal(t, secretValue{}, wrapped)
 }
 
 func TestSecretRedactsInJSON(t *testing.T) {

--- a/logging/testkit.go
+++ b/logging/testkit.go
@@ -1,0 +1,147 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Discard returns a *slog.Logger that discards everything logged through
+// it. Use it in a component test that needs a valid logger but does not
+// care what gets logged.
+func Discard() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// Record is one structured log record captured by Capture, in a shape a
+// test can assert on directly instead of parsing formatted console output.
+// Attrs holds every attribute visible on the record, including ones added
+// via Logger.With and WithGroup, with grouped attributes nested as
+// map[string]any and any slog.LogValuer (including Secret) already
+// resolved to its logged value — the same resolution a real handler
+// performs.
+type Record struct {
+	Time    time.Time
+	Level   slog.Level
+	Message string
+	Attrs   map[string]any
+}
+
+// Recorder collects the records logged through the *slog.Logger that
+// Capture returned it alongside. It is safe for concurrent use.
+type Recorder struct {
+	mu      sync.Mutex
+	records []Record
+}
+
+// Records returns every record captured so far, in the order they were
+// logged.
+func (r *Recorder) Records() []Record {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]Record, len(r.records))
+	copy(out, r.records)
+	return out
+}
+
+// Reset discards every record captured so far, so one Recorder can be
+// reused across the cases of a table-driven test instead of calling Capture
+// again for each one.
+func (r *Recorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = nil
+}
+
+func (r *Recorder) add(rec Record) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = append(r.records, rec)
+}
+
+// Capture returns a *slog.Logger and the *Recorder that captures everything
+// logged through it — for a test that needs to assert on structured log
+// output. The logger's handler is wrapped with NewContextHandler, so
+// WithCorrelationID and WithCausationID work with it exactly as they do
+// with a logger built by New.
+func Capture() (*slog.Logger, *Recorder) {
+	rec := &Recorder{}
+	h := &recordingHandler{recorder: rec, level: slog.LevelDebug}
+	return slog.New(NewContextHandler(h)), rec
+}
+
+// recordingHandler is a minimal slog.Handler that appends every record it
+// receives to a Recorder instead of formatting it, resolving attribute
+// values and honoring WithAttrs/WithGroup the same way a real handler does.
+type recordingHandler struct {
+	recorder *Recorder
+	level    slog.Level
+	attrs    []slog.Attr
+	groups   []string
+}
+
+func (h *recordingHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	attrs := map[string]any{}
+	for _, a := range h.attrs {
+		addAttr(attrs, h.groups, a)
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		addAttr(attrs, h.groups, a)
+		return true
+	})
+
+	h.recorder.add(Record{
+		Time:    r.Time,
+		Level:   r.Level,
+		Message: r.Message,
+		Attrs:   attrs,
+	})
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := *h
+	next.attrs = append(append([]slog.Attr{}, h.attrs...), attrs...)
+	return &next
+}
+
+func (h *recordingHandler) WithGroup(name string) slog.Handler {
+	next := *h
+	next.groups = append(append([]string{}, h.groups...), name)
+	return &next
+}
+
+// addAttr resolves a (running any slog.LogValuer, including Secret, to its
+// logged value) and stores it in root at the path named by groups, creating
+// nested maps for a slog.Group value the same way a real handler nests one.
+func addAttr(root map[string]any, groups []string, a slog.Attr) {
+	a.Value = a.Value.Resolve()
+
+	if a.Value.Kind() == slog.KindGroup {
+		nested := map[string]any{}
+		for _, ga := range a.Value.Group() {
+			addAttr(nested, nil, ga)
+		}
+		setNested(root, groups, a.Key, nested)
+		return
+	}
+	setNested(root, groups, a.Key, a.Value.Any())
+}
+
+func setNested(root map[string]any, groups []string, key string, value any) {
+	m := root
+	for _, g := range groups {
+		next, ok := m[g].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			m[g] = next
+		}
+		m = next
+	}
+	m[key] = value
+}

--- a/logging/testkit.go
+++ b/logging/testkit.go
@@ -36,12 +36,33 @@ type Recorder struct {
 }
 
 // Records returns every record captured so far, in the order they were
-// logged.
+// logged. The returned records, including their Attrs maps, are an
+// independent copy: mutating one has no effect on the Recorder's internal
+// state or on any other slice Records has returned, including one returned
+// by an earlier or later call.
 func (r *Recorder) Records() []Record {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	out := make([]Record, len(r.records))
-	copy(out, r.records)
+	for i, rec := range r.records {
+		out[i] = rec
+		out[i].Attrs = deepCopyAttrs(rec.Attrs)
+	}
+	return out
+}
+
+// deepCopyAttrs copies attrs, recursively copying any nested map[string]any
+// produced by a grouped attribute (see addAttr). A shallow slice copy alone
+// would still leave every Record's Attrs map — a reference type — aliased
+// between the Recorder's internal state and whatever Records returns.
+func deepCopyAttrs(attrs map[string]any) map[string]any {
+	out := make(map[string]any, len(attrs))
+	for k, v := range attrs {
+		if nested, ok := v.(map[string]any); ok {
+			v = deepCopyAttrs(nested)
+		}
+		out[k] = v
+	}
 	return out
 }
 

--- a/logging/testkit_test.go
+++ b/logging/testkit_test.go
@@ -1,0 +1,155 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscardDoesNotPanic(t *testing.T) {
+	logger := Discard()
+	require.NotNil(t, logger)
+	assert.NotPanics(t, func() {
+		logger.Info("anything", "key", "value")
+		logger.Error("anything", "err", assert.AnError)
+	})
+}
+
+func TestCaptureRecordsBasicFields(t *testing.T) {
+	logger, rec := Capture()
+	logger.Info("hello", "key", "value")
+
+	records := rec.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, slog.LevelInfo, records[0].Level)
+	assert.Equal(t, "hello", records[0].Message)
+	assert.Equal(t, "value", records[0].Attrs["key"])
+}
+
+func TestCaptureRecordsMultipleInOrder(t *testing.T) {
+	logger, rec := Capture()
+	logger.Info("first")
+	logger.Warn("second")
+	logger.Error("third")
+
+	records := rec.Records()
+	require.Len(t, records, 3)
+	assert.Equal(t, "first", records[0].Message)
+	assert.Equal(t, "second", records[1].Message)
+	assert.Equal(t, "third", records[2].Message)
+}
+
+func TestCaptureHonorsWithAttrs(t *testing.T) {
+	logger, rec := Capture()
+	scoped := logger.With("service", "trader")
+	scoped.Info("started")
+
+	records := rec.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, "trader", records[0].Attrs["service"])
+}
+
+func TestCaptureHonorsWithGroup(t *testing.T) {
+	logger, rec := Capture()
+	scoped := logger.WithGroup("request")
+	scoped.Info("handled", "status", 200)
+
+	records := rec.Records()
+	require.Len(t, records, 1)
+	group, ok := records[0].Attrs["request"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, int64(200), group["status"])
+}
+
+func TestCaptureHonorsInlineGroup(t *testing.T) {
+	logger, rec := Capture()
+	logger.Info("event", slog.Group("http", "method", "GET", "status", 200))
+
+	records := rec.Records()
+	require.Len(t, records, 1)
+	group, ok := records[0].Attrs["http"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "GET", group["method"])
+	assert.Equal(t, int64(200), group["status"])
+}
+
+func TestCaptureResolvesSecret(t *testing.T) {
+	logger, rec := Capture()
+	logger.Info("authenticated", "password", Secret("hunter2"))
+
+	records := rec.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, "REDACTED", records[0].Attrs["password"])
+}
+
+func TestCaptureWorksWithComponent(t *testing.T) {
+	logger, rec := Capture()
+	scoped := WithComponent(logger, "broker")
+	scoped.Info("connected")
+
+	records := rec.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, "broker", records[0].Attrs[Component])
+}
+
+func TestCapturePropagatesContext(t *testing.T) {
+	logger, rec := Capture()
+	ctx := WithCorrelationID(context.Background(), "corr-abc")
+	logger.InfoContext(ctx, "processing")
+
+	records := rec.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, "corr-abc", records[0].Attrs[CorrelationID])
+}
+
+func TestRecorderReset(t *testing.T) {
+	logger, rec := Capture()
+	logger.Info("first")
+	require.Len(t, rec.Records(), 1)
+
+	rec.Reset()
+	assert.Empty(t, rec.Records())
+
+	logger.Info("second")
+	records := rec.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, "second", records[0].Message)
+}
+
+func TestRecorderRecordsIsASnapshotCopy(t *testing.T) {
+	logger, rec := Capture()
+	logger.Info("first")
+
+	snapshot := rec.Records()
+	logger.Info("second")
+
+	assert.Len(t, snapshot, 1, "a previously returned slice must not grow when more is logged")
+	assert.Len(t, rec.Records(), 2)
+}
+
+func TestRecorderConcurrentUse(t *testing.T) {
+	logger, rec := Capture()
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			logger.Info("concurrent")
+		})
+	}
+	wg.Wait()
+
+	assert.Len(t, rec.Records(), 50)
+}
+
+func TestCaptureRespectsDebugLevel(t *testing.T) {
+	logger, rec := Capture()
+	logger.Debug("visible because Capture defaults to Debug level")
+
+	records := rec.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, slog.LevelDebug, records[0].Level)
+}

--- a/logging/testkit_test.go
+++ b/logging/testkit_test.go
@@ -131,6 +131,43 @@ func TestRecorderRecordsIsASnapshotCopy(t *testing.T) {
 	assert.Len(t, rec.Records(), 2)
 }
 
+// TestRecorderRecordsDeepCopiesAttrs is the regression test for Records
+// returning a slice copy while every Record's Attrs map still aliased the
+// Recorder's internal state: mutating a map obtained from one call to
+// Records used to be visible in a later call, silently violating the
+// "independent snapshot" contract Records documents.
+func TestRecorderRecordsDeepCopiesAttrs(t *testing.T) {
+	logger, rec := Capture()
+	logger.Info("event", "key", "original")
+
+	first := rec.Records()
+	first[0].Attrs["key"] = "mutated"
+	first[0].Attrs["injected"] = "should not leak"
+
+	second := rec.Records()
+	assert.Equal(t, "original", second[0].Attrs["key"],
+		"mutating a returned record must not affect a later snapshot")
+	_, present := second[0].Attrs["injected"]
+	assert.False(t, present, "a key added to a returned map must not leak into a later snapshot")
+}
+
+// TestRecorderRecordsDeepCopiesNestedGroupAttrs covers the same guarantee
+// for a grouped attribute's nested map, which deepCopyAttrs must recurse
+// into rather than copying only the top level.
+func TestRecorderRecordsDeepCopiesNestedGroupAttrs(t *testing.T) {
+	logger, rec := Capture()
+	logger.Info("event", slog.Group("http", "status", 200))
+
+	first := rec.Records()
+	group := first[0].Attrs["http"].(map[string]any)
+	group["status"] = 999
+
+	second := rec.Records()
+	secondGroup := second[0].Attrs["http"].(map[string]any)
+	assert.Equal(t, int64(200), secondGroup["status"],
+		"mutating a nested group map must not affect a later snapshot")
+}
+
 func TestRecorderConcurrentUse(t *testing.T) {
 	logger, rec := Capture()
 


### PR DESCRIPTION
## Summary

Implements `logging`, Trader's structured logging framework built directly on `log/slog`, per issue #21 (M1-03).

- `Config` (`Level slog.Level`, `Format` text/json, `Output` stderr/stdout/file path) + `New(cfg) (*slog.Logger, io.Closer, error)`. `Config`'s zero value is itself usable (`slog.LevelInfo`, text, stderr).
- Canonical attribute constants (`RunID`, `SessionID`, `AccountID`, `InstrumentID`, `OrderID`, `CorrelationID`, `CausationID`, `Component`) and a `WithComponent` helper for component-scoped child loggers.
- Context-propagated correlation: `WithCorrelationID`/`WithCausationID` store attributes on `context.Context`; a `slog.Handler` decorator (`NewContextHandler`, wired in automatically by `New`) injects them into every record logged through slog's own context-aware methods (`InfoContext`, etc.) — no new logging methods invented.
- Redaction: `Secret(v)` (an `slog.LogValuer`, correct regardless of key name) as the primary mechanism, plus a small case-insensitive denylist `ReplaceAttr` as defense in depth.
- Test kit: `Discard()` for tests that need a valid logger and don't care about output, and `Capture()`/`Recorder` for tests that need to assert on structured records without parsing formatted text.
- `arch_test.go` mechanically enforces "no mutable global logger": nothing outside `logging/cmd/test` may call `slog.SetDefault`, `slog.Default`, or the package-level `Debug`/`Info`/`Warn`/`Error`/`Log`/`LogAttrs`/`With` functions.
- No wrapper type: components accept and use `*slog.Logger` directly, per the architecture doc's explicit "avoid a wrapper that merely duplicates every slog.Logger method."

Also updates `AGENTS.md` to settle two design decisions raised during planning (see below), and adds a `logging` section to `README.md` matching the existing `num`/`config` entries.

## Design decisions

Discussed and confirmed before implementation (see the plan comment on #21):

- **No `Fatal` level.** slog has no native FATAL, and hiding `os.Exit` inside a logging helper hides process-termination control flow at the call site and makes it hard to test. An operator-actionable fatal condition is an Error-level log plus an explicit `os.Exit` in the composition root.
- **Default output `stderr`**, not `/var/log/trader.log` — portable across dev shells, tests, and containers without assuming filesystem permissions a library shouldn't assume. A flag/config field (`Output`) still lets an operator point logging at any file path.
- **Default format `text`.**

## Why

Composition roots need one consistent way to build structured loggers and inject them into components, with correlation/causation IDs that survive context propagation and redaction that's correct by construction rather than by guessing key names.

## Test plan

- [x] `make check` (fmt-check, vet, test, race) — green across the whole repository
- [x] `logging` package coverage: 98.8%
- [x] `Config` confirmed to work with `config.Load` with zero special-casing (`slog.Level` already implements `encoding.TextUnmarshaler`) — `config_integration_test.go`
- [x] Context propagation tested including sibling-context isolation (`TestSiblingContextsDoNotLeakAttributes`) and interaction with `WithGroup`/`WithAttrs`
- [x] Redaction tested for both `Secret()` and the denylist, including case-insensitivity and that groups aren't collapsed
- [x] `Recorder` tested for concurrent use, snapshot semantics, and resolving `slog.LogValuer` (so `Secret` values show up as `"REDACTED"` in captured records exactly as in real output)
- [x] 5 of 6 `Example` functions are output-verified by `go test`; `ExampleNew` is compiled/vetted but not output-asserted since `TextHandler`'s default timestamp makes exact output non-deterministic

## Acceptance criteria (#21)

- [x] Text and JSON formats supported
- [x] Level controlled through typed configuration
- [x] Canonical correlation attribute names documented
- [x] Credentials and secrets are not emitted
- [x] Components work safely with an injected discard logger
- [x] Tests can inspect structured records without parsing formatted console output
- [x] No package depends on a mutable global logger (mechanically enforced)
- [x] Package documentation includes usage examples
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)