### PR TITLE
Add instrument package: economic instrument and listing value models

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,17 +148,29 @@ identity:
 ```go
 eur, usd := num.MustParseCurrency("EUR"), num.MustParseCurrency("USD")
 eurUsd, err := instrument.NewCurrencyPair(eur, usd)
+if err != nil {
+	log.Fatal(err)
+}
 // eurUsd.ID().String() == "fx:EUR/USD", regardless of whether the
 // provider spelled it "EUR_USD", "EURUSD", or "EUR/USD"
 
 dec, err := instrument.NewFuture("ES", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
+if err != nil {
+	log.Fatal(err)
+}
 mar, err := instrument.NewFuture("ES", time.Date(2027, time.March, 20, 0, 0, 0, 0, time.UTC))
+if err != nil {
+	log.Fatal(err)
+}
 // dec and mar are distinct Instruments: an individual expiring contract,
 // not the contract family, is the Instrument
 ```
 
 Initial kinds are currency pairs, equities, ETFs, individual futures
-contracts, non-orderable continuous research series, and indices. See the
+contracts, non-orderable continuous research series, and indices. `Listing`
+keeps provider (a broker or data vendor, e.g. `"IBKR"`) distinct from venue
+(an exchange, e.g. `"NASDAQ"`) and rejects `Tradable: true` for a
+non-orderable `Instrument` — see the
 [package doc comment](instrument/doc.go) for why futures split into two
 kinds instead of one, and why synthetic/multi-leg instruments are deferred.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,31 @@ the `EventID` immediately before it. See the
 [package doc comment](id/doc.go) for the full identifier list and the
 worked intent → proposal → order → fill example.
 
+### instrument
+
+`instrument` separates *what an economic thing is* (`Instrument`) from *how
+a venue exposes it for trading* (`Listing`). Unlike `id`'s generated
+identifiers, `instrument.ID` is canonical and deterministic — two provider
+adapters parsing different spellings of the same pair resolve to the same
+identity:
+
+```go
+eur, usd := num.MustParseCurrency("EUR"), num.MustParseCurrency("USD")
+eurUsd, err := instrument.NewCurrencyPair(eur, usd)
+// eurUsd.ID().String() == "fx:EUR/USD", regardless of whether the
+// provider spelled it "EUR_USD", "EURUSD", or "EUR/USD"
+
+dec, err := instrument.NewFuture("ES", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
+mar, err := instrument.NewFuture("ES", time.Date(2027, time.March, 20, 0, 0, 0, 0, time.UTC))
+// dec and mar are distinct Instruments: an individual expiring contract,
+// not the contract family, is the Instrument
+```
+
+Initial kinds are currency pairs, equities, ETFs, individual futures
+contracts, non-orderable continuous research series, and indices. See the
+[package doc comment](instrument/doc.go) for why futures split into two
+kinds instead of one, and why synthetic/multi-leg instruments are deferred.
+
 ## Documentation
 
 - [Framework requirements](docs/arch/trader-framework-requirements.org)

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -69,7 +69,7 @@ believed at that time.
 |-----+-------------------------------------------------------------------+------------|
 | 001 | Modular monolith before service decomposition                     | Accepted   |
 | 002 | Ports and adapters dependency direction                           | Accepted   |
-| 003 | Instrument versus listing identity                                | Proposed   |
+| 003 | Instrument versus listing identity                                | Accepted   |
 | 004 | Exact numeric representation                                      | Proposed   |
 | 005 | Strategy emits intents, not broker orders                         | Accepted   |
 | 006 | Execution and risk are separate stages                            | Accepted   |
@@ -172,33 +172,90 @@ stable domain concepts.
 
 ** Status
 
-Proposed
+Accepted
 
 ** Context
 
 Symbols collide across venues, brokers rename products, and futures
 contracts expire.  The architecture proposes distinct concepts for
-economic instruments, venue listings, and specific contracts.  The exact
-identifier scheme, resolver contract, and equivalence rules are still
-under discussion.
+economic instruments, venue listings, and specific contracts.  Issue #25
+(M1-07) required settling the exact identifier scheme, the field split
+between =Instrument= and =Listing=, and — the one genuine inconsistency
+found during design review — whether a futures =Instrument= denotes a
+contract family (e.g. E-mini S&P 500) or one specific expiring contract
+(e.g. ES December 2026).
 
 ** Decision
 
-Adopt separate types for =instrument.ID=, =instrument.Listing=, and
-=instrument.Spec= as sketched in the architecture document.  Final field
-sets, identifier encoding, and resolver semantics remain open and will be
-ratified before =v0= freezes the instrument package.
+=instrument.ID= is canonical and deterministic, never a generated
+identifier: two calls to the same per-kind constructor with the same
+normalized economic attributes always produce an equal ID, regardless of
+which provider symbol spelling produced the inputs.  This is a different
+identity scheme from the =id= package's =ID[K]=, which is deliberately
+random and regenerated per event; instruments must not receive a fresh
+identity every run.  Six initial kinds are supported: =KindCurrencyPair=,
+=KindEquity=, =KindETF=, =KindFuture=, =KindContinuousSeries=, and
+=KindIndex=.
+
+=Instrument= holds economic identity only: what the thing is, independent
+of provider or venue.  =Listing= holds venue-specific trading mechanics:
+provider symbol (display-only, never identity), tick size, quantity
+increment, contract multiplier, settlement currency, and current
+tradability, via a separate =Spec= value embedded in =Listing=.
+
+A futures =Instrument= is one specific expiring contract, not the contract
+family: ES December 2026 and ES March 2027 are distinct =Instrument=
+values, because expiration is part of what makes them the actual, distinct
+orderable economic objects — the same way base/quote defines a currency
+pair's identity.  A continuous, back-adjusted research series is not a
+flag on a =Listing= of what looks like a tradable contract; it is its own
+kind, =KindContinuousSeries=, with its own ID constructor and no single
+expiration.  This makes "tradable versus research-only" and "a specific
+contract versus its continuous series" decidable from =Kind= alone.
+
+Equity and ETF identity uses exchange+ticker as Trader's =v0= identity
+convention, explicitly documented as a convention rather than a claim of
+permanent global security identity — corporate actions, ticker reuse, and
+venue changes remain a known, deferred concern.
+
+A =Resolver= mapping Trader IDs to provider- or broker-native symbols, and
+any persistent registry/catalog beyond this deterministic construction
+scheme, remain future, additive concerns and are not part of this
+decision.
 
 ** Consequences
 
-- Prevents symbol collisions across brokers.
-- Requires a resolver at every provider or broker boundary.
-- Multi-leg and synthetic instruments remain an explicit deferred concern.
+- Prevents symbol collisions across brokers without a generated identifier
+  or a persistent registry.
+- Two different provider adapters parsing different spellings of the same
+  instrument converge on the same =Instrument= automatically once they
+  normalize into typed inputs (=num.Currency=, exchange, ticker) before
+  constructing an ID.
+- Futures require two kinds rather than one, and a =Listing= is never
+  itself the unit that distinguishes a contract from its continuous
+  series.
+- Equity/ETF identity is acknowledged as provisional; a more durable
+  identity scheme is a later, additive change if exchange+ticker proves
+  insufficient.
+- Multi-leg and synthetic instruments remain an explicit deferred concern,
+  mechanically enforced by an architecture test rejecting leg/synthetic
+  field names in the =instrument= package.
 
 ** Alternatives Considered
 
 - *Single =Symbol= string as identity.* Rejected because it cannot
   represent multi-venue listings or expiring contracts safely.
+- *Generated (ULID-style) instrument identity, matching the =id=
+  package's other kinds.* Rejected because it would give two
+  representations of the same real-world instrument — or the same
+  instrument across two runs — different identities, which is exactly
+  backwards for something with natural economic identity.
+- *Futures =Instrument= as the contract family, with expiration living on
+  a =Listing= or a new =Contract= type.* Considered and rejected during
+  design review: it required inventing a third top-level concept solely to
+  hold what is actually part of a contract's identity, and blurred
+  =Listing='s meaning from "how a venue exposes an instrument" into also
+  meaning "which specific contract."
 
 * ADR-004: Exact numeric representation
 

--- a/instrument/arch_test.go
+++ b/instrument/arch_test.go
@@ -1,0 +1,101 @@
+package instrument
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file mechanically enforces the "no synthetic or multi-leg fields"
+// constraint from issue #25 and the architecture document's "Deferred:
+// Synthetic and Multi-Leg Instruments" section: nothing in this package's
+// non-test source may name a struct field after legs, synthetic
+// composition, or multi-leg execution. Adding such a field is a deliberate
+// architectural decision — the deferred section names the reasons for
+// waiting in detail — not something that should slip in as an incidental
+// addition to an unrelated change.
+var forbiddenFieldSubstrings = []string{"leg", "synthetic", "multileg"}
+
+// TestNoSyntheticOrMultiLegFields walks this package's own non-test source
+// files and fails if any struct field name matches a forbidden substring.
+func TestNoSyntheticOrMultiLegFields(t *testing.T) {
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+
+		fset := token.NewFileSet()
+		path := filepath.Join(dir, e.Name())
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		require.NoError(t, err)
+
+		for _, v := range findForbiddenFields(fset, file) {
+			assert.Fail(t, "forbidden field name", v)
+		}
+	}
+}
+
+// TestForbiddenFieldDetectorFindsSyntheticFields proves the detector used
+// above actually fires, against a fabricated source that is never part of
+// the real package.
+func TestForbiddenFieldDetectorFindsSyntheticFields(t *testing.T) {
+	const src = `package instrument
+
+type Bad struct {
+	Legs      []int
+	Synthetic bool
+	MultiLeg  bool
+	Fine      string
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "bad.go", src, 0)
+	require.NoError(t, err)
+
+	violations := findForbiddenFields(fset, file)
+	// MultiLeg matches both "leg" and "multileg", so Legs + Synthetic +
+	// MultiLeg (x2) is 4 violations, not 3.
+	assert.Len(t, violations, 4)
+}
+
+func findForbiddenFields(fset *token.FileSet, file *ast.File) []string {
+	var violations []string
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		ts, ok := n.(*ast.TypeSpec)
+		if !ok {
+			return true
+		}
+		st, ok := ts.Type.(*ast.StructType)
+		if !ok || st.Fields == nil {
+			return true
+		}
+		for _, field := range st.Fields.List {
+			for _, name := range field.Names {
+				lower := strings.ToLower(name.Name)
+				for _, forbidden := range forbiddenFieldSubstrings {
+					if strings.Contains(lower, forbidden) {
+						violations = append(violations, ts.Name.Name+"."+name.Name+" at "+
+							fset.Position(field.Pos()).String()+" matches deferred synthetic/multi-leg naming ("+forbidden+")")
+					}
+				}
+			}
+		}
+		return true
+	})
+
+	return violations
+}

--- a/instrument/doc.go
+++ b/instrument/doc.go
@@ -1,0 +1,77 @@
+// Package instrument implements Trader's economic instrument and listing
+// value models, as decided by issue #25 (M1-07) and ADR-003.
+//
+// # Instrument versus Listing
+//
+// Instrument is what an economic thing is, independent of any provider,
+// venue, or symbol spelling. Listing is how one specific venue exposes an
+// Instrument for trading: its venue-native symbol, tick size, quantity
+// increment, contract multiplier, settlement currency, and whether it is
+// currently tradable there.
+//
+//	Instrument = what economic thing is this?
+//	Listing    = how does a provider/venue expose or trade it?
+//
+// EUR/USD is one Instrument. An OANDA adapter parsing "EUR_USD" and another
+// provider's adapter parsing "EURUSD" both resolve, after normalizing to
+// num.Currency values, to the identical Instrument — see ID below. Each
+// provider's own listing of it — its symbol text, tick size, and whether it
+// is currently tradable there — is a separate Listing referencing that one
+// Instrument by ID.
+//
+// # ID is canonical and deterministic, not generated
+//
+// instrument.ID is a different identity scheme from the id package's
+// ID[K]: id.ID[K] is deliberately random and regenerated per event (a new
+// RunID per run, a new OrderID per order); an instrument has a natural,
+// canonical identity instead. Two otherwise-identical instances of EUR/USD
+// must never be distinct — a fresh identity every run would be exactly
+// wrong. This is why id's own package doc comment named this package,
+// rather than a generated id.InstrumentID, as where instrument identity
+// would come from.
+//
+// Every ID is built deterministically from an instrument's economic
+// attributes by a per-kind constructor (CurrencyPairID, EquityID, ETFID,
+// FutureID, ContinuousSeriesID, IndexID), never parsed from free-form
+// provider text. A provider adapter converts whatever spelling it receives
+// into typed inputs — num.Currency values, a normalized exchange and
+// ticker — before calling one of these constructors; by the time this
+// package sees the input, there is no spelling left to be inconsistent
+// about.
+//
+// # Six initial kinds, and why futures split in two
+//
+// KindCurrencyPair, KindEquity, KindETF, KindFuture, KindContinuousSeries,
+// and KindIndex are this package's initial kinds (see Kind).
+//
+// A futures Instrument is one specific expiring contract, not the contract
+// family: the December 2026 and March 2027 E-mini S&P 500 contracts are
+// two different Instruments, because they are the actual distinct
+// orderable economic objects — expiration is part of a future's canonical
+// identity, the same way base/quote is for a currency pair. A continuous,
+// back-adjusted research series derived from a futures family is a
+// different kind of thing entirely: synthetic, non-orderable, and without
+// a single expiration. Rather than express that as a flag on a Listing of
+// what looks like a tradable contract, it is its own kind,
+// KindContinuousSeries, with its own ID constructor, ContinuousSeriesID.
+// This makes "tradable versus research-only" and "a specific contract
+// versus its continuous series" both decidable from Kind alone, not from
+// validating a combination of Listing flags.
+//
+// # Equity and ETF identity is a convention, not a permanent identifier
+//
+// EquityID and ETFID use exchange+ticker as Trader's M1 canonical identity
+// convention. This is not a claim that exchange+ticker is a permanent,
+// globally stable security identifier: corporate actions, ticker reuse,
+// and venue changes can all break that assumption over time. It is
+// sufficient for M1's scope; a more durable identity scheme, if one proves
+// necessary, is a later, additive change.
+//
+// # Synthetic and multi-leg instruments are deferred
+//
+// Pairs trades, futures calendar spreads, options spreads, and weighted
+// baskets are explicitly out of scope, per the architecture document's
+// "Deferred: Synthetic and Multi-Leg Instruments" section. Nothing in this
+// package names a leg, a synthetic composition, or a multi-leg execution
+// concept; see arch_test.go, which enforces that mechanically.
+package instrument

--- a/instrument/doc.go
+++ b/instrument/doc.go
@@ -4,10 +4,10 @@
 // # Instrument versus Listing
 //
 // Instrument is what an economic thing is, independent of any provider,
-// venue, or symbol spelling. Listing is how one specific venue exposes an
-// Instrument for trading: its venue-native symbol, tick size, quantity
-// increment, contract multiplier, settlement currency, and whether it is
-// currently tradable there.
+// venue, or symbol spelling. Listing is how one specific provider exposes
+// an Instrument for trading: its provider-native symbol, tick size,
+// quantity increment, contract multiplier, settlement currency, and
+// whether it is currently tradable there.
 //
 //	Instrument = what economic thing is this?
 //	Listing    = how does a provider/venue expose or trade it?
@@ -18,6 +18,15 @@
 // provider's own listing of it — its symbol text, tick size, and whether it
 // is currently tradable there — is a separate Listing referencing that one
 // Instrument by ID.
+//
+// A Listing distinguishes its provider (a broker or data vendor, such as
+// "OANDA" or "IBKR") from its venue (an exchange or execution venue, such
+// as "NASDAQ" or "CME"); they are not the same thing, and one provider can
+// expose listings on several venues. Venue may be empty for markets with
+// no meaningful centralized venue, such as spot FX. NewListing also
+// rejects a Listing with Tradable set true for an Instrument that is
+// non-orderable by Kind — KindContinuousSeries or KindIndex — since a
+// Listing given only an ID could not otherwise catch that contradiction.
 //
 // # ID is canonical and deterministic, not generated
 //
@@ -39,6 +48,17 @@
 // package sees the input, there is no spelling left to be inconsistent
 // about.
 //
+// Each constructor validates its own input and returns the zero ID, never
+// a malformed non-zero one, when given an empty or invalid component: this
+// keeps IsZero a reliable check even for direct callers of the ID
+// constructors, not only for the Instrument constructors that call them
+// after their own validation. Identifier components are further
+// restricted to letters, digits, '.', and '-' — enough for real exchange
+// codes, tickers, and futures roots ("BRK.B", "RDS-A", "6E") — specifically
+// excluding ':' and '/', the characters this package uses to join
+// components together; without that restriction, EquityID("A:B", "C") and
+// EquityID("A", "B:C") could collide on the same canonical string.
+//
 // # Six initial kinds, and why futures split in two
 //
 // KindCurrencyPair, KindEquity, KindETF, KindFuture, KindContinuousSeries,
@@ -57,6 +77,15 @@
 // This makes "tradable versus research-only" and "a specific contract
 // versus its continuous series" both decidable from Kind alone, not from
 // validating a combination of Listing flags.
+//
+// Only a future's year and month are significant to its identity, matching
+// standard contract-month conventions (a real contract's exact last
+// trading day is a settlement detail, not part of what makes it "the
+// December 2026 contract"). NewFuture normalizes whatever time.Time it is
+// given down to the first instant of that month in UTC before building the
+// ID and storing Instrument.Expiration, so the two can never disagree —
+// two calls with expirations on different days of the same month always
+// produce the same Instrument.
 //
 // # Equity and ETF identity is a convention, not a permanent identifier
 //

--- a/instrument/errors.go
+++ b/instrument/errors.go
@@ -1,0 +1,20 @@
+package instrument
+
+import "errors"
+
+var (
+	// ErrInvalidInstrument reports an Instrument constructor argument that
+	// fails validation: an invalid or matching currency pair, an empty
+	// exchange/ticker/root/name, or a missing futures expiration.
+	ErrInvalidInstrument = errors.New("instrument: invalid instrument")
+
+	// ErrInvalidSpec reports a Spec constructor argument that fails
+	// validation, or a price/quantity that is not an exact multiple of a
+	// Spec's tick size or quantity increment.
+	ErrInvalidSpec = errors.New("instrument: invalid spec")
+
+	// ErrInvalidListing reports a Listing constructor argument that fails
+	// validation: a zero instrument ID, an empty venue/symbol, or a Spec
+	// that was not constructed with NewSpec.
+	ErrInvalidListing = errors.New("instrument: invalid listing")
+)

--- a/instrument/example_test.go
+++ b/instrument/example_test.go
@@ -75,16 +75,18 @@ func Example_future() {
 	// false
 }
 
-// Example_listing shows a Listing referencing an Instrument by ID, with
-// its own venue-specific symbol and trading mechanics.
+// Example_listing shows a Listing referencing an Instrument, with its own
+// provider, symbol, and trading mechanics. Provider and Venue are kept
+// distinct: IBKR (the provider) exposes a NASDAQ (the venue) listing of
+// Apple.
 func Example_listing() {
-	eurUsd, err := instrument.NewCurrencyPair(num.MustParseCurrency("EUR"), num.MustParseCurrency("USD"))
+	apple, err := instrument.NewEquity("NASDAQ", "AAPL")
 	if err != nil {
 		panic(err)
 	}
 
 	spec, err := instrument.NewSpec(
-		num.MustParsePrice("0.00001"),
+		num.MustParsePrice("0.01"),
 		num.MustParseQuantity("1"),
 		num.MustParseRate("1"),
 		num.MustParseCurrency("USD"),
@@ -94,23 +96,26 @@ func Example_listing() {
 	}
 
 	listing, err := instrument.NewListing(instrument.ListingParams{
-		InstrumentID: eurUsd.ID(),
-		Venue:        "OANDA",
-		Symbol:       "EUR_USD",
-		Spec:         spec,
-		Tradable:     true,
+		Instrument: apple,
+		Provider:   "IBKR",
+		Venue:      "NASDAQ",
+		Symbol:     "AAPL",
+		Spec:       spec,
+		Tradable:   true,
 	})
 	if err != nil {
 		panic(err)
 	}
 
+	fmt.Println(listing.Provider())
 	fmt.Println(listing.Venue())
 	fmt.Println(listing.Symbol())
 	fmt.Println(listing.Tradable())
-	fmt.Println(listing.InstrumentID().Equal(eurUsd.ID()))
+	fmt.Println(listing.InstrumentID().Equal(apple.ID()))
 	// Output:
-	// OANDA
-	// EUR_USD
+	// IBKR
+	// NASDAQ
+	// AAPL
 	// true
 	// true
 }

--- a/instrument/example_test.go
+++ b/instrument/example_test.go
@@ -1,0 +1,116 @@
+package instrument_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+)
+
+// Example_currencyPair shows that EUR/USD resolves to the same canonical
+// identity regardless of which provider spelling produced the base and
+// quote currencies passed in.
+func Example_currencyPair() {
+	eur := num.MustParseCurrency("EUR")
+	usd := num.MustParseCurrency("USD")
+
+	fromOanda, err := instrument.NewCurrencyPair(eur, usd) // parsed from "EUR_USD"
+	if err != nil {
+		panic(err)
+	}
+	fromAnotherProvider, err := instrument.NewCurrencyPair(eur, usd) // parsed from "EURUSD"
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(fromOanda.ID())
+	fmt.Println(fromOanda.ID().Equal(fromAnotherProvider.ID()))
+	// Output:
+	// fx:EUR/USD
+	// true
+}
+
+// Example_equity shows a simple equity instrument and its identity.
+func Example_equity() {
+	apple, err := instrument.NewEquity("NASDAQ", "AAPL")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(apple.Kind())
+	fmt.Println(apple.ID())
+	// Output:
+	// equity
+	// eq:NASDAQ:AAPL
+}
+
+// Example_future shows that two futures contracts on the same underlying
+// root but different expirations are distinct Instruments, and that a
+// continuous research series on the same root is distinct from either.
+func Example_future() {
+	dec, err := instrument.NewFuture("ES", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		panic(err)
+	}
+	mar, err := instrument.NewFuture("ES", time.Date(2027, time.March, 20, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		panic(err)
+	}
+	continuous, err := instrument.NewContinuousSeries("ES")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(dec.ID())
+	fmt.Println(mar.ID())
+	fmt.Println(continuous.ID())
+	fmt.Println(dec.ID().Equal(mar.ID()))
+	fmt.Println(dec.ID().Equal(continuous.ID()))
+	// Output:
+	// fut:ES:2026-12
+	// fut:ES:2027-03
+	// cont:ES
+	// false
+	// false
+}
+
+// Example_listing shows a Listing referencing an Instrument by ID, with
+// its own venue-specific symbol and trading mechanics.
+func Example_listing() {
+	eurUsd, err := instrument.NewCurrencyPair(num.MustParseCurrency("EUR"), num.MustParseCurrency("USD"))
+	if err != nil {
+		panic(err)
+	}
+
+	spec, err := instrument.NewSpec(
+		num.MustParsePrice("0.00001"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		num.MustParseCurrency("USD"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	listing, err := instrument.NewListing(instrument.ListingParams{
+		InstrumentID: eurUsd.ID(),
+		Venue:        "OANDA",
+		Symbol:       "EUR_USD",
+		Spec:         spec,
+		Tradable:     true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(listing.Venue())
+	fmt.Println(listing.Symbol())
+	fmt.Println(listing.Tradable())
+	fmt.Println(listing.InstrumentID().Equal(eurUsd.ID()))
+	// Output:
+	// OANDA
+	// EUR_USD
+	// true
+	// true
+}

--- a/instrument/id.go
+++ b/instrument/id.go
@@ -41,7 +41,15 @@ func (id ID) Equal(o ID) bool {
 // base/quote. Two calls with the same base and quote always produce an
 // equal ID, regardless of which provider symbol spelling — "EUR_USD",
 // "EURUSD", "EUR/USD" — a caller parsed before extracting base and quote.
+//
+// CurrencyPairID returns the zero ID if base or quote is not structurally
+// valid, or if base and quote are equal — the zero value of ID is
+// reserved for exactly this: a non-zero ID is always structurally
+// meaningful, never a malformed identity built from invalid input.
 func CurrencyPairID(base, quote num.Currency) ID {
+	if !base.IsValid() || !quote.IsValid() || base.Equal(quote) {
+		return ID{}
+	}
 	return ID{raw: "fx:" + base.String() + "/" + quote.String()}
 }
 
@@ -49,40 +57,113 @@ func CurrencyPairID(base, quote num.Currency) ID {
 // ticker on exchange. exchange and ticker are trimmed and upper-cased
 // before joining; see the package doc comment for why exchange+ticker is
 // Trader's M1 identity convention, not a claim of permanent identity.
+//
+// EquityID returns the zero ID if, once normalized, exchange or ticker is
+// empty or contains a character outside the safe identifier alphabet — see
+// isValidIdentifierPart. That alphabet excludes ':' and '/' specifically
+// so EquityID("A:B", "C") and EquityID("A", "B:C") can never both collapse
+// to the same canonical string; rejecting the input is preferred over
+// escaping it.
 func EquityID(exchange, ticker string) ID {
-	return ID{raw: "eq:" + normalizeIdentifierPart(exchange) + ":" + normalizeIdentifierPart(ticker)}
+	exchange = normalizeIdentifierPart(exchange)
+	ticker = normalizeIdentifierPart(ticker)
+	if !isValidIdentifierPart(exchange) || !isValidIdentifierPart(ticker) {
+		return ID{}
+	}
+	return ID{raw: "eq:" + exchange + ":" + ticker}
 }
 
 // ETFID is EquityID's counterpart for exchange-traded funds. It is a
 // distinct constructor, not a shared one, so an ETF can never collide with
-// an equity that happens to share an exchange and ticker.
+// an equity that happens to share an exchange and ticker. Its input
+// validation is identical to EquityID's.
 func ETFID(exchange, ticker string) ID {
-	return ID{raw: "etf:" + normalizeIdentifierPart(exchange) + ":" + normalizeIdentifierPart(ticker)}
+	exchange = normalizeIdentifierPart(exchange)
+	ticker = normalizeIdentifierPart(ticker)
+	if !isValidIdentifierPart(exchange) || !isValidIdentifierPart(ticker) {
+		return ID{}
+	}
+	return ID{raw: "etf:" + exchange + ":" + ticker}
 }
 
 // FutureID returns the canonical identity for one specific expiring
 // futures contract identified by its underlying root symbol and
-// expiration month. Contracts on the same root with different expirations
-// — ES December 2026 versus ES March 2027 — produce different IDs; see
-// the package doc comment for why the individual contract, not the
+// expiration month. Contracts on the same root with different expiration
+// months — ES December 2026 versus ES March 2027 — produce different IDs;
+// see the package doc comment for why the individual contract, not the
 // contract family, is the Instrument.
+//
+// Only expiration's year and month are significant: FutureID's canonical
+// string carries "YYYY-MM", not a full date, matching standard futures
+// contract-month conventions and matching what NewFuture stores as
+// Instrument.Expiration — the two are always kept in exact agreement, so
+// there is no month in which two differently-timed calls could produce the
+// same ID but disagree about Expiration, or vice versa.
+//
+// FutureID returns the zero ID if, once normalized, root is empty or
+// contains a character outside the safe identifier alphabet, or if
+// expiration is the zero time.Time.
 func FutureID(root string, expiration time.Time) ID {
-	return ID{raw: "fut:" + normalizeIdentifierPart(root) + ":" + expiration.UTC().Format("2006-01")}
+	root = normalizeIdentifierPart(root)
+	if !isValidIdentifierPart(root) || expiration.IsZero() {
+		return ID{}
+	}
+	return ID{raw: "fut:" + root + ":" + expiration.UTC().Format("2006-01")}
 }
 
 // ContinuousSeriesID returns the canonical identity for the continuous,
 // non-orderable research series derived from the futures family rooted at
 // root. It is always distinct from any FutureID sharing the same root.
+//
+// ContinuousSeriesID returns the zero ID if, once normalized, root is
+// empty or contains a character outside the safe identifier alphabet.
 func ContinuousSeriesID(root string) ID {
-	return ID{raw: "cont:" + normalizeIdentifierPart(root)}
+	root = normalizeIdentifierPart(root)
+	if !isValidIdentifierPart(root) {
+		return ID{}
+	}
+	return ID{raw: "cont:" + root}
 }
 
 // IndexID returns the canonical identity for the non-orderable index
 // name.
+//
+// IndexID returns the zero ID if, once normalized, name is empty or
+// contains a character outside the safe identifier alphabet.
 func IndexID(name string) ID {
-	return ID{raw: "idx:" + normalizeIdentifierPart(name)}
+	name = normalizeIdentifierPart(name)
+	if !isValidIdentifierPart(name) {
+		return ID{}
+	}
+	return ID{raw: "idx:" + name}
 }
 
 func normalizeIdentifierPart(s string) string {
 	return strings.ToUpper(strings.TrimSpace(s))
+}
+
+// isValidIdentifierPart reports whether s — already normalized by
+// normalizeIdentifierPart — is safe to use as one segment of a canonical
+// ID string: non-empty, and built only from characters that can never be
+// confused with the ':' and '/' separators used to join segments together.
+// Real exchange codes, tickers, and futures roots are well served by
+// letters, digits, '.', and '-' (for example "BRK.B", "RDS-A", "6E"); this
+// package intentionally does not attempt to escape or otherwise accept a
+// wider alphabet, since rejecting an ambiguous input is safer than
+// guessing how to encode it unambiguously.
+func isValidIdentifierPart(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '.' || c == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/instrument/id.go
+++ b/instrument/id.go
@@ -1,0 +1,88 @@
+package instrument
+
+import (
+	"strings"
+	"time"
+
+	"github.com/rustyeddy/trader/num"
+)
+
+// ID is Trader's canonical, deterministic identity for one economic
+// instrument. See the package doc comment for why this is a different
+// identity scheme from the id package's generated identifiers.
+//
+// ID has no exported fields and cannot be constructed to hold an arbitrary
+// value; use one of the per-kind constructors below, or obtain one from an
+// existing Instrument's ID method. Two calls to the same constructor with
+// the same normalized economic attributes always produce an equal ID.
+//
+// The zero value of ID is not a valid identity; IsZero reports true for it.
+type ID struct {
+	raw string
+}
+
+// String returns id's canonical text form, for example "fx:EUR/USD" or
+// "fut:ES:2026-12". The zero value renders as the empty string.
+func (id ID) String() string {
+	return id.raw
+}
+
+// IsZero reports whether id is the zero value.
+func (id ID) IsZero() bool {
+	return id.raw == ""
+}
+
+// Equal reports whether id and o hold the identical canonical identity.
+func (id ID) Equal(o ID) bool {
+	return id.raw == o.raw
+}
+
+// CurrencyPairID returns the canonical identity for the currency pair
+// base/quote. Two calls with the same base and quote always produce an
+// equal ID, regardless of which provider symbol spelling — "EUR_USD",
+// "EURUSD", "EUR/USD" — a caller parsed before extracting base and quote.
+func CurrencyPairID(base, quote num.Currency) ID {
+	return ID{raw: "fx:" + base.String() + "/" + quote.String()}
+}
+
+// EquityID returns the canonical identity for the equity listed under
+// ticker on exchange. exchange and ticker are trimmed and upper-cased
+// before joining; see the package doc comment for why exchange+ticker is
+// Trader's M1 identity convention, not a claim of permanent identity.
+func EquityID(exchange, ticker string) ID {
+	return ID{raw: "eq:" + normalizeIdentifierPart(exchange) + ":" + normalizeIdentifierPart(ticker)}
+}
+
+// ETFID is EquityID's counterpart for exchange-traded funds. It is a
+// distinct constructor, not a shared one, so an ETF can never collide with
+// an equity that happens to share an exchange and ticker.
+func ETFID(exchange, ticker string) ID {
+	return ID{raw: "etf:" + normalizeIdentifierPart(exchange) + ":" + normalizeIdentifierPart(ticker)}
+}
+
+// FutureID returns the canonical identity for one specific expiring
+// futures contract identified by its underlying root symbol and
+// expiration month. Contracts on the same root with different expirations
+// — ES December 2026 versus ES March 2027 — produce different IDs; see
+// the package doc comment for why the individual contract, not the
+// contract family, is the Instrument.
+func FutureID(root string, expiration time.Time) ID {
+	return ID{raw: "fut:" + normalizeIdentifierPart(root) + ":" + expiration.UTC().Format("2006-01")}
+}
+
+// ContinuousSeriesID returns the canonical identity for the continuous,
+// non-orderable research series derived from the futures family rooted at
+// root. It is always distinct from any FutureID sharing the same root.
+func ContinuousSeriesID(root string) ID {
+	return ID{raw: "cont:" + normalizeIdentifierPart(root)}
+}
+
+// IndexID returns the canonical identity for the non-orderable index
+// name.
+func IndexID(name string) ID {
+	return ID{raw: "idx:" + normalizeIdentifierPart(name)}
+}
+
+func normalizeIdentifierPart(s string) string {
+	return strings.ToUpper(strings.TrimSpace(s))
+}

--- a/instrument/id_test.go
+++ b/instrument/id_test.go
@@ -98,6 +98,41 @@ func TestIndexID(t *testing.T) {
 	assert.Equal(t, "idx:SPX", IndexID(" spx ").String())
 }
 
+func TestIDConstructorsReturnZeroForInvalidInput(t *testing.T) {
+	eur := num.MustParseCurrency("EUR")
+	usd := num.MustParseCurrency("USD")
+	dec := time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC)
+
+	assert.True(t, CurrencyPairID(num.Currency{}, usd).IsZero())
+	assert.True(t, CurrencyPairID(eur, num.Currency{}).IsZero())
+	assert.True(t, CurrencyPairID(eur, eur).IsZero(), "a pair cannot have equal base and quote")
+
+	assert.True(t, EquityID("", "AAPL").IsZero())
+	assert.True(t, EquityID("NASDAQ", "").IsZero())
+
+	assert.True(t, ETFID("", "SPY").IsZero())
+	assert.True(t, ETFID("NASDAQ", "").IsZero())
+
+	assert.True(t, FutureID("", dec).IsZero())
+	assert.True(t, FutureID("ES", time.Time{}).IsZero())
+
+	assert.True(t, ContinuousSeriesID("").IsZero())
+	assert.True(t, IndexID("").IsZero())
+}
+
+// TestEquityIDRejectsAmbiguousSeparatorCharacters is the collision-
+// prevention test: without character-set validation,
+// EquityID("A:B", "C") and EquityID("A", "B:C") would both collapse to
+// "eq:A:B:C". Rejecting ':' at the input boundary (returning the zero ID)
+// closes that collision instead of trying to escape it.
+func TestEquityIDRejectsAmbiguousSeparatorCharacters(t *testing.T) {
+	a := EquityID("A:B", "C")
+	b := EquityID("A", "B:C")
+
+	assert.True(t, a.IsZero())
+	assert.True(t, b.IsZero())
+}
+
 func TestIDZeroValue(t *testing.T) {
 	var id ID
 	assert.True(t, id.IsZero())

--- a/instrument/id_test.go
+++ b/instrument/id_test.go
@@ -1,0 +1,109 @@
+package instrument
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCurrencyPairIDIsIndependentOfProviderSpelling is the acceptance-
+// criterion test: three different "provider adapters" each parse a
+// different spelling of the same pair — "EUR_USD", "EURUSD", "EUR/USD" —
+// into base/quote currencies before calling CurrencyPairID. The instrument
+// package never sees the original spelling, so all three must resolve to
+// the identical ID.
+func TestCurrencyPairIDIsIndependentOfProviderSpelling(t *testing.T) {
+	parseOandaStyle := func(s string) (num.Currency, num.Currency) {
+		// "EUR_USD"
+		return num.MustParseCurrency(s[:3]), num.MustParseCurrency(s[4:])
+	}
+	parseCompactStyle := func(s string) (num.Currency, num.Currency) {
+		// "EURUSD"
+		return num.MustParseCurrency(s[:3]), num.MustParseCurrency(s[3:])
+	}
+	parseSlashStyle := func(s string) (num.Currency, num.Currency) {
+		// "EUR/USD"
+		return num.MustParseCurrency(s[:3]), num.MustParseCurrency(s[4:])
+	}
+
+	base1, quote1 := parseOandaStyle("EUR_USD")
+	base2, quote2 := parseCompactStyle("EURUSD")
+	base3, quote3 := parseSlashStyle("EUR/USD")
+
+	id1 := CurrencyPairID(base1, quote1)
+	id2 := CurrencyPairID(base2, quote2)
+	id3 := CurrencyPairID(base3, quote3)
+
+	assert.True(t, id1.Equal(id2))
+	assert.True(t, id2.Equal(id3))
+	assert.Equal(t, "fx:EUR/USD", id1.String())
+}
+
+func TestCurrencyPairIDDiffersByDirection(t *testing.T) {
+	eur := num.MustParseCurrency("EUR")
+	usd := num.MustParseCurrency("USD")
+
+	eurUsd := CurrencyPairID(eur, usd)
+	usdEur := CurrencyPairID(usd, eur)
+
+	assert.False(t, eurUsd.Equal(usdEur))
+}
+
+func TestEquityAndETFIDsNeverCollide(t *testing.T) {
+	eq := EquityID("NASDAQ", "SPY")
+	etf := ETFID("NASDAQ", "SPY")
+
+	assert.False(t, eq.Equal(etf))
+}
+
+func TestEquityIDNormalizesCase(t *testing.T) {
+	upper := EquityID("NASDAQ", "AAPL")
+	lower := EquityID("nasdaq", "aapl")
+	padded := EquityID("  NASDAQ  ", "  AAPL  ")
+
+	assert.True(t, upper.Equal(lower))
+	assert.True(t, upper.Equal(padded))
+	assert.Equal(t, "eq:NASDAQ:AAPL", upper.String())
+}
+
+func TestFutureIDDiffersByExpiration(t *testing.T) {
+	dec := FutureID("ES", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
+	mar := FutureID("ES", time.Date(2027, time.March, 20, 0, 0, 0, 0, time.UTC))
+
+	assert.False(t, dec.Equal(mar))
+	assert.Equal(t, "fut:ES:2026-12", dec.String())
+	assert.Equal(t, "fut:ES:2027-03", mar.String())
+}
+
+func TestFutureIDIsInsensitiveToDayWithinTheSameMonth(t *testing.T) {
+	early := FutureID("ES", time.Date(2026, time.December, 1, 0, 0, 0, 0, time.UTC))
+	late := FutureID("ES", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
+
+	assert.True(t, early.Equal(late), "FutureID uses month granularity by design")
+}
+
+func TestContinuousSeriesIDNeverCollidesWithAFutureOnTheSameRoot(t *testing.T) {
+	future := FutureID("ES", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
+	continuous := ContinuousSeriesID("ES")
+
+	assert.False(t, future.Equal(continuous))
+	assert.Equal(t, "cont:ES", continuous.String())
+}
+
+func TestIndexID(t *testing.T) {
+	assert.Equal(t, "idx:SPX", IndexID("SPX").String())
+	assert.Equal(t, "idx:SPX", IndexID(" spx ").String())
+}
+
+func TestIDZeroValue(t *testing.T) {
+	var id ID
+	assert.True(t, id.IsZero())
+	assert.Equal(t, "", id.String())
+
+	nonZero := IndexID("SPX")
+	assert.False(t, nonZero.IsZero())
+	require.False(t, id.Equal(nonZero))
+}

--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -65,8 +65,12 @@ func (i Instrument) Root() (string, bool) {
 	return i.root, i.kind == KindFuture || i.kind == KindContinuousSeries
 }
 
-// Expiration returns i's contract expiration and true when i.Kind() is
-// KindFuture; otherwise it returns the zero time.Time and false.
+// Expiration returns i's contract month and true when i.Kind() is
+// KindFuture; otherwise it returns the zero time.Time and false. The
+// returned value is always the first instant of the contract's expiration
+// month in UTC, not necessarily the exact time.Time NewFuture was called
+// with — see NewFuture and FutureID for why only the year and month are
+// significant to a futures contract's identity.
 func (i Instrument) Expiration() (time.Time, bool) {
 	return i.expiration, i.kind == KindFuture
 }
@@ -95,7 +99,8 @@ func NewCurrencyPair(base, quote num.Currency) (Instrument, error) {
 }
 
 // NewEquity returns the Instrument for the equity listed under ticker on
-// exchange. exchange and ticker must both be non-empty once trimmed.
+// exchange. Once trimmed and upper-cased, exchange and ticker must both be
+// non-empty and contain only letters, digits, '.', or '-'.
 func NewEquity(exchange, ticker string) (Instrument, error) {
 	exchange, ticker, err := validateExchangeTicker(exchange, ticker)
 	if err != nil {
@@ -110,8 +115,8 @@ func NewEquity(exchange, ticker string) (Instrument, error) {
 }
 
 // NewETF returns the Instrument for the exchange-traded fund listed under
-// ticker on exchange. exchange and ticker must both be non-empty once
-// trimmed.
+// ticker on exchange. Once trimmed and upper-cased, exchange and ticker
+// must both be non-empty and contain only letters, digits, '.', or '-'.
 func NewETF(exchange, ticker string) (Instrument, error) {
 	exchange, ticker, err := validateExchangeTicker(exchange, ticker)
 	if err != nil {
@@ -128,43 +133,62 @@ func NewETF(exchange, ticker string) (Instrument, error) {
 func validateExchangeTicker(exchange, ticker string) (string, string, error) {
 	exchange = normalizeIdentifierPart(exchange)
 	ticker = normalizeIdentifierPart(ticker)
-	if exchange == "" {
-		return "", "", fmt.Errorf("%w: exchange must not be empty", ErrInvalidInstrument)
+	if !isValidIdentifierPart(exchange) {
+		return "", "", fmt.Errorf("%w: exchange must be non-empty and contain only letters, digits, '.', or '-'", ErrInvalidInstrument)
 	}
-	if ticker == "" {
-		return "", "", fmt.Errorf("%w: ticker must not be empty", ErrInvalidInstrument)
+	if !isValidIdentifierPart(ticker) {
+		return "", "", fmt.Errorf("%w: ticker must be non-empty and contain only letters, digits, '.', or '-'", ErrInvalidInstrument)
 	}
 	return exchange, ticker, nil
 }
 
 // NewFuture returns the Instrument for one specific expiring futures
-// contract identified by its underlying root symbol and expiration. root
-// must be non-empty once trimmed and expiration must be non-zero.
-// Contracts on the same root with different expirations are different
-// Instruments — see the package doc comment.
+// contract identified by its underlying root symbol and expiration
+// month. Once trimmed and upper-cased, root must be non-empty and contain
+// only letters, digits, '.', or '-'; expiration must be non-zero.
+// Contracts on the same root with different expiration months are
+// different Instruments — see the package doc comment.
+//
+// Only expiration's year and month are significant to a futures
+// contract's identity, matching standard contract-month conventions: two
+// calls with expirations in the same month, even on different days,
+// produce the same ID. Expiration() returns the canonicalized first
+// instant of that month, never the exact time.Time passed in, so it can
+// never disagree with what FutureID encoded into the ID.
 func NewFuture(root string, expiration time.Time) (Instrument, error) {
 	root = normalizeIdentifierPart(root)
-	if root == "" {
-		return Instrument{}, fmt.Errorf("%w: root must not be empty", ErrInvalidInstrument)
+	if !isValidIdentifierPart(root) {
+		return Instrument{}, fmt.Errorf("%w: root must be non-empty and contain only letters, digits, '.', or '-'", ErrInvalidInstrument)
 	}
 	if expiration.IsZero() {
 		return Instrument{}, fmt.Errorf("%w: expiration must not be zero", ErrInvalidInstrument)
 	}
+	contractMonth := canonicalContractMonth(expiration)
 	return Instrument{
-		id:         FutureID(root, expiration),
+		id:         FutureID(root, contractMonth),
 		kind:       KindFuture,
 		root:       root,
-		expiration: expiration.UTC(),
+		expiration: contractMonth,
 	}, nil
+}
+
+// canonicalContractMonth truncates t to the first instant of its month in
+// UTC — the only granularity that is significant to a futures contract's
+// identity. Keeping FutureID and Instrument.Expiration derived from this
+// same canonicalization is what keeps them from ever disagreeing.
+func canonicalContractMonth(t time.Time) time.Time {
+	u := t.UTC()
+	return time.Date(u.Year(), u.Month(), 1, 0, 0, 0, 0, time.UTC)
 }
 
 // NewContinuousSeries returns the Instrument for the continuous,
 // non-orderable research series derived from the futures family rooted at
-// root. root must be non-empty once trimmed.
+// root. Once trimmed and upper-cased, root must be non-empty and contain
+// only letters, digits, '.', or '-'.
 func NewContinuousSeries(root string) (Instrument, error) {
 	root = normalizeIdentifierPart(root)
-	if root == "" {
-		return Instrument{}, fmt.Errorf("%w: root must not be empty", ErrInvalidInstrument)
+	if !isValidIdentifierPart(root) {
+		return Instrument{}, fmt.Errorf("%w: root must be non-empty and contain only letters, digits, '.', or '-'", ErrInvalidInstrument)
 	}
 	return Instrument{
 		id:   ContinuousSeriesID(root),
@@ -173,16 +197,17 @@ func NewContinuousSeries(root string) (Instrument, error) {
 	}, nil
 }
 
-// NewIndex returns the Instrument for the non-orderable index name. name
-// must be non-empty once trimmed.
+// NewIndex returns the Instrument for the non-orderable index name. Once
+// trimmed and upper-cased, name must be non-empty and contain only
+// letters, digits, '.', or '-'.
 func NewIndex(name string) (Instrument, error) {
-	trimmed := normalizeIdentifierPart(name)
-	if trimmed == "" {
-		return Instrument{}, fmt.Errorf("%w: name must not be empty", ErrInvalidInstrument)
+	name = normalizeIdentifierPart(name)
+	if !isValidIdentifierPart(name) {
+		return Instrument{}, fmt.Errorf("%w: name must be non-empty and contain only letters, digits, '.', or '-'", ErrInvalidInstrument)
 	}
 	return Instrument{
-		id:   IndexID(trimmed),
+		id:   IndexID(name),
 		kind: KindIndex,
-		name: trimmed,
+		name: name,
 	}, nil
 }

--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -1,0 +1,188 @@
+package instrument
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/num"
+)
+
+// Instrument is one economic instrument: what the thing is, independent of
+// any provider, venue, or symbol spelling. See Listing for how a specific
+// provider or venue exposes an Instrument for trading.
+//
+// Instrument's fields are unexported; construct one with NewCurrencyPair,
+// NewEquity, NewETF, NewFuture, NewContinuousSeries, or NewIndex, and read
+// it back through ID, Kind, and the kind-specific accessors below. There is
+// no way to construct an Instrument holding a value inconsistent with its
+// Kind: each accessor's second return value reports whether it applies to
+// i's Kind, so callers cannot mistake a zero value for a legitimate one.
+type Instrument struct {
+	id   ID
+	kind Kind
+
+	base, quote num.Currency // KindCurrencyPair only
+	exchange    string       // KindEquity, KindETF
+	ticker      string       // KindEquity, KindETF
+	root        string       // KindFuture, KindContinuousSeries
+	expiration  time.Time    // KindFuture only
+	name        string       // KindIndex only
+}
+
+// ID returns i's canonical, deterministic identity.
+func (i Instrument) ID() ID { return i.id }
+
+// Kind returns the category of economic instrument i represents.
+func (i Instrument) Kind() Kind { return i.kind }
+
+// Base returns i's base currency and true when i.Kind() is
+// KindCurrencyPair; otherwise it returns the zero Currency and false.
+func (i Instrument) Base() (num.Currency, bool) {
+	return i.base, i.kind == KindCurrencyPair
+}
+
+// Quote returns i's quote currency and true when i.Kind() is
+// KindCurrencyPair; otherwise it returns the zero Currency and false.
+func (i Instrument) Quote() (num.Currency, bool) {
+	return i.quote, i.kind == KindCurrencyPair
+}
+
+// Exchange returns i's exchange and true when i.Kind() is KindEquity or
+// KindETF; otherwise it returns "" and false.
+func (i Instrument) Exchange() (string, bool) {
+	return i.exchange, i.kind == KindEquity || i.kind == KindETF
+}
+
+// Ticker returns i's ticker and true when i.Kind() is KindEquity or
+// KindETF; otherwise it returns "" and false.
+func (i Instrument) Ticker() (string, bool) {
+	return i.ticker, i.kind == KindEquity || i.kind == KindETF
+}
+
+// Root returns i's underlying root symbol and true when i.Kind() is
+// KindFuture or KindContinuousSeries; otherwise it returns "" and false.
+func (i Instrument) Root() (string, bool) {
+	return i.root, i.kind == KindFuture || i.kind == KindContinuousSeries
+}
+
+// Expiration returns i's contract expiration and true when i.Kind() is
+// KindFuture; otherwise it returns the zero time.Time and false.
+func (i Instrument) Expiration() (time.Time, bool) {
+	return i.expiration, i.kind == KindFuture
+}
+
+// Name returns i's index name and true when i.Kind() is KindIndex;
+// otherwise it returns "" and false.
+func (i Instrument) Name() (string, bool) {
+	return i.name, i.kind == KindIndex
+}
+
+// NewCurrencyPair returns the Instrument for the currency pair base/quote.
+// base and quote must both be structurally valid and must differ.
+func NewCurrencyPair(base, quote num.Currency) (Instrument, error) {
+	if !base.IsValid() || !quote.IsValid() {
+		return Instrument{}, fmt.Errorf("%w: base and quote currencies must be valid", ErrInvalidInstrument)
+	}
+	if base.Equal(quote) {
+		return Instrument{}, fmt.Errorf("%w: base and quote currencies must differ", ErrInvalidInstrument)
+	}
+	return Instrument{
+		id:    CurrencyPairID(base, quote),
+		kind:  KindCurrencyPair,
+		base:  base,
+		quote: quote,
+	}, nil
+}
+
+// NewEquity returns the Instrument for the equity listed under ticker on
+// exchange. exchange and ticker must both be non-empty once trimmed.
+func NewEquity(exchange, ticker string) (Instrument, error) {
+	exchange, ticker, err := validateExchangeTicker(exchange, ticker)
+	if err != nil {
+		return Instrument{}, err
+	}
+	return Instrument{
+		id:       EquityID(exchange, ticker),
+		kind:     KindEquity,
+		exchange: exchange,
+		ticker:   ticker,
+	}, nil
+}
+
+// NewETF returns the Instrument for the exchange-traded fund listed under
+// ticker on exchange. exchange and ticker must both be non-empty once
+// trimmed.
+func NewETF(exchange, ticker string) (Instrument, error) {
+	exchange, ticker, err := validateExchangeTicker(exchange, ticker)
+	if err != nil {
+		return Instrument{}, err
+	}
+	return Instrument{
+		id:       ETFID(exchange, ticker),
+		kind:     KindETF,
+		exchange: exchange,
+		ticker:   ticker,
+	}, nil
+}
+
+func validateExchangeTicker(exchange, ticker string) (string, string, error) {
+	exchange = normalizeIdentifierPart(exchange)
+	ticker = normalizeIdentifierPart(ticker)
+	if exchange == "" {
+		return "", "", fmt.Errorf("%w: exchange must not be empty", ErrInvalidInstrument)
+	}
+	if ticker == "" {
+		return "", "", fmt.Errorf("%w: ticker must not be empty", ErrInvalidInstrument)
+	}
+	return exchange, ticker, nil
+}
+
+// NewFuture returns the Instrument for one specific expiring futures
+// contract identified by its underlying root symbol and expiration. root
+// must be non-empty once trimmed and expiration must be non-zero.
+// Contracts on the same root with different expirations are different
+// Instruments — see the package doc comment.
+func NewFuture(root string, expiration time.Time) (Instrument, error) {
+	root = normalizeIdentifierPart(root)
+	if root == "" {
+		return Instrument{}, fmt.Errorf("%w: root must not be empty", ErrInvalidInstrument)
+	}
+	if expiration.IsZero() {
+		return Instrument{}, fmt.Errorf("%w: expiration must not be zero", ErrInvalidInstrument)
+	}
+	return Instrument{
+		id:         FutureID(root, expiration),
+		kind:       KindFuture,
+		root:       root,
+		expiration: expiration.UTC(),
+	}, nil
+}
+
+// NewContinuousSeries returns the Instrument for the continuous,
+// non-orderable research series derived from the futures family rooted at
+// root. root must be non-empty once trimmed.
+func NewContinuousSeries(root string) (Instrument, error) {
+	root = normalizeIdentifierPart(root)
+	if root == "" {
+		return Instrument{}, fmt.Errorf("%w: root must not be empty", ErrInvalidInstrument)
+	}
+	return Instrument{
+		id:   ContinuousSeriesID(root),
+		kind: KindContinuousSeries,
+		root: root,
+	}, nil
+}
+
+// NewIndex returns the Instrument for the non-orderable index name. name
+// must be non-empty once trimmed.
+func NewIndex(name string) (Instrument, error) {
+	trimmed := normalizeIdentifierPart(name)
+	if trimmed == "" {
+		return Instrument{}, fmt.Errorf("%w: name must not be empty", ErrInvalidInstrument)
+	}
+	return Instrument{
+		id:   IndexID(trimmed),
+		kind: KindIndex,
+		name: trimmed,
+	}, nil
+}

--- a/instrument/instrument_test.go
+++ b/instrument/instrument_test.go
@@ -9,6 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func mustFuture(t *testing.T) Instrument {
+	t.Helper()
+	inst, err := NewFuture("ES", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	return inst
+}
+
 func TestNewCurrencyPair(t *testing.T) {
 	eur := num.MustParseCurrency("EUR")
 	usd := num.MustParseCurrency("USD")
@@ -106,19 +113,23 @@ func TestNewFuture(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "ES", root)
 
+	want := time.Date(2026, time.December, 1, 0, 0, 0, 0, time.UTC)
 	got, ok := inst.Expiration()
 	assert.True(t, ok)
-	assert.True(t, got.Equal(expiration))
+	assert.True(t, got.Equal(want), "Expiration returns the canonical first-of-month value, not the exact input")
 
 	_, ok = inst.Name()
 	assert.False(t, ok)
 }
 
-func TestNewFutureRejectsEmptyRootOrZeroExpiration(t *testing.T) {
+func TestNewFutureRejectsInvalidRootOrZeroExpiration(t *testing.T) {
 	_, err := NewFuture("", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
 	require.ErrorIs(t, err, ErrInvalidInstrument)
 
 	_, err = NewFuture("ES", time.Time{})
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+
+	_, err = NewFuture("E:S", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
 	require.ErrorIs(t, err, ErrInvalidInstrument)
 }
 
@@ -130,6 +141,25 @@ func TestTwoFutureContractsOnTheSameRootAreDistinctInstruments(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.False(t, dec.ID().Equal(mar.ID()))
+}
+
+// TestTwoExpirationsInTheSameMonthProduceTheSameInstrument is the
+// identity-invariant test: since FutureID only encodes year and month,
+// Instrument.Expiration must be normalized to match exactly, or two
+// Instrument values could share an ID while disagreeing about
+// Expiration.
+func TestTwoExpirationsInTheSameMonthProduceTheSameInstrument(t *testing.T) {
+	early, err := NewFuture("ES", time.Date(2026, time.December, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	late, err := NewFuture("ES", time.Date(2026, time.December, 19, 15, 30, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	assert.True(t, early.ID().Equal(late.ID()))
+
+	earlyExp, _ := early.Expiration()
+	lateExp, _ := late.Expiration()
+	assert.True(t, earlyExp.Equal(lateExp), "Expiration is normalized to contract month, matching ID exactly")
 }
 
 func TestNewContinuousSeries(t *testing.T) {
@@ -147,8 +177,11 @@ func TestNewContinuousSeries(t *testing.T) {
 	assert.False(t, ok, "a continuous series has no single expiration")
 }
 
-func TestNewContinuousSeriesRejectsEmptyRoot(t *testing.T) {
+func TestNewContinuousSeriesRejectsEmptyOrInvalidRoot(t *testing.T) {
 	_, err := NewContinuousSeries("")
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+
+	_, err = NewContinuousSeries("E:S")
 	require.ErrorIs(t, err, ErrInvalidInstrument)
 }
 
@@ -175,8 +208,19 @@ func TestNewIndex(t *testing.T) {
 	assert.Equal(t, "SPX", name)
 }
 
-func TestNewIndexRejectsEmptyName(t *testing.T) {
+func TestNewIndexRejectsEmptyOrInvalidName(t *testing.T) {
 	_, err := NewIndex("   ")
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+
+	_, err = NewIndex("SPX:500")
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+}
+
+func TestNewEquityRejectsInvalidCharacters(t *testing.T) {
+	_, err := NewEquity("A:B", "C")
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+
+	_, err = NewEquity("A", "B/C")
 	require.ErrorIs(t, err, ErrInvalidInstrument)
 }
 

--- a/instrument/instrument_test.go
+++ b/instrument/instrument_test.go
@@ -1,0 +1,187 @@
+package instrument
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCurrencyPair(t *testing.T) {
+	eur := num.MustParseCurrency("EUR")
+	usd := num.MustParseCurrency("USD")
+
+	inst, err := NewCurrencyPair(eur, usd)
+	require.NoError(t, err)
+
+	assert.Equal(t, KindCurrencyPair, inst.Kind())
+	assert.Equal(t, "fx:EUR/USD", inst.ID().String())
+
+	base, ok := inst.Base()
+	assert.True(t, ok)
+	assert.True(t, base.Equal(eur))
+
+	quote, ok := inst.Quote()
+	assert.True(t, ok)
+	assert.True(t, quote.Equal(usd))
+
+	_, ok = inst.Exchange()
+	assert.False(t, ok)
+}
+
+func TestNewCurrencyPairRejectsInvalidOrMatchingCurrencies(t *testing.T) {
+	eur := num.MustParseCurrency("EUR")
+
+	_, err := NewCurrencyPair(eur, eur)
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+
+	_, err = NewCurrencyPair(num.Currency{}, eur)
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+
+	_, err = NewCurrencyPair(eur, num.Currency{})
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+}
+
+func TestNewEquity(t *testing.T) {
+	inst, err := NewEquity("NASDAQ", "AAPL")
+	require.NoError(t, err)
+
+	assert.Equal(t, KindEquity, inst.Kind())
+	assert.Equal(t, "eq:NASDAQ:AAPL", inst.ID().String())
+
+	exchange, ok := inst.Exchange()
+	assert.True(t, ok)
+	assert.Equal(t, "NASDAQ", exchange)
+
+	ticker, ok := inst.Ticker()
+	assert.True(t, ok)
+	assert.Equal(t, "AAPL", ticker)
+
+	_, ok = inst.Base()
+	assert.False(t, ok)
+}
+
+func TestNewEquityRejectsEmptyExchangeOrTicker(t *testing.T) {
+	_, err := NewEquity("", "AAPL")
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+
+	_, err = NewEquity("NASDAQ", "")
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+
+	_, err = NewEquity("   ", "AAPL")
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+}
+
+func TestNewETF(t *testing.T) {
+	inst, err := NewETF("NASDAQ", "SPY")
+	require.NoError(t, err)
+
+	assert.Equal(t, KindETF, inst.Kind())
+	assert.Equal(t, "etf:NASDAQ:SPY", inst.ID().String())
+
+	exchange, ok := inst.Exchange()
+	assert.True(t, ok)
+	assert.Equal(t, "NASDAQ", exchange)
+}
+
+func TestNewETFRejectsEmptyExchangeOrTicker(t *testing.T) {
+	_, err := NewETF("", "SPY")
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+
+	_, err = NewETF("NASDAQ", "")
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+}
+
+func TestNewFuture(t *testing.T) {
+	expiration := time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC)
+	inst, err := NewFuture("ES", expiration)
+	require.NoError(t, err)
+
+	assert.Equal(t, KindFuture, inst.Kind())
+	assert.Equal(t, "fut:ES:2026-12", inst.ID().String())
+
+	root, ok := inst.Root()
+	assert.True(t, ok)
+	assert.Equal(t, "ES", root)
+
+	got, ok := inst.Expiration()
+	assert.True(t, ok)
+	assert.True(t, got.Equal(expiration))
+
+	_, ok = inst.Name()
+	assert.False(t, ok)
+}
+
+func TestNewFutureRejectsEmptyRootOrZeroExpiration(t *testing.T) {
+	_, err := NewFuture("", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+
+	_, err = NewFuture("ES", time.Time{})
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+}
+
+func TestTwoFutureContractsOnTheSameRootAreDistinctInstruments(t *testing.T) {
+	dec, err := NewFuture("ES", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	mar, err := NewFuture("ES", time.Date(2027, time.March, 20, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	assert.False(t, dec.ID().Equal(mar.ID()))
+}
+
+func TestNewContinuousSeries(t *testing.T) {
+	inst, err := NewContinuousSeries("ES")
+	require.NoError(t, err)
+
+	assert.Equal(t, KindContinuousSeries, inst.Kind())
+	assert.Equal(t, "cont:ES", inst.ID().String())
+
+	root, ok := inst.Root()
+	assert.True(t, ok)
+	assert.Equal(t, "ES", root)
+
+	_, ok = inst.Expiration()
+	assert.False(t, ok, "a continuous series has no single expiration")
+}
+
+func TestNewContinuousSeriesRejectsEmptyRoot(t *testing.T) {
+	_, err := NewContinuousSeries("")
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+}
+
+func TestContinuousSeriesIsDistinctFromAnyFutureOnTheSameRoot(t *testing.T) {
+	future, err := NewFuture("ES", time.Date(2026, time.December, 19, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	continuous, err := NewContinuousSeries("ES")
+	require.NoError(t, err)
+
+	assert.False(t, future.ID().Equal(continuous.ID()))
+	assert.NotEqual(t, future.Kind(), continuous.Kind())
+}
+
+func TestNewIndex(t *testing.T) {
+	inst, err := NewIndex("SPX")
+	require.NoError(t, err)
+
+	assert.Equal(t, KindIndex, inst.Kind())
+	assert.Equal(t, "idx:SPX", inst.ID().String())
+
+	name, ok := inst.Name()
+	assert.True(t, ok)
+	assert.Equal(t, "SPX", name)
+}
+
+func TestNewIndexRejectsEmptyName(t *testing.T) {
+	_, err := NewIndex("   ")
+	require.ErrorIs(t, err, ErrInvalidInstrument)
+}
+
+func TestInstrumentZeroValue(t *testing.T) {
+	var inst Instrument
+	assert.True(t, inst.ID().IsZero())
+	assert.False(t, inst.Kind().IsValid())
+}

--- a/instrument/kind.go
+++ b/instrument/kind.go
@@ -31,7 +31,8 @@ const (
 	KindIndex
 )
 
-// String returns a lowercase, human-readable name for k.
+// String returns a human-readable name for k. Names are lowercase except
+// where an initialism reads better uppercase, such as KindETF's "ETF".
 func (k Kind) String() string {
 	switch k {
 	case KindCurrencyPair:

--- a/instrument/kind.go
+++ b/instrument/kind.go
@@ -1,0 +1,63 @@
+package instrument
+
+// Kind identifies the general category of economic instrument. See the
+// package doc comment for why futures use two separate kinds rather than
+// one "future" kind with a continuous/expiring flag.
+type Kind uint8
+
+const (
+	// KindCurrencyPair is an FX pair such as EUR/USD.
+	KindCurrencyPair Kind = iota + 1
+
+	// KindEquity is a common stock.
+	KindEquity
+
+	// KindETF is an exchange-traded fund.
+	KindETF
+
+	// KindFuture is one specific expiring futures contract, such as the
+	// December 2026 E-mini S&P 500 contract. Two contracts on the same
+	// underlying root with different expirations are different
+	// Instruments — see FutureID and NewFuture.
+	KindFuture
+
+	// KindContinuousSeries is a synthetic, non-orderable research series
+	// derived from a futures family, such as a continuous, back-adjusted
+	// ES series. It is never confused with an individual KindFuture
+	// contract, even one sharing the same root.
+	KindContinuousSeries
+
+	// KindIndex is a non-orderable index.
+	KindIndex
+)
+
+// String returns a lowercase, human-readable name for k.
+func (k Kind) String() string {
+	switch k {
+	case KindCurrencyPair:
+		return "currency pair"
+	case KindEquity:
+		return "equity"
+	case KindETF:
+		return "ETF"
+	case KindFuture:
+		return "future"
+	case KindContinuousSeries:
+		return "continuous series"
+	case KindIndex:
+		return "index"
+	default:
+		return "unknown instrument kind"
+	}
+}
+
+// IsValid reports whether k is one of the defined Kind constants. The Go
+// zero value of Kind is not valid.
+func (k Kind) IsValid() bool {
+	switch k {
+	case KindCurrencyPair, KindEquity, KindETF, KindFuture, KindContinuousSeries, KindIndex:
+		return true
+	default:
+		return false
+	}
+}

--- a/instrument/kind_test.go
+++ b/instrument/kind_test.go
@@ -1,0 +1,40 @@
+package instrument
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKindString(t *testing.T) {
+	tests := []struct {
+		k    Kind
+		want string
+	}{
+		{KindCurrencyPair, "currency pair"},
+		{KindEquity, "equity"},
+		{KindETF, "ETF"},
+		{KindFuture, "future"},
+		{KindContinuousSeries, "continuous series"},
+		{KindIndex, "index"},
+		{Kind(0), "unknown instrument kind"},
+		{Kind(99), "unknown instrument kind"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.k.String())
+		})
+	}
+}
+
+func TestKindIsValid(t *testing.T) {
+	valid := []Kind{KindCurrencyPair, KindEquity, KindETF, KindFuture, KindContinuousSeries, KindIndex}
+	for _, k := range valid {
+		assert.Truef(t, k.IsValid(), "%s should be valid", k)
+	}
+
+	var zero Kind
+	assert.False(t, zero.IsValid())
+	assert.False(t, Kind(99).IsValid())
+}

--- a/instrument/listing.go
+++ b/instrument/listing.go
@@ -6,17 +6,22 @@ import (
 )
 
 // Listing is one venue's tradable, or research-only non-tradable,
-// representation of an Instrument: which venue, under what provider
-// symbol, with what trading mechanics, and whether it can currently be
-// traded there.
+// representation of an Instrument: which provider and venue, under what
+// provider symbol, with what trading mechanics, and whether it can
+// currently be traded there.
 //
-// Listing's fields are unexported; construct one with NewListing. A
-// Listing's InstrumentID names an Instrument by ID but does not itself
-// reference or validate against a constructed Instrument value — Listing
-// has no dependency on a catalog or registry; composing the two, if a
-// caller needs that, is left to the caller.
+// Provider and Venue are kept distinct. A provider is a broker or data
+// vendor — "OANDA", "IBKR" — and a venue is an exchange or execution
+// venue — "NASDAQ", "CME". They are not interchangeable: one provider can
+// expose listings on several venues (IBKR can offer a NASDAQ listing), and
+// the same venue's listing can be reached through several providers.
+// Venue may be empty for markets with no meaningful centralized venue,
+// such as spot FX.
+//
+// Listing's fields are unexported; construct one with NewListing.
 type Listing struct {
 	instrumentID ID
+	provider     string
 	venue        string
 	symbol       string
 	spec         Spec
@@ -25,14 +30,21 @@ type Listing struct {
 
 // ListingParams collects NewListing's arguments.
 type ListingParams struct {
-	// InstrumentID is the Instrument this Listing represents.
-	InstrumentID ID
+	// Instrument is the Instrument this Listing represents. NewListing
+	// stores only its ID, but uses the full value to validate Tradable
+	// against Instrument.Kind — see Tradable below.
+	Instrument Instrument
 
-	// Venue names the provider or exchange offering this listing, for
-	// example "OANDA" or "NASDAQ".
+	// Provider names the broker or data vendor offering this listing, for
+	// example "OANDA" or "IBKR".
+	Provider string
+
+	// Venue names the exchange or execution venue, for example "NASDAQ"
+	// or "CME". Venue may be left empty for markets with no meaningful
+	// centralized venue, such as spot FX.
 	Venue string
 
-	// Symbol is the venue's own symbol text, for example "EUR_USD" or
+	// Symbol is the provider's own symbol text, for example "EUR_USD" or
 	// "AAPL". It is preserved verbatim except for trimming — it is
 	// display-only and never used as identity; see the package doc
 	// comment.
@@ -43,23 +55,24 @@ type ListingParams struct {
 	Spec Spec
 
 	// Tradable reports whether this listing can currently be traded.
-	// KindContinuousSeries instruments are never tradable in practice,
-	// but Listing does not enforce that against Kind — see the package
-	// doc comment for why that distinction is Instrument.Kind's
-	// responsibility, not a Listing-level flag combination.
+	// NewListing rejects Tradable: true when Instrument.Kind() is
+	// KindContinuousSeries or KindIndex — both are non-orderable by
+	// definition, not merely by convention — see the package doc comment.
 	Tradable bool
 }
 
-// NewListing validates and returns a Listing. InstrumentID must be
-// non-zero, Venue and Symbol must be non-empty once trimmed, and Spec must
-// have been constructed with NewSpec.
+// NewListing validates and returns a Listing. Instrument must be a
+// constructed, non-zero Instrument; Provider and Symbol must be non-empty
+// once trimmed; Venue is trimmed but may be empty; Spec must have been
+// constructed with NewSpec; and Tradable must not be true when Instrument
+// is a KindContinuousSeries or KindIndex.
 func NewListing(p ListingParams) (Listing, error) {
-	if p.InstrumentID.IsZero() {
-		return Listing{}, fmt.Errorf("%w: instrument ID must not be zero", ErrInvalidListing)
+	if p.Instrument.ID().IsZero() {
+		return Listing{}, fmt.Errorf("%w: instrument must be constructed", ErrInvalidListing)
 	}
-	venue := strings.TrimSpace(p.Venue)
-	if venue == "" {
-		return Listing{}, fmt.Errorf("%w: venue must not be empty", ErrInvalidListing)
+	provider := strings.TrimSpace(p.Provider)
+	if provider == "" {
+		return Listing{}, fmt.Errorf("%w: provider must not be empty", ErrInvalidListing)
 	}
 	symbol := strings.TrimSpace(p.Symbol)
 	if symbol == "" {
@@ -68,22 +81,39 @@ func NewListing(p ListingParams) (Listing, error) {
 	if p.Spec.TickSize().IsZero() {
 		return Listing{}, fmt.Errorf("%w: spec must be constructed with NewSpec", ErrInvalidListing)
 	}
+	if p.Tradable && isNeverTradable(p.Instrument.Kind()) {
+		return Listing{}, fmt.Errorf("%w: a %s listing can never be tradable", ErrInvalidListing, p.Instrument.Kind())
+	}
 	return Listing{
-		instrumentID: p.InstrumentID,
-		venue:        venue,
+		instrumentID: p.Instrument.ID(),
+		provider:     provider,
+		venue:        strings.TrimSpace(p.Venue),
 		symbol:       symbol,
 		spec:         p.Spec,
 		tradable:     p.Tradable,
 	}, nil
 }
 
+// isNeverTradable reports whether k is non-orderable by definition, not
+// merely by convention: a continuous research series and an index are
+// never the tradable thing themselves, even though tradable instruments —
+// futures contracts on a root, ETFs tracking an index — may exist
+// alongside them.
+func isNeverTradable(k Kind) bool {
+	return k == KindContinuousSeries || k == KindIndex
+}
+
 // InstrumentID returns the Instrument l represents.
 func (l Listing) InstrumentID() ID { return l.instrumentID }
 
-// Venue returns the provider or exchange offering l.
+// Provider returns the broker or data vendor offering l.
+func (l Listing) Provider() string { return l.provider }
+
+// Venue returns the exchange or execution venue for l, or "" if l has no
+// meaningful centralized venue.
 func (l Listing) Venue() string { return l.venue }
 
-// Symbol returns the venue's own symbol text for l.
+// Symbol returns the provider's own symbol text for l.
 func (l Listing) Symbol() string { return l.symbol }
 
 // Spec returns l's trading mechanics.

--- a/instrument/listing.go
+++ b/instrument/listing.go
@@ -1,0 +1,93 @@
+package instrument
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Listing is one venue's tradable, or research-only non-tradable,
+// representation of an Instrument: which venue, under what provider
+// symbol, with what trading mechanics, and whether it can currently be
+// traded there.
+//
+// Listing's fields are unexported; construct one with NewListing. A
+// Listing's InstrumentID names an Instrument by ID but does not itself
+// reference or validate against a constructed Instrument value — Listing
+// has no dependency on a catalog or registry; composing the two, if a
+// caller needs that, is left to the caller.
+type Listing struct {
+	instrumentID ID
+	venue        string
+	symbol       string
+	spec         Spec
+	tradable     bool
+}
+
+// ListingParams collects NewListing's arguments.
+type ListingParams struct {
+	// InstrumentID is the Instrument this Listing represents.
+	InstrumentID ID
+
+	// Venue names the provider or exchange offering this listing, for
+	// example "OANDA" or "NASDAQ".
+	Venue string
+
+	// Symbol is the venue's own symbol text, for example "EUR_USD" or
+	// "AAPL". It is preserved verbatim except for trimming — it is
+	// display-only and never used as identity; see the package doc
+	// comment.
+	Symbol string
+
+	// Spec holds this listing's trading mechanics. It must have been
+	// constructed with NewSpec.
+	Spec Spec
+
+	// Tradable reports whether this listing can currently be traded.
+	// KindContinuousSeries instruments are never tradable in practice,
+	// but Listing does not enforce that against Kind — see the package
+	// doc comment for why that distinction is Instrument.Kind's
+	// responsibility, not a Listing-level flag combination.
+	Tradable bool
+}
+
+// NewListing validates and returns a Listing. InstrumentID must be
+// non-zero, Venue and Symbol must be non-empty once trimmed, and Spec must
+// have been constructed with NewSpec.
+func NewListing(p ListingParams) (Listing, error) {
+	if p.InstrumentID.IsZero() {
+		return Listing{}, fmt.Errorf("%w: instrument ID must not be zero", ErrInvalidListing)
+	}
+	venue := strings.TrimSpace(p.Venue)
+	if venue == "" {
+		return Listing{}, fmt.Errorf("%w: venue must not be empty", ErrInvalidListing)
+	}
+	symbol := strings.TrimSpace(p.Symbol)
+	if symbol == "" {
+		return Listing{}, fmt.Errorf("%w: symbol must not be empty", ErrInvalidListing)
+	}
+	if p.Spec.TickSize().IsZero() {
+		return Listing{}, fmt.Errorf("%w: spec must be constructed with NewSpec", ErrInvalidListing)
+	}
+	return Listing{
+		instrumentID: p.InstrumentID,
+		venue:        venue,
+		symbol:       symbol,
+		spec:         p.Spec,
+		tradable:     p.Tradable,
+	}, nil
+}
+
+// InstrumentID returns the Instrument l represents.
+func (l Listing) InstrumentID() ID { return l.instrumentID }
+
+// Venue returns the provider or exchange offering l.
+func (l Listing) Venue() string { return l.venue }
+
+// Symbol returns the venue's own symbol text for l.
+func (l Listing) Symbol() string { return l.symbol }
+
+// Spec returns l's trading mechanics.
+func (l Listing) Spec() Spec { return l.spec }
+
+// Tradable reports whether l can currently be traded.
+func (l Listing) Tradable() bool { return l.tradable }

--- a/instrument/listing_test.go
+++ b/instrument/listing_test.go
@@ -1,0 +1,97 @@
+package instrument
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewListing(t *testing.T) {
+	instID := CurrencyPairID(num.MustParseCurrency("EUR"), num.MustParseCurrency("USD"))
+	spec := validFXSpec(t)
+
+	l, err := NewListing(ListingParams{
+		InstrumentID: instID,
+		Venue:        "OANDA",
+		Symbol:       "EUR_USD",
+		Spec:         spec,
+		Tradable:     true,
+	})
+	require.NoError(t, err)
+
+	assert.True(t, l.InstrumentID().Equal(instID))
+	assert.Equal(t, "OANDA", l.Venue())
+	assert.Equal(t, "EUR_USD", l.Symbol())
+	assert.True(t, l.Tradable())
+	assert.Equal(t, spec, l.Spec())
+}
+
+func TestNewListingPreservesSymbolCaseAndTrimsWhitespace(t *testing.T) {
+	instID := IndexID("SPX")
+	spec := validFXSpec(t)
+
+	l, err := NewListing(ListingParams{
+		InstrumentID: instID,
+		Venue:        "  NASDAQ  ",
+		Symbol:       "  spx.us  ",
+		Spec:         spec,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "NASDAQ", l.Venue())
+	assert.Equal(t, "spx.us", l.Symbol(), "provider symbol text is display-only and never normalized")
+}
+
+func TestNewListingRejectsZeroInstrumentID(t *testing.T) {
+	_, err := NewListing(ListingParams{
+		Venue:  "OANDA",
+		Symbol: "EUR_USD",
+		Spec:   validFXSpec(t),
+	})
+	require.ErrorIs(t, err, ErrInvalidListing)
+}
+
+func TestNewListingRejectsEmptyVenueOrSymbol(t *testing.T) {
+	instID := IndexID("SPX")
+	spec := validFXSpec(t)
+
+	_, err := NewListing(ListingParams{InstrumentID: instID, Venue: "", Symbol: "SPX", Spec: spec})
+	require.ErrorIs(t, err, ErrInvalidListing)
+
+	_, err = NewListing(ListingParams{InstrumentID: instID, Venue: "NASDAQ", Symbol: "", Spec: spec})
+	require.ErrorIs(t, err, ErrInvalidListing)
+}
+
+func TestNewListingRejectsUnconstructedSpec(t *testing.T) {
+	instID := IndexID("SPX")
+
+	_, err := NewListing(ListingParams{
+		InstrumentID: instID,
+		Venue:        "NASDAQ",
+		Symbol:       "SPX",
+		Spec:         Spec{},
+	})
+	require.ErrorIs(t, err, ErrInvalidListing)
+}
+
+// TestContinuousSeriesListingIsNeverTradableByConvention documents that
+// tradability is decided by the caller, driven by Instrument.Kind, not
+// enforced structurally by Listing — see the package doc comment for why
+// that distinction belongs to Kind rather than a Listing-level flag
+// combination.
+func TestContinuousSeriesListingIsNeverTradableByConvention(t *testing.T) {
+	inst, err := NewContinuousSeries("ES")
+	require.NoError(t, err)
+
+	l, err := NewListing(ListingParams{
+		InstrumentID: inst.ID(),
+		Venue:        "Trader Research",
+		Symbol:       "ES-CONT",
+		Spec:         validFXSpec(t),
+		Tradable:     false,
+	})
+	require.NoError(t, err)
+	assert.False(t, l.Tradable())
+}

--- a/instrument/listing_test.go
+++ b/instrument/listing_test.go
@@ -8,90 +8,165 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func mustEurUsd(t *testing.T) Instrument {
+	t.Helper()
+	inst, err := NewCurrencyPair(num.MustParseCurrency("EUR"), num.MustParseCurrency("USD"))
+	require.NoError(t, err)
+	return inst
+}
+
 func TestNewListing(t *testing.T) {
-	instID := CurrencyPairID(num.MustParseCurrency("EUR"), num.MustParseCurrency("USD"))
+	inst := mustEurUsd(t)
 	spec := validFXSpec(t)
 
 	l, err := NewListing(ListingParams{
-		InstrumentID: instID,
-		Venue:        "OANDA",
-		Symbol:       "EUR_USD",
-		Spec:         spec,
-		Tradable:     true,
+		Instrument: inst,
+		Provider:   "OANDA",
+		Venue:      "",
+		Symbol:     "EUR_USD",
+		Spec:       spec,
+		Tradable:   true,
 	})
 	require.NoError(t, err)
 
-	assert.True(t, l.InstrumentID().Equal(instID))
-	assert.Equal(t, "OANDA", l.Venue())
+	assert.True(t, l.InstrumentID().Equal(inst.ID()))
+	assert.Equal(t, "OANDA", l.Provider())
+	assert.Equal(t, "", l.Venue(), "spot FX has no meaningful centralized venue")
 	assert.Equal(t, "EUR_USD", l.Symbol())
 	assert.True(t, l.Tradable())
 	assert.Equal(t, spec, l.Spec())
 }
 
-func TestNewListingPreservesSymbolCaseAndTrimsWhitespace(t *testing.T) {
-	instID := IndexID("SPX")
+func TestNewListingDistinguishesProviderFromVenue(t *testing.T) {
+	inst, err := NewEquity("NASDAQ", "AAPL")
+	require.NoError(t, err)
 	spec := validFXSpec(t)
 
 	l, err := NewListing(ListingParams{
-		InstrumentID: instID,
-		Venue:        "  NASDAQ  ",
-		Symbol:       "  spx.us  ",
-		Spec:         spec,
+		Instrument: inst,
+		Provider:   "IBKR",
+		Venue:      "NASDAQ",
+		Symbol:     "AAPL",
+		Spec:       spec,
+		Tradable:   true,
 	})
 	require.NoError(t, err)
 
+	assert.Equal(t, "IBKR", l.Provider())
+	assert.Equal(t, "NASDAQ", l.Venue())
+}
+
+func TestNewListingPreservesSymbolCaseAndTrimsWhitespace(t *testing.T) {
+	inst, err := NewIndex("SPX")
+	require.NoError(t, err)
+	spec := validFXSpec(t)
+
+	l, err := NewListing(ListingParams{
+		Instrument: inst,
+		Provider:   "  Bloomberg  ",
+		Venue:      "  NASDAQ  ",
+		Symbol:     "  spx.us  ",
+		Spec:       spec,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bloomberg", l.Provider())
 	assert.Equal(t, "NASDAQ", l.Venue())
 	assert.Equal(t, "spx.us", l.Symbol(), "provider symbol text is display-only and never normalized")
 }
 
-func TestNewListingRejectsZeroInstrumentID(t *testing.T) {
+func TestNewListingRejectsUnconstructedInstrument(t *testing.T) {
 	_, err := NewListing(ListingParams{
-		Venue:  "OANDA",
-		Symbol: "EUR_USD",
-		Spec:   validFXSpec(t),
+		Provider: "OANDA",
+		Symbol:   "EUR_USD",
+		Spec:     validFXSpec(t),
 	})
 	require.ErrorIs(t, err, ErrInvalidListing)
 }
 
-func TestNewListingRejectsEmptyVenueOrSymbol(t *testing.T) {
-	instID := IndexID("SPX")
+func TestNewListingRejectsEmptyProviderOrSymbol(t *testing.T) {
+	inst, err := NewIndex("SPX")
+	require.NoError(t, err)
 	spec := validFXSpec(t)
 
-	_, err := NewListing(ListingParams{InstrumentID: instID, Venue: "", Symbol: "SPX", Spec: spec})
+	_, err = NewListing(ListingParams{Instrument: inst, Provider: "", Symbol: "SPX", Spec: spec})
 	require.ErrorIs(t, err, ErrInvalidListing)
 
-	_, err = NewListing(ListingParams{InstrumentID: instID, Venue: "NASDAQ", Symbol: "", Spec: spec})
+	_, err = NewListing(ListingParams{Instrument: inst, Provider: "Bloomberg", Symbol: "", Spec: spec})
 	require.ErrorIs(t, err, ErrInvalidListing)
 }
 
 func TestNewListingRejectsUnconstructedSpec(t *testing.T) {
-	instID := IndexID("SPX")
+	inst, err := NewIndex("SPX")
+	require.NoError(t, err)
 
-	_, err := NewListing(ListingParams{
-		InstrumentID: instID,
-		Venue:        "NASDAQ",
-		Symbol:       "SPX",
-		Spec:         Spec{},
+	_, err = NewListing(ListingParams{
+		Instrument: inst,
+		Provider:   "Bloomberg",
+		Symbol:     "SPX",
+		Spec:       Spec{},
 	})
 	require.ErrorIs(t, err, ErrInvalidListing)
 }
 
-// TestContinuousSeriesListingIsNeverTradableByConvention documents that
-// tradability is decided by the caller, driven by Instrument.Kind, not
-// enforced structurally by Listing — see the package doc comment for why
-// that distinction belongs to Kind rather than a Listing-level flag
-// combination.
-func TestContinuousSeriesListingIsNeverTradableByConvention(t *testing.T) {
+// TestNewListingRejectsTradableContinuousSeries is the acceptance-
+// criterion test: NewListing mechanically rejects the contradictory
+// combination the package doc comment describes — Tradable: true for an
+// instrument that is non-orderable by Kind.
+func TestNewListingRejectsTradableContinuousSeries(t *testing.T) {
+	inst, err := NewContinuousSeries("ES")
+	require.NoError(t, err)
+
+	_, err = NewListing(ListingParams{
+		Instrument: inst,
+		Provider:   "Trader Research",
+		Symbol:     "ES-CONT",
+		Spec:       validFXSpec(t),
+		Tradable:   true,
+	})
+	require.ErrorIs(t, err, ErrInvalidListing)
+}
+
+func TestNewListingRejectsTradableIndex(t *testing.T) {
+	inst, err := NewIndex("SPX")
+	require.NoError(t, err)
+
+	_, err = NewListing(ListingParams{
+		Instrument: inst,
+		Provider:   "Bloomberg",
+		Symbol:     "SPX",
+		Spec:       validFXSpec(t),
+		Tradable:   true,
+	})
+	require.ErrorIs(t, err, ErrInvalidListing)
+}
+
+func TestNewListingAllowsNonTradableContinuousSeries(t *testing.T) {
 	inst, err := NewContinuousSeries("ES")
 	require.NoError(t, err)
 
 	l, err := NewListing(ListingParams{
-		InstrumentID: inst.ID(),
-		Venue:        "Trader Research",
-		Symbol:       "ES-CONT",
-		Spec:         validFXSpec(t),
-		Tradable:     false,
+		Instrument: inst,
+		Provider:   "Trader Research",
+		Symbol:     "ES-CONT",
+		Spec:       validFXSpec(t),
+		Tradable:   false,
 	})
 	require.NoError(t, err)
 	assert.False(t, l.Tradable())
+}
+
+func TestNewListingAllowsTradableFuture(t *testing.T) {
+	inst := mustFuture(t)
+
+	l, err := NewListing(ListingParams{
+		Instrument: inst,
+		Provider:   "CME",
+		Venue:      "CME",
+		Symbol:     "ESZ26",
+		Spec:       validFXSpec(t),
+		Tradable:   true,
+	})
+	require.NoError(t, err)
+	assert.True(t, l.Tradable())
 }

--- a/instrument/spec.go
+++ b/instrument/spec.go
@@ -1,0 +1,84 @@
+package instrument
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/num"
+)
+
+// Spec holds one Listing's exact trading mechanics: its minimum price
+// increment, minimum quantity increment, contract multiplier, and the
+// currency it settles in.
+//
+// Spec's fields are unexported; construct one with NewSpec. The Go zero
+// value of Spec is not a valid, constructed Spec — NewListing rejects it.
+type Spec struct {
+	tickSize           num.Price
+	quantityIncrement  num.Quantity
+	multiplier         num.Rate
+	settlementCurrency num.Currency
+}
+
+// NewSpec validates and returns a Spec. tickSize and quantityIncrement
+// must be strictly positive, multiplier must be strictly positive
+// (instruments with no meaningful contract multiplier, such as equities
+// and currency pairs, pass num.MustParseRate("1")), and settlementCurrency
+// must be structurally valid.
+func NewSpec(tickSize num.Price, quantityIncrement num.Quantity, multiplier num.Rate, settlementCurrency num.Currency) (Spec, error) {
+	if tickSize.IsZero() {
+		return Spec{}, fmt.Errorf("%w: tick size must be positive", ErrInvalidSpec)
+	}
+	if quantityIncrement.IsZero() {
+		return Spec{}, fmt.Errorf("%w: quantity increment must be positive", ErrInvalidSpec)
+	}
+	if multiplier.Sign() <= 0 {
+		return Spec{}, fmt.Errorf("%w: multiplier must be positive", ErrInvalidSpec)
+	}
+	if !settlementCurrency.IsValid() {
+		return Spec{}, fmt.Errorf("%w: settlement currency must be valid", ErrInvalidSpec)
+	}
+	return Spec{
+		tickSize:           tickSize,
+		quantityIncrement:  quantityIncrement,
+		multiplier:         multiplier,
+		settlementCurrency: settlementCurrency,
+	}, nil
+}
+
+// TickSize returns s's minimum price increment.
+func (s Spec) TickSize() num.Price { return s.tickSize }
+
+// QuantityIncrement returns s's minimum quantity increment.
+func (s Spec) QuantityIncrement() num.Quantity { return s.quantityIncrement }
+
+// Multiplier returns s's contract multiplier.
+func (s Spec) Multiplier() num.Rate { return s.multiplier }
+
+// SettlementCurrency returns the currency s settles in.
+func (s Spec) SettlementCurrency() num.Currency { return s.settlementCurrency }
+
+// ValidatePrice reports an error unless price is an exact multiple of s's
+// tick size, per ADR-004's exact price-increment rule.
+func (s Spec) ValidatePrice(price num.Price) error {
+	ok, err := price.DivisibleBy(s.tickSize)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("%w: price %s is not a multiple of tick size %s", ErrInvalidSpec, price, s.tickSize)
+	}
+	return nil
+}
+
+// ValidateQuantity reports an error unless qty is an exact multiple of s's
+// quantity increment.
+func (s Spec) ValidateQuantity(qty num.Quantity) error {
+	ok, err := qty.DivisibleBy(s.quantityIncrement)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("%w: quantity %s is not a multiple of quantity increment %s", ErrInvalidSpec, qty, s.quantityIncrement)
+	}
+	return nil
+}

--- a/instrument/spec.go
+++ b/instrument/spec.go
@@ -58,8 +58,13 @@ func (s Spec) Multiplier() num.Rate { return s.multiplier }
 func (s Spec) SettlementCurrency() num.Currency { return s.settlementCurrency }
 
 // ValidatePrice reports an error unless price is an exact multiple of s's
-// tick size, per ADR-004's exact price-increment rule.
+// tick size, per ADR-004's exact price-increment rule. ValidatePrice
+// reports ErrInvalidSpec, not num.ErrDivideByZero, if s is the
+// unconstructed zero value.
 func (s Spec) ValidatePrice(price num.Price) error {
+	if s.tickSize.IsZero() {
+		return fmt.Errorf("%w: spec must be constructed with NewSpec", ErrInvalidSpec)
+	}
 	ok, err := price.DivisibleBy(s.tickSize)
 	if err != nil {
 		return err
@@ -71,8 +76,12 @@ func (s Spec) ValidatePrice(price num.Price) error {
 }
 
 // ValidateQuantity reports an error unless qty is an exact multiple of s's
-// quantity increment.
+// quantity increment. ValidateQuantity reports ErrInvalidSpec, not
+// num.ErrDivideByZero, if s is the unconstructed zero value.
 func (s Spec) ValidateQuantity(qty num.Quantity) error {
+	if s.quantityIncrement.IsZero() {
+		return fmt.Errorf("%w: spec must be constructed with NewSpec", ErrInvalidSpec)
+	}
 	ok, err := qty.DivisibleBy(s.quantityIncrement)
 	if err != nil {
 		return err

--- a/instrument/spec_test.go
+++ b/instrument/spec_test.go
@@ -1,0 +1,81 @@
+package instrument
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validFXSpec(t *testing.T) Spec {
+	t.Helper()
+	s, err := NewSpec(
+		num.MustParsePrice("0.00001"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		num.MustParseCurrency("USD"),
+	)
+	require.NoError(t, err)
+	return s
+}
+
+func TestNewSpec(t *testing.T) {
+	s := validFXSpec(t)
+
+	assert.Equal(t, "0.00001", s.TickSize().String())
+	assert.Equal(t, "1", s.QuantityIncrement().String())
+	assert.Equal(t, "1", s.Multiplier().String())
+	assert.Equal(t, "USD", s.SettlementCurrency().String())
+}
+
+func TestNewSpecRejectsInvalidFields(t *testing.T) {
+	tickSize := num.MustParsePrice("0.01")
+	qtyIncrement := num.MustParseQuantity("1")
+	multiplier := num.MustParseRate("1")
+	currency := num.MustParseCurrency("USD")
+
+	tests := []struct {
+		name              string
+		tickSize          num.Price
+		quantityIncrement num.Quantity
+		multiplier        num.Rate
+		currency          num.Currency
+	}{
+		{"zero tick size", num.Price{}, qtyIncrement, multiplier, currency},
+		{"zero quantity increment", tickSize, num.Quantity{}, multiplier, currency},
+		{"zero multiplier", tickSize, qtyIncrement, num.Rate{}, currency},
+		{"negative multiplier", tickSize, qtyIncrement, num.MustParseRate("-1"), currency},
+		{"invalid currency", tickSize, qtyIncrement, multiplier, num.Currency{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewSpec(tt.tickSize, tt.quantityIncrement, tt.multiplier, tt.currency)
+			require.ErrorIs(t, err, ErrInvalidSpec)
+		})
+	}
+}
+
+func TestSpecValidatePrice(t *testing.T) {
+	s := validFXSpec(t)
+
+	require.NoError(t, s.ValidatePrice(num.MustParsePrice("1.08450")))
+	err := s.ValidatePrice(num.MustParsePrice("1.084503"))
+	require.ErrorIs(t, err, ErrInvalidSpec)
+}
+
+func TestSpecValidateQuantity(t *testing.T) {
+	tickSize := num.MustParsePrice("0.01")
+	s, err := NewSpec(tickSize, num.MustParseQuantity("5"), num.MustParseRate("1"), num.MustParseCurrency("USD"))
+	require.NoError(t, err)
+
+	require.NoError(t, s.ValidateQuantity(num.MustParseQuantity("100")))
+	err = s.ValidateQuantity(num.MustParseQuantity("101"))
+	require.ErrorIs(t, err, ErrInvalidSpec)
+}
+
+func TestSpecZeroValueIsNotConstructed(t *testing.T) {
+	var s Spec
+	assert.True(t, s.TickSize().IsZero())
+}

--- a/num/price.go
+++ b/num/price.go
@@ -116,3 +116,15 @@ func (p Price) Div(o Price) (Rate, error) {
 	}
 	return Rate{raw: raw}, nil
 }
+
+// DivisibleBy reports whether p is an exact integer multiple of step, per
+// ADR-004's price-increment rule: priceRaw % tickRaw == 0. The comparison is
+// exact scaled-integer arithmetic; no rounding is involved.
+//
+// DivisibleBy reports ErrDivideByZero when step is zero.
+func (p Price) DivisibleBy(step Price) (bool, error) {
+	if step.raw == 0 {
+		return false, ErrDivideByZero
+	}
+	return p.raw%step.raw == 0, nil
+}

--- a/num/price_test.go
+++ b/num/price_test.go
@@ -134,3 +134,35 @@ func TestPriceDivByZero(t *testing.T) {
 	_, err := a.Div(Price{})
 	require.ErrorIs(t, err, ErrDivideByZero)
 }
+
+func TestPriceDivisibleBy(t *testing.T) {
+	tests := []struct {
+		name string
+		p    string
+		step string
+		want bool
+	}{
+		{name: "exact multiple", p: "1.08450", step: "0.00010", want: true},
+		{name: "on the step itself", p: "0.25", step: "0.25", want: true},
+		{name: "zero is divisible by anything nonzero", p: "0", step: "0.01", want: true},
+		{name: "not a multiple", p: "1.08453", step: "0.00010", want: false},
+		{name: "one quantum short", p: "1.00000001", step: "0.00000010", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := MustParsePrice(tt.p)
+			step := MustParsePrice(tt.step)
+
+			got, err := p.DivisibleBy(step)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPriceDivisibleByZeroStep(t *testing.T) {
+	p := MustParsePrice("1.00")
+	_, err := p.DivisibleBy(Price{})
+	require.ErrorIs(t, err, ErrDivideByZero)
+}

--- a/num/quantity.go
+++ b/num/quantity.go
@@ -121,3 +121,16 @@ func (q Quantity) Div(o Quantity) (Rate, error) {
 	}
 	return Rate{raw: raw}, nil
 }
+
+// DivisibleBy reports whether q is an exact integer multiple of step, the
+// same exact-remainder rule ADR-004 prescribes for price increments applied
+// to quantity increments. The comparison is exact scaled-integer arithmetic;
+// no rounding is involved.
+//
+// DivisibleBy reports ErrDivideByZero when step is zero.
+func (q Quantity) DivisibleBy(step Quantity) (bool, error) {
+	if step.raw == 0 {
+		return false, ErrDivideByZero
+	}
+	return q.raw%step.raw == 0, nil
+}

--- a/num/quantity_test.go
+++ b/num/quantity_test.go
@@ -133,3 +133,35 @@ func TestQuantityDivByZero(t *testing.T) {
 	_, err := a.Div(Quantity{})
 	require.ErrorIs(t, err, ErrDivideByZero)
 }
+
+func TestQuantityDivisibleBy(t *testing.T) {
+	tests := []struct {
+		name string
+		q    string
+		step string
+		want bool
+	}{
+		{name: "exact multiple", q: "100", step: "5", want: true},
+		{name: "on the step itself", q: "0.001", step: "0.001", want: true},
+		{name: "zero is divisible by anything nonzero", q: "0", step: "1", want: true},
+		{name: "not a multiple", q: "101", step: "5", want: false},
+		{name: "fractional increment not met", q: "1.00000001", step: "0.00000010", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := MustParseQuantity(tt.q)
+			step := MustParseQuantity(tt.step)
+
+			got, err := q.DivisibleBy(step)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestQuantityDivisibleByZeroStep(t *testing.T) {
+	q := MustParseQuantity("1")
+	_, err := q.DivisibleBy(Quantity{})
+	require.ErrorIs(t, err, ErrDivideByZero)
+}


### PR DESCRIPTION
## Summary

Implements #25 (M1-07 Define instrument and listing value models) and ratifies ADR-003, which had been left `Proposed` and thin.

- `Instrument` — canonical economic identity (`ID`, `Kind`, and kind-specific accessors), independent of provider/venue. `ID` is deterministic and canonical, built from an instrument's economic attributes via per-kind constructors (`CurrencyPairID`, `EquityID`, `ETFID`, `FutureID`, `ContinuousSeriesID`, `IndexID`) — never parsed from provider text, never generated the way `id.ID[K]` is.
- `Listing` — one venue's tradable/research-only representation: venue, provider symbol (display-only), `Spec`, and `Tradable`.
- `Spec` — tick size, quantity increment, multiplier, settlement currency, plus `ValidatePrice`/`ValidateQuantity` built on new `num.Price.DivisibleBy`/`num.Quantity.DivisibleBy` methods (ADR-004's exact-remainder rule, computed inside `num` without re-exposing raw scaled values).
- Six kinds: `KindCurrencyPair`, `KindEquity`, `KindETF`, `KindFuture`, `KindContinuousSeries`, `KindIndex`.

**Design note**: the plan posted to #25 initially described a futures `Instrument` as the contract *family*, but also gave `FutureID` an `expiration` parameter — a real inconsistency, caught during design review on the issue. Resolved per the issue owner's steer: an individual expiring contract (e.g. ES Dec-2026) is the `Instrument`; a continuous/back-adjusted research series is a distinct kind (`KindContinuousSeries`), not a `Listing`-level flag. See the issue thread and `instrument/doc.go` for the full reasoning.

## Test plan

- [x] `make check` (fmt, vet, `go test -race ./...`) passes
- [x] 98.1% coverage on `instrument`, table-driven tests including validation/error paths
- [x] Alias-independence test: three different "provider spellings" of EUR/USD all resolve to the identical `ID`
- [x] Architecture guard (AST-based) rejecting any leg/synthetic-named struct field, with a regression test proving the detector fires
- [x] `Example` functions for FX, equity, futures (incl. the continuous-series distinction), and a `Listing`

## Documentation

- `instrument/doc.go` — package-level design rationale
- ADR-003 updated from `Proposed` to `Accepted`, decision text rewritten to match what was actually built
- `README.md` — new `### instrument` section

Closes #25.