### PR TITLE
Add symbol and listing resolution to instrument package

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,31 @@ non-orderable `Instrument` — see the
 [package doc comment](instrument/doc.go) for why futures split into two
 kinds instead of one, and why synthetic/multi-leg instruments are deferred.
 
+`instrument.Resolver` resolves provider symbols and `Instrument`+venue
+combinations to `Listing`s without ever letting a symbol or alias become
+identity. `MemoryResolver` is the in-memory reference implementation —
+a plain value with no package-level registry, so independent instances
+need no special setup:
+
+```go
+r := instrument.NewMemoryResolver()
+if err := r.Register(oandaListing); err != nil {
+	log.Fatal(err)
+}
+if err := r.RegisterAlias("OANDA", "", "EURUSD", "OANDA", "", "EUR_USD"); err != nil {
+	log.Fatal(err)
+}
+
+listing, err := r.ResolveSymbol("OANDA", "", "EURUSD") // resolves via the alias
+// listing.Symbol() == "EUR_USD" -- the alias never becomes the identity
+```
+
+An unconstrained provider/venue that matches more than one `Listing`
+reports `ErrAmbiguousSymbol` rather than picking one; no match reports
+`ErrUnknownSymbol`. See [ADR-016](docs/arch/adr-decisions.org) and the
+[package doc comment](instrument/doc.go) for the full resolution
+semantics.
+
 ## Documentation
 
 - [Framework requirements](docs/arch/trader-framework-requirements.org)

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -744,8 +744,9 @@ canonical value, unchanged — an alias never becomes identity.
   already had to handle correctly.
 - *A query/options struct (for example =SymbolQuery{Provider, Venue,
   Symbol}=) instead of positional string parameters.*  Rejected for M1 as
-  premature: two string parameters are enough for both methods today: the
-  struct is the natural next step only if a third resolution axis proves
+  premature: =ResolveSymbol='s three parameters and =ResolveInstrument='s
+  three are still few enough to stay readable positionally; the struct is
+  the natural next step only if a further resolution axis proves
   necessary.
 - *A package-level global registry.*  Rejected per issue #26's explicit
   constraint and Trader's broader avoidance of hidden global state (see

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -81,6 +81,7 @@ believed at that time.
 | 012 | Trading calendar and bar-alignment semantics                      | Proposed   |
 | 013 | Greenfield repository with controlled legacy transplant           | Accepted   |
 | 014 | Paper trading is the safe default                                 | Accepted   |
+| 016 | Symbol and listing resolution                                     | Accepted   |
 
 * ADR-001: Modular monolith before service decomposition
 
@@ -669,6 +670,87 @@ depending on any particular risk configuration.
   default because it complicates simulation and paper workflows without
   additional safety benefit beyond what an explicit enablement decision
   already provides.
+
+* ADR-016: Symbol and listing resolution
+
+** Status
+
+Accepted
+
+** Context
+
+ADR-003 established =Instrument= and =Listing= as distinct concepts but
+explicitly deferred the resolver mapping provider-native symbols to them:
+"A =Resolver= mapping Trader IDs to provider- or broker-native symbols ...
+remain[s] a future, additive concern[] and [is] not part of this
+decision."  Issue #26 (M1-08) required settling that resolver: how
+provider symbols and aliases resolve to a =Listing= without ever becoming
+instrument identity themselves, how ambiguity is detected rather than
+silently guessed at, and how registration works without a package-level
+global registry.
+
+** Decision
+
+=instrument.Resolver= is a small, read-only interface with two resolution
+directions:
+
+- =ResolveSymbol(provider, venue, symbol string) (Listing, error)=
+- =ResolveInstrument(instrumentID ID, provider, venue string) (Listing, error)=
+
+Both treat an empty =provider=/=venue=/=symbol= argument as "unconstrained
+on this axis," and both resolve to exactly one =Listing= or fail: zero
+matches after applying whatever context was supplied reports
+=ErrUnknownSymbol=, and more than one reports =ErrAmbiguousSymbol=.  A
+=Resolver= never guesses which =Listing= a caller means.  In particular, a
+provider is not assumed to expose a given symbol on at most one venue —
+=(provider, symbol)= alone is not treated as a globally unique lookup key,
+so an unconstrained venue on =ResolveSymbol= is a real, tested source of
+ambiguity, not a convenience default that happens to always resolve.
+
+=instrument.MemoryResolver= is the in-memory reference implementation:
+a plain value returned by =NewMemoryResolver=, with no package-level
+state, so independently configured resolver instances (per environment,
+per test) require no special support.  It exposes =Register= (indexes a
+constructed =Listing= under its own provider/venue/symbol and its
+=InstrumentID=, rejecting an exact provider/venue/symbol duplicate) and
+=RegisterAlias= (adds an additional provider/venue/symbol lookup key that
+resolves to an existing registration's =Listing=, resolving that canonical
+reference through the same zero/one/many logic =ResolveSymbol= uses, so an
+underspecified alias target is caught at registration time).  An alias is
+never itself indexed as a new =Listing= and never gains its own entry in
+the instrument index, and the =Listing= it resolves to is always the
+canonical value, unchanged — an alias never becomes identity.
+=MemoryResolver= holds a =sync.RWMutex= and is safe for concurrent use.
+
+** Consequences
+
+- Registration/loading strategy (in-memory, a future config-file-backed
+  or persistent resolver) can vary behind the same =Resolver= interface
+  that consumers (execution, broker adapters) depend on.
+- Ambiguity is a first-class, tested outcome distinguishable from
+  "unknown," on both resolution directions, via distinct sentinel errors.
+- No global mutable registry exists anywhere in the package; every
+  =MemoryResolver= is independent by construction.
+- Aliases add lookup keys, never new identity: resolving through one
+  returns the exact canonical =Listing= value.
+
+** Alternatives Considered
+
+- *=(provider, symbol)= as a globally unique lookup key, ambiguity only on
+  the =Instrument= -> =Listing= direction.*  Considered and rejected during
+  design review: a provider is not guaranteed to expose a symbol on only
+  one venue, and baking that assumption into the public contract would
+  have made =ResolveSymbol= unable to express a case =ResolveInstrument=
+  already had to handle correctly.
+- *A query/options struct (for example =SymbolQuery{Provider, Venue,
+  Symbol}=) instead of positional string parameters.*  Rejected for M1 as
+  premature: two string parameters are enough for both methods today: the
+  struct is the natural next step only if a third resolution axis proves
+  necessary.
+- *A package-level global registry.*  Rejected per issue #26's explicit
+  constraint and Trader's broader avoidance of hidden global state (see
+  ADR-002's dependency-direction rules and the architecture document's
+  determinism principles).
 
 * ADR Template                                                       :noexport:
 

--- a/instrument/doc.go
+++ b/instrument/doc.go
@@ -96,6 +96,26 @@
 // sufficient for M1's scope; a more durable identity scheme, if one proves
 // necessary, is a later, additive change.
 //
+// # Resolving provider symbols without treating them as identity
+//
+// Resolver, and its in-memory reference implementation MemoryResolver
+// (see resolver.go), resolve provider-specific symbols and
+// Instrument+venue combinations to Listings — without ever letting an
+// alias, or a provider's own symbol spelling, become instrument identity.
+// This is issue #26 (M1-08) and ADR-016.
+//
+// Resolution never guesses: ResolveSymbol and ResolveInstrument both
+// resolve to exactly one Listing or report an error — ErrUnknownSymbol
+// for zero matches, ErrAmbiguousSymbol for more than one — rather than
+// picking an arbitrary match. A provider is not guaranteed to expose a
+// given symbol on only one venue, so an unconstrained (empty) venue on a
+// ResolveSymbol call is a real source of ambiguity, not merely a
+// convenience default.
+//
+// There is no package-level registry: MemoryResolver is a plain value
+// returned by NewMemoryResolver, and every instance is independent of
+// every other one.
+//
 // # Synthetic and multi-leg instruments are deferred
 //
 // Pairs trades, futures calendar spreads, options spreads, and weighted

--- a/instrument/errors.go
+++ b/instrument/errors.go
@@ -14,7 +14,23 @@ var (
 	ErrInvalidSpec = errors.New("instrument: invalid spec")
 
 	// ErrInvalidListing reports a Listing constructor argument that fails
-	// validation: a zero instrument ID, an empty venue/symbol, or a Spec
-	// that was not constructed with NewSpec.
+	// validation: an unconstructed Instrument, an empty provider/symbol, a
+	// Spec that was not constructed with NewSpec, or Tradable: true for an
+	// Instrument that is non-orderable by Kind.
 	ErrInvalidListing = errors.New("instrument: invalid listing")
+
+	// ErrUnknownSymbol reports a Resolver lookup — by provider/venue/symbol
+	// or by Instrument — that matched no registered Listing.
+	ErrUnknownSymbol = errors.New("instrument: unknown symbol")
+
+	// ErrAmbiguousSymbol reports a Resolver lookup that matched more than
+	// one registered Listing: the supplied provider/venue context was not
+	// enough to identify exactly one. Resolver never guesses; the caller
+	// must narrow the lookup.
+	ErrAmbiguousSymbol = errors.New("instrument: ambiguous symbol")
+
+	// ErrDuplicateListing reports an attempt to register a Listing or
+	// alias under a provider/venue/symbol combination that is already
+	// registered on that Resolver.
+	ErrDuplicateListing = errors.New("instrument: duplicate listing registration")
 )

--- a/instrument/errors.go
+++ b/instrument/errors.go
@@ -33,4 +33,9 @@ var (
 	// alias under a provider/venue/symbol combination that is already
 	// registered on that Resolver.
 	ErrDuplicateListing = errors.New("instrument: duplicate listing registration")
+
+	// ErrInvalidResolution reports a Resolver query missing required
+	// context: ResolveSymbol requires a non-empty provider and symbol
+	// (venue alone may be left unconstrained).
+	ErrInvalidResolution = errors.New("instrument: invalid resolution query")
 )

--- a/instrument/example_test.go
+++ b/instrument/example_test.go
@@ -1,6 +1,7 @@
 package instrument_test
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -118,4 +119,117 @@ func Example_listing() {
 	// AAPL
 	// true
 	// true
+}
+
+// Example_resolver shows registering EUR/USD under two different
+// providers' symbol spellings, plus an alias, and resolving all three back
+// to the same Instrument without any of them becoming its identity.
+func Example_resolver() {
+	eurUsd, err := instrument.NewCurrencyPair(num.MustParseCurrency("EUR"), num.MustParseCurrency("USD"))
+	if err != nil {
+		panic(err)
+	}
+
+	spec, err := instrument.NewSpec(
+		num.MustParsePrice("0.00001"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		num.MustParseCurrency("USD"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	r := instrument.NewMemoryResolver()
+
+	oanda, err := instrument.NewListing(instrument.ListingParams{
+		Instrument: eurUsd,
+		Provider:   "OANDA",
+		Symbol:     "EUR_USD",
+		Spec:       spec,
+		Tradable:   true,
+	})
+	if err != nil {
+		panic(err)
+	}
+	if err := r.Register(oanda); err != nil {
+		panic(err)
+	}
+
+	// A convenience spelling application code might use, registered as an
+	// alias rather than a second Listing.
+	if err := r.RegisterAlias("OANDA", "", "EURUSD", "OANDA", "", "EUR_USD"); err != nil {
+		panic(err)
+	}
+
+	bySymbol, err := r.ResolveSymbol("OANDA", "", "EUR_USD")
+	if err != nil {
+		panic(err)
+	}
+	byAlias, err := r.ResolveSymbol("OANDA", "", "EURUSD")
+	if err != nil {
+		panic(err)
+	}
+	byInstrument, err := r.ResolveInstrument(eurUsd.ID(), "OANDA", "")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(bySymbol.Symbol())
+	fmt.Println(byAlias.Symbol()) // the alias resolves to the canonical Listing's own symbol, not "EURUSD"
+	fmt.Println(byInstrument.Symbol())
+	// Output:
+	// EUR_USD
+	// EUR_USD
+	// EUR_USD
+}
+
+// Example_resolverAmbiguous shows an unconstrained lookup failing because
+// one provider exposes the same symbol on two venues, and resolved by
+// supplying the venue.
+func Example_resolverAmbiguous() {
+	apple, err := instrument.NewEquity("NASDAQ", "AAPL")
+	if err != nil {
+		panic(err)
+	}
+
+	spec, err := instrument.NewSpec(
+		num.MustParsePrice("0.01"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		num.MustParseCurrency("USD"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	r := instrument.NewMemoryResolver()
+	for _, venue := range []string{"NASDAQ", "BATS"} {
+		l, err := instrument.NewListing(instrument.ListingParams{
+			Instrument: apple,
+			Provider:   "IBKR",
+			Venue:      venue,
+			Symbol:     "AAPL",
+			Spec:       spec,
+			Tradable:   true,
+		})
+		if err != nil {
+			panic(err)
+		}
+		if err := r.Register(l); err != nil {
+			panic(err)
+		}
+	}
+
+	_, err = r.ResolveSymbol("IBKR", "", "AAPL")
+	fmt.Println(errors.Is(err, instrument.ErrAmbiguousSymbol))
+
+	got, err := r.ResolveSymbol("IBKR", "BATS", "AAPL")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(got.Venue())
+	// Output:
+	// true
+	// BATS
 }

--- a/instrument/resolver.go
+++ b/instrument/resolver.go
@@ -14,12 +14,16 @@ import (
 // file, a future persistent catalog — is an implementation concern, not
 // part of the contract callers depend on.
 //
-// Both methods treat an empty provider, venue, or symbol argument as
-// meaning "unconstrained on this axis," never as a literal empty value to
-// match against. A Listing legitimately registered with an empty Venue —
-// spot FX has no meaningful centralized venue, see Listing — is still
-// found by a query that passes "" for venue; "" is a wildcard on the
-// query side, not a distinct registered value to search for.
+// venue is the only axis either method treats as a wildcard: an empty
+// venue means "unconstrained," never a literal empty value to match
+// against. A Listing legitimately registered with an empty Venue — spot FX
+// has no meaningful centralized venue, see Listing — is still found by a
+// query that passes "" for venue; "" is a wildcard on the query side, not
+// a distinct registered value to search for. provider and instrumentID are
+// not wildcardable: ResolveSymbol requires a non-empty provider (and
+// symbol), and ResolveInstrument always operates within one instrumentID.
+// ResolveInstrument's provider parameter, unlike ResolveSymbol's, may be
+// left "" — see its own doc comment.
 //
 // Both methods resolve to exactly one Listing or fail: zero matches after
 // applying whatever context was supplied reports ErrUnknownSymbol, and
@@ -28,14 +32,18 @@ import (
 // context to narrow the match to one.
 type Resolver interface {
 	// ResolveSymbol resolves the Listing registered under provider, venue,
-	// and symbol. provider and symbol should normally be supplied; venue
-	// may be left "" when it does not disambiguate — but if a provider
-	// exposes the same symbol on more than one venue, an unconstrained
-	// venue will report ErrAmbiguousSymbol rather than pick one.
+	// and symbol. provider and symbol must both be non-empty —
+	// ResolveSymbol reports ErrInvalidResolution otherwise. venue may be
+	// left "" when it does not disambiguate, but if provider exposes
+	// symbol on more than one venue, an unconstrained venue reports
+	// ErrAmbiguousSymbol rather than picking one.
 	ResolveSymbol(provider, venue, symbol string) (Listing, error)
 
-	// ResolveInstrument resolves the orderable Listing for instrumentID,
-	// optionally narrowed by provider and/or venue.
+	// ResolveInstrument resolves the orderable Listing — one whose
+	// Tradable is true — for instrumentID, optionally narrowed by
+	// provider and/or venue (either or both may be left ""). A registered
+	// non-tradable Listing for instrumentID is never returned and never
+	// contributes to an ambiguous match.
 	ResolveInstrument(instrumentID ID, provider, venue string) (Listing, error)
 }
 
@@ -98,10 +106,12 @@ func (r *MemoryResolver) Register(listing Listing) error {
 // RegisterAlias registers an additional provider/venue/symbol lookup key —
 // aliasProvider, aliasVenue, aliasSymbol — that resolves to the Listing
 // already registered under canonicalProvider/canonicalVenue/
-// canonicalSymbol. The canonical reference is resolved with the same
-// zero/one/many logic ResolveSymbol uses, so an underspecified canonical
-// reference reports ErrAmbiguousSymbol here too, at registration time
-// rather than silently aliasing the wrong Listing.
+// canonicalSymbol. The canonical reference is resolved with the same logic
+// ResolveSymbol uses — canonicalProvider and canonicalSymbol must both be
+// non-empty, and an underspecified or unmatched canonical reference
+// reports the same ErrInvalidResolution/ErrUnknownSymbol/
+// ErrAmbiguousSymbol here, at registration time, rather than silently
+// aliasing the wrong Listing.
 //
 // The Listing an alias resolves to is always the canonical Listing value,
 // unchanged: its own Provider, Venue, and Symbol remain whatever it was
@@ -142,8 +152,15 @@ func (r *MemoryResolver) ResolveSymbol(provider, venue, symbol string) (Listing,
 // lookupSymbol is ResolveSymbol's implementation, factored out so
 // RegisterAlias can call it while already holding the write lock — it
 // assumes the caller holds whatever lock is appropriate and never locks
-// itself.
+// itself. provider and symbol are not wildcardable: unlike venue, an empty
+// provider or symbol is a missing required argument, not "unconstrained,"
+// because providerSymbolKey is a direct map lookup on (provider, symbol) —
+// there is no candidate list to scan the way byInstrument gives
+// ResolveInstrument for its optional axes.
 func (r *MemoryResolver) lookupSymbol(provider, venue, symbol string) (Listing, error) {
+	if provider == "" || symbol == "" {
+		return Listing{}, fmt.Errorf("%w: provider and symbol are both required", ErrInvalidResolution)
+	}
 	key := newProviderSymbolKey(provider, symbol)
 	candidates := filterByVenue(r.bySymbol[key], venue)
 	return exactlyOne(candidates, fmt.Sprintf("provider %q venue %q symbol %q", provider, venue, symbol))
@@ -154,7 +171,7 @@ func (r *MemoryResolver) ResolveInstrument(instrumentID ID, provider, venue stri
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	candidates := r.byInstrument[instrumentID]
+	candidates := filterTradable(r.byInstrument[instrumentID])
 	if provider != "" {
 		candidates = filterByProvider(candidates, provider)
 	}
@@ -212,6 +229,21 @@ func filterByProvider(candidates []Listing, provider string) []Listing {
 	var out []Listing
 	for _, l := range candidates {
 		if normalizeIdentifierPart(l.Provider()) == provider {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// filterTradable narrows candidates to those with Tradable() true. Only
+// ResolveInstrument uses this — it promises an orderable Listing;
+// ResolveSymbol makes no such promise, since a caller may legitimately
+// look up a known non-tradable Listing (a continuous series, for example)
+// by its own symbol.
+func filterTradable(candidates []Listing) []Listing {
+	var out []Listing
+	for _, l := range candidates {
+		if l.Tradable() {
 			out = append(out, l)
 		}
 	}

--- a/instrument/resolver.go
+++ b/instrument/resolver.go
@@ -1,0 +1,234 @@
+package instrument
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Resolver resolves provider-specific symbols and Instrument+venue
+// combinations to Listings, without ever treating an alias or a provider
+// symbol as instrument identity — see the package doc comment.
+//
+// Resolver is intentionally read-only: how a Resolver's mappings are
+// populated — in-memory registration (MemoryResolver), a loaded config
+// file, a future persistent catalog — is an implementation concern, not
+// part of the contract callers depend on.
+//
+// Both methods treat an empty provider, venue, or symbol argument as
+// meaning "unconstrained on this axis," never as a literal empty value to
+// match against. A Listing legitimately registered with an empty Venue —
+// spot FX has no meaningful centralized venue, see Listing — is still
+// found by a query that passes "" for venue; "" is a wildcard on the
+// query side, not a distinct registered value to search for.
+//
+// Both methods resolve to exactly one Listing or fail: zero matches after
+// applying whatever context was supplied reports ErrUnknownSymbol, and
+// more than one reports ErrAmbiguousSymbol. A Resolver never guesses which
+// Listing a caller means; the caller must supply enough provider/venue
+// context to narrow the match to one.
+type Resolver interface {
+	// ResolveSymbol resolves the Listing registered under provider, venue,
+	// and symbol. provider and symbol should normally be supplied; venue
+	// may be left "" when it does not disambiguate — but if a provider
+	// exposes the same symbol on more than one venue, an unconstrained
+	// venue will report ErrAmbiguousSymbol rather than pick one.
+	ResolveSymbol(provider, venue, symbol string) (Listing, error)
+
+	// ResolveInstrument resolves the orderable Listing for instrumentID,
+	// optionally narrowed by provider and/or venue.
+	ResolveInstrument(instrumentID ID, provider, venue string) (Listing, error)
+}
+
+// providerSymbolKey indexes MemoryResolver's registrations by provider and
+// symbol only — not venue — because a provider is not guaranteed to expose
+// a symbol on at most one venue; venue narrows within the indexed slice at
+// resolution time instead. Both fields are pre-normalized with
+// normalizeIdentifierPart so lookups are case-insensitive.
+type providerSymbolKey struct {
+	provider string
+	symbol   string
+}
+
+// MemoryResolver is an in-memory, mutable Resolver: the reference
+// implementation this package provides. It holds no package-level state —
+// every MemoryResolver returned by NewMemoryResolver is independent of
+// every other one, so multiple resolvers (per environment, per test) can
+// be configured without interfering with each other. It is safe for
+// concurrent use: registration and resolution are both expected to happen
+// from multiple goroutines in real Trader use.
+type MemoryResolver struct {
+	mu           sync.RWMutex
+	bySymbol     map[providerSymbolKey][]Listing
+	byInstrument map[ID][]Listing
+}
+
+var _ Resolver = (*MemoryResolver)(nil)
+
+// NewMemoryResolver returns an empty MemoryResolver.
+func NewMemoryResolver() *MemoryResolver {
+	return &MemoryResolver{
+		bySymbol:     make(map[providerSymbolKey][]Listing),
+		byInstrument: make(map[ID][]Listing),
+	}
+}
+
+// Register indexes listing under its own Provider/Venue/Symbol and under
+// its InstrumentID. listing must be a constructed, non-zero Listing.
+// Register reports ErrDuplicateListing if a Listing with the same
+// Provider, Venue, and Symbol (all case-insensitive) is already
+// registered on r.
+func (r *MemoryResolver) Register(listing Listing) error {
+	if listing.InstrumentID().IsZero() {
+		return fmt.Errorf("%w: listing must be constructed", ErrInvalidListing)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	key := newProviderSymbolKey(listing.Provider(), listing.Symbol())
+	if findByVenue(r.bySymbol[key], listing.Venue()) != nil {
+		return fmt.Errorf("%w: provider %q venue %q symbol %q", ErrDuplicateListing, listing.Provider(), listing.Venue(), listing.Symbol())
+	}
+
+	r.bySymbol[key] = append(r.bySymbol[key], listing)
+	r.byInstrument[listing.InstrumentID()] = append(r.byInstrument[listing.InstrumentID()], listing)
+	return nil
+}
+
+// RegisterAlias registers an additional provider/venue/symbol lookup key —
+// aliasProvider, aliasVenue, aliasSymbol — that resolves to the Listing
+// already registered under canonicalProvider/canonicalVenue/
+// canonicalSymbol. The canonical reference is resolved with the same
+// zero/one/many logic ResolveSymbol uses, so an underspecified canonical
+// reference reports ErrAmbiguousSymbol here too, at registration time
+// rather than silently aliasing the wrong Listing.
+//
+// The Listing an alias resolves to is always the canonical Listing value,
+// unchanged: its own Provider, Venue, and Symbol remain whatever it was
+// registered with. An alias is never itself indexed as a new Listing, and
+// never gains its own entry in the instrument index — aliasing a symbol
+// twice must never make ResolveInstrument see two listings where there is
+// only one.
+//
+// RegisterAlias reports ErrUnknownSymbol or ErrAmbiguousSymbol if the
+// canonical reference does not resolve to exactly one Listing, and
+// ErrDuplicateListing if the alias's own provider/venue/symbol is already
+// registered.
+func (r *MemoryResolver) RegisterAlias(aliasProvider, aliasVenue, aliasSymbol, canonicalProvider, canonicalVenue, canonicalSymbol string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	canonical, err := r.lookupSymbol(canonicalProvider, canonicalVenue, canonicalSymbol)
+	if err != nil {
+		return err
+	}
+
+	key := newProviderSymbolKey(aliasProvider, aliasSymbol)
+	if findByVenue(r.bySymbol[key], aliasVenue) != nil {
+		return fmt.Errorf("%w: provider %q venue %q symbol %q", ErrDuplicateListing, aliasProvider, aliasVenue, aliasSymbol)
+	}
+
+	r.bySymbol[key] = append(r.bySymbol[key], canonical)
+	return nil
+}
+
+// ResolveSymbol implements Resolver.
+func (r *MemoryResolver) ResolveSymbol(provider, venue, symbol string) (Listing, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.lookupSymbol(provider, venue, symbol)
+}
+
+// lookupSymbol is ResolveSymbol's implementation, factored out so
+// RegisterAlias can call it while already holding the write lock — it
+// assumes the caller holds whatever lock is appropriate and never locks
+// itself.
+func (r *MemoryResolver) lookupSymbol(provider, venue, symbol string) (Listing, error) {
+	key := newProviderSymbolKey(provider, symbol)
+	candidates := filterByVenue(r.bySymbol[key], venue)
+	return exactlyOne(candidates, fmt.Sprintf("provider %q venue %q symbol %q", provider, venue, symbol))
+}
+
+// ResolveInstrument implements Resolver.
+func (r *MemoryResolver) ResolveInstrument(instrumentID ID, provider, venue string) (Listing, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	candidates := r.byInstrument[instrumentID]
+	if provider != "" {
+		candidates = filterByProvider(candidates, provider)
+	}
+	candidates = filterByVenue(candidates, venue)
+	return exactlyOne(candidates, fmt.Sprintf("instrument %s provider %q venue %q", instrumentID, provider, venue))
+}
+
+func newProviderSymbolKey(provider, symbol string) providerSymbolKey {
+	return providerSymbolKey{
+		provider: normalizeIdentifierPart(provider),
+		symbol:   normalizeIdentifierPart(symbol),
+	}
+}
+
+// findByVenue returns the first Listing in candidates whose Venue matches
+// venue (case-insensitively, including two empty venues matching each
+// other), or nil if none does. Unlike filterByVenue, an empty venue here
+// is an exact value to match, not a wildcard — findByVenue answers "is
+// this exact provider/venue/symbol combination already registered,"
+// which is a different question from "which listings match this query."
+func findByVenue(candidates []Listing, venue string) *Listing {
+	venue = normalizeIdentifierPart(venue)
+	for i, l := range candidates {
+		if normalizeIdentifierPart(l.Venue()) == venue {
+			return &candidates[i]
+		}
+	}
+	return nil
+}
+
+// filterByVenue narrows candidates to those whose Venue matches venue
+// case-insensitively. An empty venue is a wildcard here — it leaves
+// candidates unfiltered — matching Resolver's documented "" semantics.
+func filterByVenue(candidates []Listing, venue string) []Listing {
+	if venue == "" {
+		return candidates
+	}
+	venue = normalizeIdentifierPart(venue)
+
+	var out []Listing
+	for _, l := range candidates {
+		if normalizeIdentifierPart(l.Venue()) == venue {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// filterByProvider narrows candidates to those whose Provider matches
+// provider case-insensitively. Callers only invoke this when provider is
+// non-empty; there is no wildcard case to handle here.
+func filterByProvider(candidates []Listing, provider string) []Listing {
+	provider = normalizeIdentifierPart(provider)
+
+	var out []Listing
+	for _, l := range candidates {
+		if normalizeIdentifierPart(l.Provider()) == provider {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// exactlyOne implements Resolver's shared zero/one/many resolution
+// outcome: ErrUnknownSymbol, the single match, or ErrAmbiguousSymbol. Both
+// ResolveSymbol and ResolveInstrument funnel through this so the two
+// resolution directions cannot drift apart on failure semantics.
+func exactlyOne(candidates []Listing, desc string) (Listing, error) {
+	switch len(candidates) {
+	case 0:
+		return Listing{}, fmt.Errorf("%w: %s", ErrUnknownSymbol, desc)
+	case 1:
+		return candidates[0], nil
+	default:
+		return Listing{}, fmt.Errorf("%w: %s matches %d listings", ErrAmbiguousSymbol, desc, len(candidates))
+	}
+}

--- a/instrument/resolver_test.go
+++ b/instrument/resolver_test.go
@@ -63,6 +63,24 @@ func TestResolveSymbolUnknown(t *testing.T) {
 	require.ErrorIs(t, err, ErrUnknownSymbol)
 }
 
+// TestResolveSymbolRequiresProviderAndSymbol pins the corrected contract:
+// unlike venue, provider and symbol are not wildcardable on ResolveSymbol.
+// An earlier draft's doc comment claimed otherwise while the
+// implementation only ever wildcarded venue — "" for provider or symbol
+// reports ErrInvalidResolution rather than silently searching a
+// nonsensical empty-provider or empty-symbol bucket.
+func TestResolveSymbolRequiresProviderAndSymbol(t *testing.T) {
+	eurUsd := mustEurUsd(t)
+	r := NewMemoryResolver()
+	require.NoError(t, r.Register(mustListing(t, eurUsd, "OANDA", "", "EUR_USD")))
+
+	_, err := r.ResolveSymbol("", "", "EUR_USD")
+	require.ErrorIs(t, err, ErrInvalidResolution)
+
+	_, err = r.ResolveSymbol("OANDA", "", "")
+	require.ErrorIs(t, err, ErrInvalidResolution)
+}
+
 // TestResolveSymbolAmbiguousAcrossVenues shows that an unconstrained venue
 // query is a wildcard, not a filter for a literal empty Venue: when one
 // provider exposes the same symbol on two different venues, an
@@ -127,6 +145,77 @@ func TestResolveInstrumentAmbiguousThenNarrowed(t *testing.T) {
 	got, err = r.ResolveInstrument(apple.ID(), "AnotherBroker", "NASDAQ")
 	require.NoError(t, err)
 	assert.Equal(t, "AAPL.US", got.Symbol())
+}
+
+// TestResolveInstrumentOnlyReturnsOrderableListings is the "resolve an
+// instrument and venue to an orderable listing" acceptance criterion:
+// ResolveInstrument must filter to Tradable listings, not merely narrow by
+// provider/venue among all registered listings regardless of tradability.
+func TestResolveInstrumentOnlyReturnsOrderableListings(t *testing.T) {
+	inst, err := NewContinuousSeries("ES")
+	require.NoError(t, err)
+	r := NewMemoryResolver()
+
+	nonTradable, err := NewListing(ListingParams{
+		Instrument: inst,
+		Provider:   "Trader Research",
+		Symbol:     "ES-CONT",
+		Spec:       validFXSpec(t),
+		Tradable:   false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, r.Register(nonTradable))
+
+	// The only registered listing for this instrument is non-tradable, so
+	// there is nothing orderable to resolve to.
+	_, err = r.ResolveInstrument(inst.ID(), "", "")
+	require.ErrorIs(t, err, ErrUnknownSymbol)
+
+	// ResolveSymbol makes no orderable promise, so the same listing is
+	// still reachable by its own symbol.
+	got, err := r.ResolveSymbol("Trader Research", "", "ES-CONT")
+	require.NoError(t, err)
+	assert.False(t, got.Tradable())
+}
+
+// TestResolveInstrumentIgnoresNonTradableListingsWhenDisambiguating shows
+// that a non-tradable listing sharing an instrument and venue with a
+// tradable one never contributes to ambiguity: without the Tradable
+// filter, these two registrations would make an unnarrowed-by-provider
+// lookup ambiguous even though only one of them is actually orderable.
+func TestResolveInstrumentIgnoresNonTradableListingsWhenDisambiguating(t *testing.T) {
+	apple, err := NewEquity("NASDAQ", "AAPL")
+	require.NoError(t, err)
+	r := NewMemoryResolver()
+
+	tradable, err := NewListing(ListingParams{
+		Instrument: apple,
+		Provider:   "IBKR",
+		Venue:      "NASDAQ",
+		Symbol:     "AAPL",
+		Spec:       validFXSpec(t),
+		Tradable:   true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, r.Register(tradable))
+
+	// Halted at this venue through this second provider -- still a real
+	// registered listing of the same instrument and venue, just not
+	// currently orderable.
+	nonTradable, err := NewListing(ListingParams{
+		Instrument: apple,
+		Provider:   "AnotherBroker",
+		Venue:      "NASDAQ",
+		Symbol:     "AAPL",
+		Spec:       validFXSpec(t),
+		Tradable:   false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, r.Register(nonTradable))
+
+	got, err := r.ResolveInstrument(apple.ID(), "", "NASDAQ")
+	require.NoError(t, err)
+	assert.Equal(t, "IBKR", got.Provider())
 }
 
 func TestRegisterRejectsUnconstructedListing(t *testing.T) {

--- a/instrument/resolver_test.go
+++ b/instrument/resolver_test.go
@@ -1,0 +1,263 @@
+package instrument
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustListing(t *testing.T, inst Instrument, provider, venue, symbol string) Listing {
+	t.Helper()
+	l, err := NewListing(ListingParams{
+		Instrument: inst,
+		Provider:   provider,
+		Venue:      venue,
+		Symbol:     symbol,
+		Spec:       validFXSpec(t),
+		Tradable:   !isNeverTradable(inst.Kind()),
+	})
+	require.NoError(t, err)
+	return l
+}
+
+// TestEurUsdResolvesForTwoProviderSymbolFormats is the acceptance-
+// criterion test: EUR/USD registered under two different providers, each
+// with its own symbol spelling, resolves correctly through both.
+func TestEurUsdResolvesForTwoProviderSymbolFormats(t *testing.T) {
+	eurUsd := mustEurUsd(t)
+	r := NewMemoryResolver()
+
+	oanda := mustListing(t, eurUsd, "OANDA", "", "EUR_USD")
+	require.NoError(t, r.Register(oanda))
+
+	other := mustListing(t, eurUsd, "OtherProvider", "", "EURUSD")
+	require.NoError(t, r.Register(other))
+
+	got1, err := r.ResolveSymbol("OANDA", "", "EUR_USD")
+	require.NoError(t, err)
+	assert.True(t, got1.InstrumentID().Equal(eurUsd.ID()))
+	assert.Equal(t, "EUR_USD", got1.Symbol())
+
+	got2, err := r.ResolveSymbol("OtherProvider", "", "EURUSD")
+	require.NoError(t, err)
+	assert.True(t, got2.InstrumentID().Equal(eurUsd.ID()))
+	assert.Equal(t, "EURUSD", got2.Symbol())
+}
+
+func TestResolveSymbolIsCaseInsensitive(t *testing.T) {
+	eurUsd := mustEurUsd(t)
+	r := NewMemoryResolver()
+	require.NoError(t, r.Register(mustListing(t, eurUsd, "OANDA", "", "EUR_USD")))
+
+	got, err := r.ResolveSymbol("oanda", "", "eur_usd")
+	require.NoError(t, err)
+	assert.Equal(t, "EUR_USD", got.Symbol(), "the returned Listing's own fields are never normalized")
+}
+
+func TestResolveSymbolUnknown(t *testing.T) {
+	r := NewMemoryResolver()
+	_, err := r.ResolveSymbol("OANDA", "", "EUR_USD")
+	require.ErrorIs(t, err, ErrUnknownSymbol)
+}
+
+// TestResolveSymbolAmbiguousAcrossVenues shows that an unconstrained venue
+// query is a wildcard, not a filter for a literal empty Venue: when one
+// provider exposes the same symbol on two different venues, an
+// unconstrained ResolveSymbol call cannot pick one.
+func TestResolveSymbolAmbiguousAcrossVenues(t *testing.T) {
+	apple, err := NewEquity("NASDAQ", "AAPL")
+	require.NoError(t, err)
+	r := NewMemoryResolver()
+
+	require.NoError(t, r.Register(mustListing(t, apple, "IBKR", "NASDAQ", "AAPL")))
+	require.NoError(t, r.Register(mustListing(t, apple, "IBKR", "BATS", "AAPL")))
+
+	_, err = r.ResolveSymbol("IBKR", "", "AAPL")
+	require.ErrorIs(t, err, ErrAmbiguousSymbol)
+
+	got, err := r.ResolveSymbol("IBKR", "NASDAQ", "AAPL")
+	require.NoError(t, err)
+	assert.Equal(t, "NASDAQ", got.Venue())
+}
+
+// TestEmptyVenueQueryIsWildcardNotLiteralMatch confirms that a Listing
+// legitimately registered with an empty Venue (spot FX) is still found by
+// an unconstrained ("") venue query when it is the only match — "" is a
+// wildcard on the query side, not a request to match only literal empty
+// Venue values.
+func TestEmptyVenueQueryIsWildcardNotLiteralMatch(t *testing.T) {
+	eurUsd := mustEurUsd(t)
+	r := NewMemoryResolver()
+	require.NoError(t, r.Register(mustListing(t, eurUsd, "OANDA", "", "EUR_USD")))
+
+	got, err := r.ResolveSymbol("OANDA", "", "EUR_USD")
+	require.NoError(t, err)
+	assert.Equal(t, "", got.Venue())
+}
+
+func TestResolveInstrumentUnknown(t *testing.T) {
+	eurUsd := mustEurUsd(t)
+	r := NewMemoryResolver()
+	_, err := r.ResolveInstrument(eurUsd.ID(), "", "")
+	require.ErrorIs(t, err, ErrUnknownSymbol)
+}
+
+func TestResolveInstrumentAmbiguousThenNarrowed(t *testing.T) {
+	apple, err := NewEquity("NASDAQ", "AAPL")
+	require.NoError(t, err)
+	r := NewMemoryResolver()
+
+	require.NoError(t, r.Register(mustListing(t, apple, "IBKR", "NASDAQ", "AAPL")))
+	require.NoError(t, r.Register(mustListing(t, apple, "AnotherBroker", "NASDAQ", "AAPL.US")))
+
+	_, err = r.ResolveInstrument(apple.ID(), "", "")
+	require.ErrorIs(t, err, ErrAmbiguousSymbol)
+
+	got, err := r.ResolveInstrument(apple.ID(), "IBKR", "")
+	require.NoError(t, err)
+	assert.Equal(t, "AAPL", got.Symbol())
+
+	got, err = r.ResolveInstrument(apple.ID(), "", "NASDAQ")
+	require.Error(t, err) // still ambiguous: both are on NASDAQ
+	require.ErrorIs(t, err, ErrAmbiguousSymbol)
+
+	got, err = r.ResolveInstrument(apple.ID(), "AnotherBroker", "NASDAQ")
+	require.NoError(t, err)
+	assert.Equal(t, "AAPL.US", got.Symbol())
+}
+
+func TestRegisterRejectsUnconstructedListing(t *testing.T) {
+	r := NewMemoryResolver()
+	err := r.Register(Listing{})
+	require.ErrorIs(t, err, ErrInvalidListing)
+}
+
+func TestRegisterRejectsExactDuplicate(t *testing.T) {
+	eurUsd := mustEurUsd(t)
+	r := NewMemoryResolver()
+	require.NoError(t, r.Register(mustListing(t, eurUsd, "OANDA", "", "EUR_USD")))
+
+	err := r.Register(mustListing(t, eurUsd, "OANDA", "", "EUR_USD"))
+	require.ErrorIs(t, err, ErrDuplicateListing)
+}
+
+func TestRegisterAllowsSameProviderSymbolOnDifferentVenues(t *testing.T) {
+	apple, err := NewEquity("NASDAQ", "AAPL")
+	require.NoError(t, err)
+	r := NewMemoryResolver()
+
+	require.NoError(t, r.Register(mustListing(t, apple, "IBKR", "NASDAQ", "AAPL")))
+	require.NoError(t, r.Register(mustListing(t, apple, "IBKR", "BATS", "AAPL")))
+}
+
+// TestRegisterAliasResolvesToUnchangedCanonicalListing is the "aliases do
+// not become canonical identity" acceptance criterion: resolving through
+// an alias returns the exact canonical Listing value, with its own
+// Provider/Venue/Symbol intact, not anything derived from the alias.
+func TestRegisterAliasResolvesToUnchangedCanonicalListing(t *testing.T) {
+	eurUsd := mustEurUsd(t)
+	r := NewMemoryResolver()
+	canonical := mustListing(t, eurUsd, "OANDA", "", "EUR_USD")
+	require.NoError(t, r.Register(canonical))
+
+	require.NoError(t, r.RegisterAlias("OANDA", "", "EURUSD", "OANDA", "", "EUR_USD"))
+
+	got, err := r.ResolveSymbol("OANDA", "", "EURUSD")
+	require.NoError(t, err)
+	assert.Equal(t, canonical, got)
+	assert.Equal(t, "EUR_USD", got.Symbol(), "an alias never changes the resolved Listing's own symbol")
+}
+
+func TestRegisterAliasRejectsUnknownCanonical(t *testing.T) {
+	r := NewMemoryResolver()
+	err := r.RegisterAlias("OANDA", "", "EURUSD", "OANDA", "", "EUR_USD")
+	require.ErrorIs(t, err, ErrUnknownSymbol)
+}
+
+func TestRegisterAliasRejectsAmbiguousCanonical(t *testing.T) {
+	apple, err := NewEquity("NASDAQ", "AAPL")
+	require.NoError(t, err)
+	r := NewMemoryResolver()
+	require.NoError(t, r.Register(mustListing(t, apple, "IBKR", "NASDAQ", "AAPL")))
+	require.NoError(t, r.Register(mustListing(t, apple, "IBKR", "BATS", "AAPL")))
+
+	err = r.RegisterAlias("IBKR", "", "APPL", "IBKR", "", "AAPL")
+	require.ErrorIs(t, err, ErrAmbiguousSymbol)
+}
+
+func TestRegisterAliasRejectsDuplicateAliasKey(t *testing.T) {
+	eurUsd := mustEurUsd(t)
+	r := NewMemoryResolver()
+	require.NoError(t, r.Register(mustListing(t, eurUsd, "OANDA", "", "EUR_USD")))
+	require.NoError(t, r.Register(mustListing(t, eurUsd, "OANDA", "", "EURUSD")))
+
+	err := r.RegisterAlias("OANDA", "", "EURUSD", "OANDA", "", "EUR_USD")
+	require.ErrorIs(t, err, ErrDuplicateListing)
+}
+
+// TestAliasNeverDuplicatesTheInstrumentIndex confirms that registering an
+// alias for an already-registered Listing does not make ResolveInstrument
+// see two listings where there is only one.
+func TestAliasNeverDuplicatesTheInstrumentIndex(t *testing.T) {
+	eurUsd := mustEurUsd(t)
+	r := NewMemoryResolver()
+	require.NoError(t, r.Register(mustListing(t, eurUsd, "OANDA", "", "EUR_USD")))
+	require.NoError(t, r.RegisterAlias("OANDA", "", "EURUSD", "OANDA", "", "EUR_USD"))
+
+	got, err := r.ResolveInstrument(eurUsd.ID(), "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "EUR_USD", got.Symbol())
+}
+
+func TestMultipleResolverInstancesAreIndependent(t *testing.T) {
+	eurUsd := mustEurUsd(t)
+	r1 := NewMemoryResolver()
+	r2 := NewMemoryResolver()
+
+	require.NoError(t, r1.Register(mustListing(t, eurUsd, "OANDA", "", "EUR_USD")))
+
+	_, err := r1.ResolveSymbol("OANDA", "", "EUR_USD")
+	require.NoError(t, err)
+
+	_, err = r2.ResolveSymbol("OANDA", "", "EUR_USD")
+	require.ErrorIs(t, err, ErrUnknownSymbol, "r2 must not see r1's registrations")
+}
+
+// TestConcurrentRegisterAndResolve exercises Register and ResolveSymbol
+// from many goroutines at once; it is meaningful under -race.
+func TestConcurrentRegisterAndResolve(t *testing.T) {
+	r := NewMemoryResolver()
+	const n = 50
+
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			base := num.MustParseCurrency("EUR")
+			quote := num.MustParseCurrency("USD")
+			inst, err := NewCurrencyPair(base, quote)
+			require.NoError(t, err)
+
+			l, err := NewListing(ListingParams{
+				Instrument: inst,
+				Provider:   "OANDA",
+				Symbol:     "EUR_USD",
+				Spec:       validFXSpec(t),
+				Tradable:   true,
+			})
+			require.NoError(t, err)
+
+			_ = r.Register(l) // exactly one goroutine's Register succeeds; races are the point under -race
+			_, _ = r.ResolveSymbol("OANDA", "", "EUR_USD")
+		}(i)
+	}
+	wg.Wait()
+
+	got, err := r.ResolveSymbol("OANDA", "", "EUR_USD")
+	require.NoError(t, err)
+	assert.Equal(t, "EUR_USD", got.Symbol())
+}


### PR DESCRIPTION
## Summary

Implements #26 (M1-08 Implement symbol and listing resolution) and adds ADR-016.

- `Resolver` — small, read-only interface: `ResolveSymbol(provider, venue, symbol string) (Listing, error)` and `ResolveInstrument(instrumentID ID, provider, venue string) (Listing, error)`. Both share one internal zero/one/many outcome (`exactlyOne`): zero matches → `ErrUnknownSymbol`, exactly one → returned, more than one → `ErrAmbiguousSymbol`. An empty `provider`/`venue`/`symbol` means "unconstrained on this axis," documented and tested as distinct from a literal empty `Venue()` (spot FX).
- `MemoryResolver` — in-memory reference implementation. Plain value from `NewMemoryResolver()`, no package-level state, `sync.RWMutex`-protected for concurrent use. `Register` indexes a `Listing` under its own provider/venue/symbol and its `InstrumentID`; `RegisterAlias` adds an additional lookup key resolving to an already-registered canonical `Listing` — resolved through the same zero/one/many logic, so an ambiguous alias target is caught at registration time, not silently.

**Design note**: the initial plan posted to #26 assumed `(provider, symbol)` was a sufficiently unique lookup key, with ambiguity only possible on the instrument→listing direction. Caught during design review on the issue: a provider isn't guaranteed to expose a symbol on only one venue, so `ResolveSymbol` needed a `venue` parameter too, with the same symmetric failure semantics as `ResolveInstrument`. See the issue thread for the full discussion.

## Test plan

- [x] `make check` passes
- [x] `instrument` package coverage 98.0%, `resolver.go` itself 100%
- [x] EUR/USD resolves via two different provider symbol formats (acceptance criterion)
- [x] Alias resolves to the unchanged canonical `Listing` — never becomes identity (acceptance criterion)
- [x] Unknown vs. ambiguous are distinct errors on both resolution directions (acceptance criterion)
- [x] Multiple `MemoryResolver` instances are independent (acceptance criterion)
- [x] `-race`-covered concurrent register/resolve test
- [x] `Example_resolver` / `Example_resolverAmbiguous` in `example_test.go` (registration + resolution examples, acceptance criterion)

## Documentation

- `instrument/doc.go` — new "Resolving provider symbols without treating them as identity" section
- ADR-016 added to `docs/arch/adr-decisions.org`, referencing ADR-003's original deferral
- `README.md` — resolver usage under the existing `### instrument` section

Closes #26.