### PR TITLE
M1-09: intervals and FX trading-calendar vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,35 @@ reports `ErrAmbiguousSymbol` rather than picking one; no match reports
 [package doc comment](instrument/doc.go) for the full resolution
 semantics.
 
+### marketdata
+
+`marketdata` defines Trader's bar-interval and trading-calendar vocabulary
+— not yet acquisition, storage, or resampling, which land in a later
+milestone. `Interval` is built from a typed unit and count, never parsed
+from a provider string, with five predefined values:
+
+```go
+marketdata.M1, marketdata.H1, marketdata.H4, marketdata.D1, marketdata.W1
+```
+
+`Calendar` aligns a `time.Time` to sessions and bar boundaries; minute and
+hour bars align to the UTC clock, but day and week bars do not, since a
+trading day is not a UTC calendar day. `FXCalendar` is the one
+implementation so far, covering spot FX's continuous weekly session —
+open Sunday 17:00 New York time, closed Friday 17:00 through Sunday
+17:00 — with `time.Date`-based arithmetic in the `America/New_York`
+location so daylight-saving transitions resolve correctly:
+
+```go
+c := marketdata.NewFXCalendar(marketdata.FXCalendarParams{})
+bar, err := c.Bar(someTime, marketdata.D1)
+// bar.Start() and bar.End() are the 17:00 New York rollovers bracketing someTime
+```
+
+See [ADR-012](docs/arch/adr-decisions.org) and the
+[package doc comment](marketdata/doc.go) for the full half-open range
+convention, DST handling, and why day/week bars use a `Calendar` seam.
+
 ## Documentation
 
 - [Framework requirements](docs/arch/trader-framework-requirements.org)

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -603,8 +603,8 @@ decision ships, covering spot FX's continuous weekly session: open Sunday
 time on every other day.  =D1= bars align to that daily rollover; =W1=
 bars align to the Sunday 17:00 week open.  Minute and hour bars instead
 align to the UTC clock, via truncation since the Go zero time — which
-falls at 2:00 UTC, itself hour-of-day zero — so =H4= bars land on
-00:00/04:00/.../20:00 UTC regardless of date.  =FXCalendar= only aligns
+falls at 00:00:00 UTC — so =H4= bars land on 00:00/04:00/.../20:00 UTC
+regardless of date.  =FXCalendar= only aligns
 single-day and single-week bars; multi-day/multi-week counts report an
 error rather than inventing an untested grouping convention, since
 grouping is a resampling concern this issue explicitly excludes.
@@ -619,12 +619,15 @@ deliberate binary-size tradeoff (roughly 450 KB) made in favor of
 deterministic backtests, not an incidental one.
 
 Holidays are representable via an optional =FXCalendarParams.Holidays=
-list of civil dates (matched in New York local time, independent of the
-time-of-day or location the caller happened to supply): a holiday date
-reports =StatusHoliday= for its entire span and no =Session=.  No real
-holiday data ships with this decision — populating an actual holiday
-calendar is a data-acquisition concern, deferred along with the rest of
-M2.
+list: each entry's Year/Month/Day fields, read literally regardless of
+its own time-of-day or Location, name a New York civil date.  A holiday
+closes the entire rollover-to-rollover trading session that ends on that
+date — the same session grouping =Session= uses — not just that
+calendar day's own clock hours, so =Status= and =Session= always agree:
+every instant a returned =Session= contains reports =StatusOpen=.  No
+real holiday data ships with this decision — populating an actual
+holiday calendar is a data-acquisition concern, deferred along with the
+rest of M2.
 
 ** Consequences
 

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -78,7 +78,7 @@ believed at that time.
 | 009 | Journal and reconciliation model                                  | Proposed   |
 | 010 | gRPC primary external strategy protocol; MQTT integration         | Proposed   |
 | 011 | Public API and semantic-versioning policy                         | Proposed   |
-| 012 | Trading calendar and bar-alignment semantics                      | Proposed   |
+| 012 | Trading calendar and bar-alignment semantics                      | Accepted   |
 | 013 | Greenfield repository with controlled legacy transplant           | Accepted   |
 | 014 | Paper trading is the safe default                                 | Accepted   |
 | 016 | Symbol and listing resolution                                     | Accepted   |
@@ -559,33 +559,104 @@ rules will be ratified by a later ADR.
 
 ** Status
 
-Proposed
+Accepted
 
 ** Context
 
 Daily, weekly, and monthly bars must align to trading sessions or named
 calendars, not solely to elapsed seconds.  Trader must eventually support
 exchange sessions, holidays, early closes, futures session boundaries,
-and FX week boundaries.  The concrete calendar model, session
-identifiers, and resampling rules are not yet finalized.
+and FX week boundaries.  Issue #27 (M1-09) required settling the initial
+=Interval= and calendar vocabulary: how a bar interval is represented
+without core string parsing, how daily/weekly bars align to something
+other than UTC midnight, how DST transitions are handled, and how closed
+markets, holidays, and incomplete bars are made representable — scoped to
+a basic FX calendar, with non-FX session calendars, resampling, and
+coverage tracking explicitly deferred to M2.
 
 ** Decision
 
-Represent bar intervals with a unit, count, and calendar/alignment as
-sketched in the architecture document.  The precise calendar
-representation, session identifiers, and resampling contract will be
-ratified by a later ADR.
+=marketdata.Interval= is a typed =Unit= (=UnitMinute=, =UnitHour=,
+=UnitDay=, =UnitWeek=) plus a count, constructed via =NewInterval= or one
+of five predefined values (=M1=, =H1=, =H4=, =D1=, =W1=).  Intervals are
+never parsed from provider-native strings such as ="H4"= in core code;
+=Interval.String= exists only for display and is documented as
+one-directional.
+
+=marketdata.TimeRange= is the shared half-open range type, =[start,
+end)=, used for sessions and bars alike.  =Contains= includes =start= and
+excludes =end=; =Elapsed(now)= reports whether a range has finished,
+expressing bar completeness without a separate concept.
+
+=marketdata.Calendar= is a small interface — =Status=, =Session=, =Bar= —
+kept as an interface rather than a single concrete type because the
+architecture document's "Important Missing Requirements" section already
+commits M2+ to exchange, futures, and holiday calendars distinct from FX;
+a second implementation is a documented near-term certainty, not a
+speculative one.  Every =Calendar= method is a pure function of its
+=time.Time= argument; no implementation may call =time.Now=.
+
+=marketdata.FXCalendar= is the one =Calendar= implementation this
+decision ships, covering spot FX's continuous weekly session: open Sunday
+17:00 and closed Friday 17:00 through Sunday 17:00, both in
+=America/New_York= civil time, with a daily rollover at 17:00 New York
+time on every other day.  =D1= bars align to that daily rollover; =W1=
+bars align to the Sunday 17:00 week open.  Minute and hour bars instead
+align to the UTC clock, via truncation since the Go zero time — which
+falls at 2:00 UTC, itself hour-of-day zero — so =H4= bars land on
+00:00/04:00/.../20:00 UTC regardless of date.  =FXCalendar= only aligns
+single-day and single-week bars; multi-day/multi-week counts report an
+error rather than inventing an untested grouping convention, since
+grouping is a resampling concern this issue explicitly excludes.
+
+DST correctness comes directly from computing rollover instants with
+=time.Date= in the =America/New_York= =*time.Location=, which resolves
+the correct UTC offset for whichever regime applies on that date — no
+manual offset arithmetic.  =FXCalendar= blank-imports =time/tzdata= to
+embed the IANA database in the binary, so DST transitions resolve
+identically regardless of the host's installed time zone data; this is a
+deliberate binary-size tradeoff (roughly 450 KB) made in favor of
+deterministic backtests, not an incidental one.
+
+Holidays are representable via an optional =FXCalendarParams.Holidays=
+list of civil dates (matched in New York local time, independent of the
+time-of-day or location the caller happened to supply): a holiday date
+reports =StatusHoliday= for its entire span and no =Session=.  No real
+holiday data ships with this decision — populating an actual holiday
+calendar is a data-acquisition concern, deferred along with the rest of
+M2.
 
 ** Consequences
 
 - Bar alignment can be validated against provider-native session bars.
 - Session-aware calendars will be required before non-FX asset classes
-  are supported end-to-end.
+  are supported end-to-end; =Calendar= is already shaped to add them
+  without disturbing =FXCalendar= or its callers.
+- DST transition weeks and days have wall-clock durations other than
+  exactly 24h or 7×24h, and callers relying on =TimeRange.Duration= must
+  account for that rather than assuming a fixed bar length.
+- Multi-day and multi-week bars are not yet representable through
+  =FXCalendar=; a caller needing them must wait for the resampling work
+  in M2 rather than assuming =Bar= silently groups sessions.
 
 ** Alternatives Considered
 
 - *=time.Duration= alone as an interval.* Rejected because it cannot
   represent session-aligned daily, weekly, or monthly bars correctly.
+- *A single concrete =FXCalendar= type with no =Calendar= interface.*
+  Rejected because the architecture document already commits to a second
+  (exchange/holiday) implementation in M2, and package-boundaries.org's
+  guidance against interfaces with exactly one implementation applies
+  only when a second implementation is speculative, not documented and
+  imminent.
+- *Deriving DST behavior from a fixed UTC offset table maintained inside
+  =marketdata=.* Rejected in favor of the standard library's =time.Date=
+  plus =*time.Location= arithmetic, which is already correct and does not
+  require Trader to track its own transition rules.
+- *Grouping multi-day/multi-week bars via a simple day-count modulus
+  anchored at the Unix epoch.* Rejected as an untested, arbitrary
+  convention with no real consumer yet; reporting an error keeps the
+  decision honest about what is actually implemented.
 
 * ADR-013: Greenfield repository with controlled legacy transplant
 

--- a/marketdata/calendar.go
+++ b/marketdata/calendar.go
@@ -9,8 +9,14 @@ import (
 type Status uint8
 
 const (
+	// StatusUnknown is Status's zero value: no Calendar implementation
+	// returns it. Reserving zero for an invalid/unset state means an
+	// uninitialized Status can never be silently mistaken for
+	// StatusOpen, the least conservative possible default for trading
+	// code.
+	StatusUnknown Status = iota
 	// StatusOpen means the market is trading at the queried time.
-	StatusOpen Status = iota
+	StatusOpen
 	// StatusClosed means the market is not trading (a weekend or a
 	// non-session hour), but the closure is routine rather than a
 	// named holiday.
@@ -23,6 +29,8 @@ const (
 // String returns a human-readable Status name.
 func (s Status) String() string {
 	switch s {
+	case StatusUnknown:
+		return "unknown"
 	case StatusOpen:
 		return "open"
 	case StatusClosed:

--- a/marketdata/calendar.go
+++ b/marketdata/calendar.go
@@ -1,0 +1,60 @@
+package marketdata
+
+import (
+	"fmt"
+	"time"
+)
+
+// Status is a market's trading status at a point in time.
+type Status uint8
+
+const (
+	// StatusOpen means the market is trading at the queried time.
+	StatusOpen Status = iota
+	// StatusClosed means the market is not trading (a weekend or a
+	// non-session hour), but the closure is routine rather than a
+	// named holiday.
+	StatusClosed
+	// StatusHoliday means the market is not trading because the
+	// queried time falls on a calendar holiday.
+	StatusHoliday
+)
+
+// String returns a human-readable Status name.
+func (s Status) String() string {
+	switch s {
+	case StatusOpen:
+		return "open"
+	case StatusClosed:
+		return "closed"
+	case StatusHoliday:
+		return "holiday"
+	default:
+		return fmt.Sprintf("Status(%d)", uint8(s))
+	}
+}
+
+// Calendar aligns points in time to trading sessions and bar boundaries.
+// It is a seam because Trader is expected to need more than one
+// implementation: the initial FXCalendar covers spot FX's continuous
+// weekly session, and exchange-traded asset classes will eventually need
+// session, holiday, and early-close calendars of their own.
+//
+// Every method is a pure function of its time.Time argument. A Calendar
+// implementation must not call time.Now internally; callers supply
+// whatever time they want evaluated, keeping backtests deterministic.
+type Calendar interface {
+	// Status reports whether the market is open, routinely closed, or
+	// on a holiday at t.
+	Status(t time.Time) Status
+
+	// Session returns the half-open trading session containing t. ok is
+	// false when Status(t) is not StatusOpen.
+	Session(t time.Time) (session TimeRange, ok bool)
+
+	// Bar returns the half-open TimeRange for interval that contains t.
+	// Minute and hour intervals align to the UTC clock. Day and week
+	// intervals align to this Calendar's session and week boundaries
+	// rather than UTC midnight.
+	Bar(t time.Time, interval Interval) (TimeRange, error)
+}

--- a/marketdata/calendar_test.go
+++ b/marketdata/calendar_test.go
@@ -1,0 +1,14 @@
+package marketdata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusString(t *testing.T) {
+	assert.Equal(t, "open", StatusOpen.String())
+	assert.Equal(t, "closed", StatusClosed.String())
+	assert.Equal(t, "holiday", StatusHoliday.String())
+	assert.Contains(t, Status(200).String(), "200")
+}

--- a/marketdata/calendar_test.go
+++ b/marketdata/calendar_test.go
@@ -7,8 +7,15 @@ import (
 )
 
 func TestStatusString(t *testing.T) {
+	assert.Equal(t, "unknown", StatusUnknown.String())
 	assert.Equal(t, "open", StatusOpen.String())
 	assert.Equal(t, "closed", StatusClosed.String())
 	assert.Equal(t, "holiday", StatusHoliday.String())
 	assert.Contains(t, Status(200).String(), "200")
+}
+
+func TestStatusZeroValueIsUnknownNotOpen(t *testing.T) {
+	var s Status
+	assert.Equal(t, StatusUnknown, s)
+	assert.NotEqual(t, StatusOpen, s)
 }

--- a/marketdata/doc.go
+++ b/marketdata/doc.go
@@ -1,0 +1,44 @@
+// Package marketdata defines Trader's bar-interval and trading-calendar
+// vocabulary, as decided by issue #27 (M1-09) and ADR-012. It does not yet
+// acquire, normalize, store, or resample market data — see the
+// architecture document for that larger scope, which lands in M2.
+//
+// # Half-open ranges
+//
+// TimeRange represents every time span in this package as [start, end):
+// start is included, end is excluded. A bar that ends at 17:00 and the
+// bar that starts at 17:00 therefore never both claim that instant.
+//
+// # Intervals are typed, not parsed
+//
+// Interval is built from a typed Unit and a count — never from a
+// provider-native string such as "H4" — so core code cannot misinterpret
+// a malformed interval spelling. M1, H1, H4, D1, and W1 are provided as
+// predefined values; Interval's String method exists only for display and
+// is never parsed back.
+//
+// # Calendars align bars to sessions, not just the clock
+//
+// Minute and hour bars align to the UTC clock. Day and week bars do not:
+// a trading day is not a UTC calendar day, and Calendar exists to make
+// that alignment explicit and testable rather than assumed. FXCalendar is
+// the one implementation this package provides, covering spot FX's
+// continuous weekly session — open Sunday 17:00 New York time, closed
+// Friday 17:00 through Sunday 17:00, with a daily rollover at 17:00 New
+// York time on every other day. Exchange-traded asset classes will need
+// their own Calendar implementations (holidays, early closes, futures
+// session boundaries) in later milestones; Calendar is an interface for
+// exactly that reason.
+//
+// FXCalendar blank-imports time/tzdata so its New York DST transitions
+// resolve identically regardless of the host's installed time zone
+// database — a deliberate binary-size tradeoff in favor of deterministic
+// backtests.
+//
+// # No time.Now
+//
+// Every method in this package is a pure function of an explicit
+// time.Time argument. Nothing here calls time.Now; callers supply
+// whatever time they want evaluated, including from a clock.Clock at a
+// composition root.
+package marketdata

--- a/marketdata/example_test.go
+++ b/marketdata/example_test.go
@@ -1,0 +1,56 @@
+package marketdata_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/marketdata"
+)
+
+// Example_interval shows the predefined intervals and their display form.
+// String is for display only — never parsed back into an Interval.
+func Example_interval() {
+	fmt.Println(marketdata.M1, marketdata.H1, marketdata.H4, marketdata.D1, marketdata.W1)
+	// Output:
+	// M1 H1 H4 D1 W1
+}
+
+// ExampleFXCalendar_Bar shows that a daily bar aligns to FX's 17:00 New
+// York rollover, not to UTC midnight.
+func ExampleFXCalendar_Bar() {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		panic(err)
+	}
+	c := marketdata.NewFXCalendar(marketdata.FXCalendarParams{})
+
+	wednesdayMorning := time.Date(2026, time.January, 7, 9, 0, 0, 0, loc)
+	bar, err := c.Bar(wednesdayMorning, marketdata.D1)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(bar.Start().In(loc))
+	fmt.Println(bar.End().In(loc))
+	// Output:
+	// 2026-01-06 17:00:00 -0500 EST
+	// 2026-01-07 17:00:00 -0500 EST
+}
+
+// ExampleFXCalendar_Session shows that Session reports ok=false outside
+// the FX trading week.
+func ExampleFXCalendar_Session() {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		panic(err)
+	}
+	c := marketdata.NewFXCalendar(marketdata.FXCalendarParams{})
+
+	saturday := time.Date(2026, time.January, 3, 12, 0, 0, 0, loc)
+	fmt.Println(c.Status(saturday))
+	_, ok := c.Session(saturday)
+	fmt.Println(ok)
+	// Output:
+	// closed
+	// false
+}

--- a/marketdata/fxcalendar.go
+++ b/marketdata/fxcalendar.go
@@ -49,9 +49,13 @@ type dateKey struct {
 
 // FXCalendarParams configures a new FXCalendar.
 type FXCalendarParams struct {
-	// Holidays lists dates, in New York civil time, on which the
-	// market is closed all day. Only the date portion is used; any
-	// time-of-day and any other location are ignored.
+	// Holidays names New York civil dates on which the market is closed
+	// for the entire rollover-to-rollover trading session that ends on
+	// that date (see Session): the Year/Month/Day fields of each entry
+	// are taken literally, regardless of its Location or time-of-day —
+	// construct entries with time.Date(y, m, d, 0, 0, 0, 0, loc) using
+	// whatever Location is convenient, since only the calendar fields
+	// are read.
 	Holidays []time.Time
 }
 
@@ -59,19 +63,20 @@ type FXCalendarParams struct {
 func NewFXCalendar(params FXCalendarParams) *FXCalendar {
 	holidays := make(map[dateKey]struct{}, len(params.Holidays))
 	for _, h := range params.Holidays {
-		holidays[dateKeyOf(h)] = struct{}{}
+		holidays[literalDateKey(h)] = struct{}{}
 	}
 	return &FXCalendar{holidays: holidays}
 }
 
 var _ Calendar = (*FXCalendar)(nil)
 
-// Status implements Calendar.
+// Status implements Calendar. Status and Session agree with each other:
+// both group time by the same rollover-to-rollover trading session
+// (dayStart to dayStart+1day), labeled by the New York civil date on
+// which that session closes, so every instant a returned Session
+// contains reports the same Status.
 func (c *FXCalendar) Status(t time.Time) Status {
 	nyT := t.In(newYorkLocation)
-	if _, holiday := c.holidays[dateKeyOf(nyT)]; holiday {
-		return StatusHoliday
-	}
 	switch nyT.Weekday() {
 	case time.Saturday:
 		return StatusClosed
@@ -83,6 +88,10 @@ func (c *FXCalendar) Status(t time.Time) Status {
 		if nyT.Before(rolloverOn(nyT)) {
 			return StatusClosed
 		}
+	}
+	sessionEnd := c.dayStart(t).AddDate(0, 0, 1)
+	if _, holiday := c.holidays[dateKeyOf(sessionEnd)]; holiday {
+		return StatusHoliday
 	}
 	return StatusOpen
 }
@@ -153,9 +162,20 @@ func rolloverOn(nyT time.Time) time.Time {
 	return time.Date(nyT.Year(), nyT.Month(), nyT.Day(), fxRolloverHour, 0, 0, 0, newYorkLocation)
 }
 
+// dateKeyOf returns t's New York civil date, converting t to
+// newYorkLocation first. Used for query times, which may be expressed in
+// any location.
 func dateKeyOf(t time.Time) dateKey {
 	nyT := t.In(newYorkLocation)
 	y, m, d := nyT.Date()
+	return dateKey{year: y, month: m, day: d}
+}
+
+// literalDateKey returns h's Year/Month/Day fields as given, with no
+// Location conversion. Used for FXCalendarParams.Holidays entries, whose
+// calendar fields are documented as the literal holiday date.
+func literalDateKey(h time.Time) dateKey {
+	y, m, d := h.Date()
 	return dateKey{year: y, month: m, day: d}
 }
 

--- a/marketdata/fxcalendar.go
+++ b/marketdata/fxcalendar.go
@@ -180,10 +180,11 @@ func literalDateKey(h time.Time) dateKey {
 }
 
 // utcBar truncates t to the most recent multiple of duration since the
-// Go zero time, which — because the zero time falls at 00:00:00 UTC and
-// every calendar day divides evenly into duration for the minute/hour
-// counts Interval permits — aligns bars to the UTC clock (00:00, 04:00,
-// ... for four-hour bars, for example).
+// Go zero time. The zero time falls at 00:00:00 UTC, so this always
+// aligns to the UTC clock rather than to an arbitrary epoch. For
+// durations that evenly divide 24 hours — as every predefined Interval
+// here does — the resulting boundaries repeat at the same clock time
+// every day (00:00, 04:00, ... for four-hour bars, for example).
 func utcBar(t time.Time, duration time.Duration) (TimeRange, error) {
 	start := t.UTC().Truncate(duration)
 	return NewTimeRange(start, start.Add(duration))

--- a/marketdata/fxcalendar.go
+++ b/marketdata/fxcalendar.go
@@ -1,0 +1,170 @@
+package marketdata
+
+import (
+	"fmt"
+	"time"
+
+	// tzdata embeds the IANA time zone database in the binary so
+	// America/New_York (and its DST transition rules) resolve
+	// identically regardless of the host's installed tzdata, keeping
+	// FXCalendar's DST-dependent boundaries deterministic.
+	_ "time/tzdata"
+)
+
+// newYorkLocation is loaded once at package init from the embedded
+// tzdata database. Loading it can only fail if the embedded database
+// itself is corrupt, which would indicate a broken Go toolchain rather
+// than a recoverable runtime condition.
+var newYorkLocation = func() *time.Location {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		panic(fmt.Sprintf("marketdata: failed to load America/New_York: %v", err))
+	}
+	return loc
+}()
+
+// fxRolloverHour is the local New York clock hour at which the FX
+// trading day and week roll over: 17:00 (5pm), unaffected by whether
+// New York is currently observing daylight saving time — time.Date
+// resolves 17:00 to the correct UTC instant for whichever offset
+// applies on that date.
+const fxRolloverHour = 17
+
+// FXCalendar is a Calendar for spot FX's continuous weekly session: open
+// Sunday 17:00 New York time, closed Friday 17:00 through Sunday 17:00,
+// with a daily rollover at 17:00 New York time every other day of the
+// week. It supports an optional fixed holiday list; no holiday data
+// ships with Trader itself.
+type FXCalendar struct {
+	holidays map[dateKey]struct{}
+}
+
+// dateKey identifies a civil date in New York's calendar, independent of
+// time-of-day, for holiday matching.
+type dateKey struct {
+	year  int
+	month time.Month
+	day   int
+}
+
+// FXCalendarParams configures a new FXCalendar.
+type FXCalendarParams struct {
+	// Holidays lists dates, in New York civil time, on which the
+	// market is closed all day. Only the date portion is used; any
+	// time-of-day and any other location are ignored.
+	Holidays []time.Time
+}
+
+// NewFXCalendar returns an FXCalendar configured with params.
+func NewFXCalendar(params FXCalendarParams) *FXCalendar {
+	holidays := make(map[dateKey]struct{}, len(params.Holidays))
+	for _, h := range params.Holidays {
+		holidays[dateKeyOf(h)] = struct{}{}
+	}
+	return &FXCalendar{holidays: holidays}
+}
+
+var _ Calendar = (*FXCalendar)(nil)
+
+// Status implements Calendar.
+func (c *FXCalendar) Status(t time.Time) Status {
+	nyT := t.In(newYorkLocation)
+	if _, holiday := c.holidays[dateKeyOf(nyT)]; holiday {
+		return StatusHoliday
+	}
+	switch nyT.Weekday() {
+	case time.Saturday:
+		return StatusClosed
+	case time.Friday:
+		if !nyT.Before(rolloverOn(nyT)) {
+			return StatusClosed
+		}
+	case time.Sunday:
+		if nyT.Before(rolloverOn(nyT)) {
+			return StatusClosed
+		}
+	}
+	return StatusOpen
+}
+
+// Session implements Calendar.
+func (c *FXCalendar) Session(t time.Time) (TimeRange, bool) {
+	if c.Status(t) != StatusOpen {
+		return TimeRange{}, false
+	}
+	start := c.dayStart(t)
+	r, err := NewTimeRange(start, start.AddDate(0, 0, 1))
+	if err != nil {
+		// start.AddDate(0, 0, 1) is always strictly after start.
+		panic(fmt.Sprintf("marketdata: unreachable: %v", err))
+	}
+	return r, true
+}
+
+// Bar implements Calendar.
+func (c *FXCalendar) Bar(t time.Time, interval Interval) (TimeRange, error) {
+	switch interval.Unit() {
+	case UnitMinute:
+		return utcBar(t, time.Duration(interval.Count())*time.Minute)
+	case UnitHour:
+		return utcBar(t, time.Duration(interval.Count())*time.Hour)
+	case UnitDay:
+		if interval.Count() != 1 {
+			return TimeRange{}, fmt.Errorf("marketdata: FXCalendar only aligns single-day bars, got count %d", interval.Count())
+		}
+		start := c.dayStart(t)
+		return NewTimeRange(start, start.AddDate(0, 0, 1))
+	case UnitWeek:
+		if interval.Count() != 1 {
+			return TimeRange{}, fmt.Errorf("marketdata: FXCalendar only aligns single-week bars, got count %d", interval.Count())
+		}
+		start := c.weekStart(t)
+		return NewTimeRange(start, start.AddDate(0, 0, 7))
+	default:
+		return TimeRange{}, fmt.Errorf("marketdata: invalid interval unit %v", interval.Unit())
+	}
+}
+
+// dayStart returns the most recent 17:00 New York rollover at or before
+// t: the start of the trading day containing t, independent of whether
+// that day is open, closed, or a holiday.
+func (c *FXCalendar) dayStart(t time.Time) time.Time {
+	nyT := t.In(newYorkLocation)
+	rollover := rolloverOn(nyT)
+	if nyT.Before(rollover) {
+		rollover = rollover.AddDate(0, 0, -1)
+	}
+	return rollover
+}
+
+// weekStart returns the Sunday 17:00 New York rollover that opens the
+// trading week containing t.
+func (c *FXCalendar) weekStart(t time.Time) time.Time {
+	d := c.dayStart(t)
+	for d.Weekday() != time.Sunday {
+		d = d.AddDate(0, 0, -1)
+	}
+	return d
+}
+
+// rolloverOn returns the 17:00 New York instant on nyT's own calendar
+// date. nyT must already be in newYorkLocation.
+func rolloverOn(nyT time.Time) time.Time {
+	return time.Date(nyT.Year(), nyT.Month(), nyT.Day(), fxRolloverHour, 0, 0, 0, newYorkLocation)
+}
+
+func dateKeyOf(t time.Time) dateKey {
+	nyT := t.In(newYorkLocation)
+	y, m, d := nyT.Date()
+	return dateKey{year: y, month: m, day: d}
+}
+
+// utcBar truncates t to the most recent multiple of duration since the
+// Go zero time, which — because the zero time falls at 00:00:00 UTC and
+// every calendar day divides evenly into duration for the minute/hour
+// counts Interval permits — aligns bars to the UTC clock (00:00, 04:00,
+// ... for four-hour bars, for example).
+func utcBar(t time.Time, duration time.Duration) (TimeRange, error) {
+	start := t.UTC().Truncate(duration)
+	return NewTimeRange(start, start.Add(duration))
+}

--- a/marketdata/fxcalendar_test.go
+++ b/marketdata/fxcalendar_test.go
@@ -1,0 +1,198 @@
+package marketdata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func nyTime(year int, month time.Month, day, hour, minute int) time.Time {
+	return time.Date(year, month, day, hour, minute, 0, 0, newYorkLocation)
+}
+
+func TestFXCalendarStatusFridayCloseBoundary(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	assert.Equal(t, StatusOpen, c.Status(nyTime(2026, time.January, 2, 16, 59)), "just before Friday close")
+	assert.Equal(t, StatusClosed, c.Status(nyTime(2026, time.January, 2, 17, 0)), "exactly at Friday close")
+	assert.Equal(t, StatusClosed, c.Status(nyTime(2026, time.January, 2, 17, 1)), "just after Friday close")
+}
+
+func TestFXCalendarStatusSundayOpenBoundary(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	assert.Equal(t, StatusClosed, c.Status(nyTime(2026, time.January, 4, 16, 59)), "just before Sunday open")
+	assert.Equal(t, StatusOpen, c.Status(nyTime(2026, time.January, 4, 17, 0)), "exactly at Sunday open")
+	assert.Equal(t, StatusOpen, c.Status(nyTime(2026, time.January, 4, 17, 1)), "just after Sunday open")
+}
+
+func TestFXCalendarStatusSaturdayAlwaysClosed(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	assert.Equal(t, StatusClosed, c.Status(nyTime(2026, time.January, 3, 0, 0)))
+	assert.Equal(t, StatusClosed, c.Status(nyTime(2026, time.January, 3, 12, 0)))
+	assert.Equal(t, StatusClosed, c.Status(nyTime(2026, time.January, 3, 23, 59)))
+}
+
+func TestFXCalendarStatusOrdinaryWeekdayOpen(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	assert.Equal(t, StatusOpen, c.Status(nyTime(2026, time.January, 6, 3, 0)), "Tuesday overnight")
+	assert.Equal(t, StatusOpen, c.Status(nyTime(2026, time.January, 7, 12, 0)), "Wednesday midday")
+}
+
+func TestFXCalendarSessionAlignsToRollover(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	session, ok := c.Session(nyTime(2026, time.January, 6, 10, 0)) // Tuesday
+	require.True(t, ok)
+	assert.Equal(t, nyTime(2026, time.January, 5, 17, 0), session.Start(), "Monday 17:00 NY open")
+	assert.Equal(t, nyTime(2026, time.January, 6, 17, 0), session.End(), "Tuesday 17:00 NY close")
+}
+
+func TestFXCalendarSessionMondayMorningBelongsToSundayOpenSession(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	session, ok := c.Session(nyTime(2026, time.January, 5, 10, 0)) // Monday morning
+	require.True(t, ok)
+	assert.Equal(t, nyTime(2026, time.January, 4, 17, 0), session.Start(), "session opened Sunday 17:00 NY")
+	assert.Equal(t, nyTime(2026, time.January, 5, 17, 0), session.End())
+}
+
+func TestFXCalendarSessionNotOkWhenClosed(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	_, ok := c.Session(nyTime(2026, time.January, 3, 12, 0)) // Saturday
+	assert.False(t, ok)
+}
+
+func TestFXCalendarDayBarOrdinaryWeekday(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	bar, err := c.Bar(nyTime(2026, time.January, 7, 9, 0), D1) // Wednesday
+	require.NoError(t, err)
+	assert.Equal(t, nyTime(2026, time.January, 6, 17, 0), bar.Start())
+	assert.Equal(t, nyTime(2026, time.January, 7, 17, 0), bar.End())
+	assert.Equal(t, 24*time.Hour, bar.Duration())
+}
+
+func TestFXCalendarWeekBarAlignsToSundayOpen(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	bar, err := c.Bar(nyTime(2026, time.January, 7, 9, 0), W1) // Wednesday
+	require.NoError(t, err)
+	assert.Equal(t, nyTime(2026, time.January, 4, 17, 0), bar.Start(), "prior Sunday open")
+	assert.Equal(t, nyTime(2026, time.January, 11, 17, 0), bar.End(), "following Sunday open")
+}
+
+func TestFXCalendarBarRejectsMultiDayAndMultiWeekCounts(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	d2, err := NewInterval(UnitDay, 2)
+	require.NoError(t, err)
+	_, err = c.Bar(nyTime(2026, time.January, 7, 9, 0), d2)
+	assert.Error(t, err)
+
+	w2, err := NewInterval(UnitWeek, 2)
+	require.NoError(t, err)
+	_, err = c.Bar(nyTime(2026, time.January, 7, 9, 0), w2)
+	assert.Error(t, err)
+}
+
+func TestFXCalendarBarUTCAlignmentForHourAndMinute(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+	t9h13 := time.Date(2026, time.January, 7, 9, 13, 27, 0, time.UTC)
+
+	h4, err := c.Bar(t9h13, H4)
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, time.January, 7, 8, 0, 0, 0, time.UTC), h4.Start())
+	assert.Equal(t, time.Date(2026, time.January, 7, 12, 0, 0, 0, time.UTC), h4.End())
+
+	m1, err := c.Bar(t9h13, M1)
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, time.January, 7, 9, 13, 0, 0, time.UTC), m1.Start())
+	assert.Equal(t, time.Date(2026, time.January, 7, 9, 14, 0, 0, time.UTC), m1.End())
+}
+
+func TestFXCalendarBarRejectsUnknownUnit(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+	_, err := c.Bar(nyTime(2026, time.January, 7, 9, 0), Interval{unit: Unit(200), count: 1})
+	assert.Error(t, err)
+}
+
+// 2026-03-08 is the US spring-forward transition: New York clocks jump
+// from 02:00 to 03:00, so the trading day containing that instant loses
+// an hour of wall-clock time.
+func TestFXCalendarDayBarSpringForwardLosesAnHour(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	bar, err := c.Bar(nyTime(2026, time.March, 8, 10, 0), D1)
+	require.NoError(t, err)
+	assert.Equal(t, nyTime(2026, time.March, 7, 17, 0), bar.Start())
+	assert.Equal(t, nyTime(2026, time.March, 8, 17, 0), bar.End())
+	assert.Equal(t, 23*time.Hour, bar.Duration(), "spring-forward day is 23 hours")
+}
+
+// 2026-11-01 is the US fall-back transition: New York clocks repeat
+// 01:00-02:00, so the trading day containing that instant gains an hour.
+func TestFXCalendarDayBarFallBackGainsAnHour(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	bar, err := c.Bar(nyTime(2026, time.November, 1, 10, 0), D1)
+	require.NoError(t, err)
+	assert.Equal(t, nyTime(2026, time.October, 31, 17, 0), bar.Start())
+	assert.Equal(t, nyTime(2026, time.November, 1, 17, 0), bar.End())
+	assert.Equal(t, 25*time.Hour, bar.Duration(), "fall-back day is 25 hours")
+}
+
+// The week opening 2026-03-01 17:00 NY spans the spring-forward
+// transition on 2026-03-08, so it is one hour short of 7*24h.
+func TestFXCalendarWeekBarSpringForwardLosesAnHour(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	bar, err := c.Bar(nyTime(2026, time.March, 3, 9, 0), W1) // Tuesday within that week
+	require.NoError(t, err)
+	assert.Equal(t, nyTime(2026, time.March, 1, 17, 0), bar.Start())
+	assert.Equal(t, nyTime(2026, time.March, 8, 17, 0), bar.End())
+	assert.Equal(t, 7*24*time.Hour-time.Hour, bar.Duration())
+}
+
+// The week opening 2026-10-25 17:00 NY spans the fall-back transition on
+// 2026-11-01, so it is one hour longer than 7*24h.
+func TestFXCalendarWeekBarFallBackGainsAnHour(t *testing.T) {
+	c := NewFXCalendar(FXCalendarParams{})
+
+	bar, err := c.Bar(nyTime(2026, time.October, 29, 9, 0), W1) // Thursday within that week
+	require.NoError(t, err)
+	assert.Equal(t, nyTime(2026, time.October, 25, 17, 0), bar.Start())
+	assert.Equal(t, nyTime(2026, time.November, 1, 17, 0), bar.End())
+	assert.Equal(t, 7*24*time.Hour+time.Hour, bar.Duration())
+}
+
+func TestFXCalendarHoliday(t *testing.T) {
+	holiday := nyTime(2026, time.January, 1, 0, 0) // New Year's Day, a Thursday
+	c := NewFXCalendar(FXCalendarParams{Holidays: []time.Time{holiday}})
+
+	assert.Equal(t, StatusHoliday, c.Status(nyTime(2026, time.January, 1, 10, 0)))
+	assert.Equal(t, StatusHoliday, c.Status(nyTime(2026, time.January, 1, 23, 59)))
+
+	_, ok := c.Session(nyTime(2026, time.January, 1, 10, 0))
+	assert.False(t, ok, "holiday has no session")
+
+	assert.Equal(t, StatusOpen, c.Status(nyTime(2026, time.January, 2, 10, 0)), "the following day is unaffected")
+}
+
+func TestFXCalendarHolidayIgnoresTimeOfDayAndLocation(t *testing.T) {
+	// Supplied in UTC, at a time-of-day that would fall on a different
+	// New York calendar date; only the New York civil date must match.
+	holiday := time.Date(2026, time.July, 4, 23, 30, 0, 0, time.UTC) // 19:30 NY on July 4
+	c := NewFXCalendar(FXCalendarParams{Holidays: []time.Time{holiday}})
+
+	assert.Equal(t, StatusHoliday, c.Status(nyTime(2026, time.July, 4, 8, 0)))
+}
+
+func TestFXCalendarImplementsCalendar(t *testing.T) {
+	var _ Calendar = NewFXCalendar(FXCalendarParams{})
+}

--- a/marketdata/fxcalendar_test.go
+++ b/marketdata/fxcalendar_test.go
@@ -171,26 +171,63 @@ func TestFXCalendarWeekBarFallBackGainsAnHour(t *testing.T) {
 	assert.Equal(t, 7*24*time.Hour+time.Hour, bar.Duration())
 }
 
-func TestFXCalendarHoliday(t *testing.T) {
+// The holiday closure covers the entire rollover-to-rollover session
+// that ends on the named date, not just that calendar day's own hours —
+// Status and Session must agree on every instant within that session.
+func TestFXCalendarHolidayClosesTheWholeSessionThatEndsOnIt(t *testing.T) {
 	holiday := nyTime(2026, time.January, 1, 0, 0) // New Year's Day, a Thursday
 	c := NewFXCalendar(FXCalendarParams{Holidays: []time.Time{holiday}})
 
+	// The session ending Jan 1 17:00 NY opens Dec 31 17:00 NY.
+	assert.Equal(t, StatusHoliday, c.Status(nyTime(2025, time.December, 31, 20, 0)), "evening portion of the session ending on the holiday")
 	assert.Equal(t, StatusHoliday, c.Status(nyTime(2026, time.January, 1, 10, 0)))
-	assert.Equal(t, StatusHoliday, c.Status(nyTime(2026, time.January, 1, 23, 59)))
+	assert.Equal(t, StatusHoliday, c.Status(nyTime(2026, time.January, 1, 16, 59)))
 
-	_, ok := c.Session(nyTime(2026, time.January, 1, 10, 0))
-	assert.False(t, ok, "holiday has no session")
+	_, ok := c.Session(nyTime(2025, time.December, 31, 20, 0))
+	assert.False(t, ok, "holiday session has no Session")
+	_, ok = c.Session(nyTime(2026, time.January, 1, 10, 0))
+	assert.False(t, ok, "holiday has no Session")
 
-	assert.Equal(t, StatusOpen, c.Status(nyTime(2026, time.January, 2, 10, 0)), "the following day is unaffected")
+	// The next session, ending Jan 2, is unaffected.
+	assert.Equal(t, StatusOpen, c.Status(nyTime(2026, time.January, 1, 20, 0)))
+	assert.Equal(t, StatusOpen, c.Status(nyTime(2026, time.January, 2, 10, 0)))
 }
 
-func TestFXCalendarHolidayIgnoresTimeOfDayAndLocation(t *testing.T) {
-	// Supplied in UTC, at a time-of-day that would fall on a different
-	// New York calendar date; only the New York civil date must match.
-	holiday := time.Date(2026, time.July, 4, 23, 30, 0, 0, time.UTC) // 19:30 NY on July 4
+// Regression coverage for the previous Status/Session disagreement:
+// every instant inside a returned Session must itself report StatusOpen,
+// and Session's ok must exactly track Status == StatusOpen, across a
+// window that includes a configured holiday.
+func TestFXCalendarStatusAndSessionAgreeAcrossAHoliday(t *testing.T) {
+	holiday := nyTime(2026, time.January, 1, 0, 0)
 	c := NewFXCalendar(FXCalendarParams{Holidays: []time.Time{holiday}})
 
-	assert.Equal(t, StatusHoliday, c.Status(nyTime(2026, time.July, 4, 8, 0)))
+	start := nyTime(2025, time.December, 29, 0, 0)
+	for i := range 14 * 24 {
+		at := start.Add(time.Duration(i) * time.Hour)
+
+		session, ok := c.Session(at)
+		open := c.Status(at) == StatusOpen
+		require.Equal(t, open, ok, "Session ok must track Status==StatusOpen at %s", at)
+		if !ok {
+			continue
+		}
+		require.True(t, session.Contains(at))
+		assert.Equal(t, StatusOpen, c.Status(session.Start()), "session start must be open")
+		assert.Equal(t, StatusOpen, c.Status(session.End().Add(-time.Nanosecond)), "instant just before session end must be open")
+	}
+}
+
+func TestFXCalendarHolidayUsesLiteralDateFieldsNotConvertedLocation(t *testing.T) {
+	// 03:00 UTC on Jan 2 is Jan 1 22:00 EST in New York — a different
+	// civil date. The holiday's literal Year/Month/Day (Jan 2) is what
+	// must match, regardless of Location.
+	holiday := time.Date(2026, time.January, 2, 3, 0, 0, 0, time.UTC)
+	c := NewFXCalendar(FXCalendarParams{Holidays: []time.Time{holiday}})
+
+	// Session ending Jan 2 17:00 NY (opens Jan 1 17:00 NY) is the holiday.
+	assert.Equal(t, StatusHoliday, c.Status(nyTime(2026, time.January, 2, 10, 0)))
+	// Session ending Jan 1 17:00 NY is not.
+	assert.Equal(t, StatusOpen, c.Status(nyTime(2026, time.January, 1, 10, 0)))
 }
 
 func TestFXCalendarImplementsCalendar(t *testing.T) {

--- a/marketdata/interval.go
+++ b/marketdata/interval.go
@@ -1,0 +1,99 @@
+package marketdata
+
+import "fmt"
+
+// Unit is the calendar unit an Interval counts in.
+type Unit uint8
+
+const (
+	// UnitMinute counts elapsed minutes, aligned to the UTC clock.
+	UnitMinute Unit = iota
+	// UnitHour counts elapsed hours, aligned to the UTC clock.
+	UnitHour
+	// UnitDay counts trading days, aligned to a Calendar's session
+	// rollover rather than UTC midnight.
+	UnitDay
+	// UnitWeek counts trading weeks, aligned to a Calendar's week open.
+	UnitWeek
+)
+
+// String returns u's short display name: "m", "h", "d", or "w". It is
+// never parsed back into a Unit; see Interval.String.
+func (u Unit) String() string {
+	switch u {
+	case UnitMinute:
+		return "m"
+	case UnitHour:
+		return "h"
+	case UnitDay:
+		return "d"
+	case UnitWeek:
+		return "w"
+	default:
+		return fmt.Sprintf("Unit(%d)", uint8(u))
+	}
+}
+
+// Interval is a typed bar interval: a Unit and a count, for example one
+// hour or four hours. Interval values are constructed from typed
+// unit/count pairs — never parsed from provider-native strings such as
+// "H4" — so core code cannot silently misinterpret a malformed interval
+// string. Interval's own String method exists only for display and
+// logging; it is documented as one-directional.
+type Interval struct {
+	unit  Unit
+	count int
+}
+
+// NewInterval returns an Interval for unit and count. It reports an error
+// if count is less than 1 or unit is not one of the defined Unit values.
+func NewInterval(unit Unit, count int) (Interval, error) {
+	switch unit {
+	case UnitMinute, UnitHour, UnitDay, UnitWeek:
+	default:
+		return Interval{}, fmt.Errorf("marketdata: invalid interval unit %v", unit)
+	}
+	if count < 1 {
+		return Interval{}, fmt.Errorf("marketdata: invalid interval count %d: must be at least 1", count)
+	}
+	return Interval{unit: unit, count: count}, nil
+}
+
+// Unit returns i's calendar unit.
+func (i Interval) Unit() Unit {
+	return i.unit
+}
+
+// Count returns i's unit count.
+func (i Interval) Count() int {
+	return i.count
+}
+
+// String returns a short display form such as "M1", "H4", "D1", or "W1".
+// It is display-only: Trader never parses an Interval back out of this
+// string, so it carries no obligation to round-trip.
+func (i Interval) String() string {
+	unitLetter := "?"
+	switch i.unit {
+	case UnitMinute:
+		unitLetter = "M"
+	case UnitHour:
+		unitLetter = "H"
+	case UnitDay:
+		unitLetter = "D"
+	case UnitWeek:
+		unitLetter = "W"
+	}
+	return fmt.Sprintf("%s%d", unitLetter, i.count)
+}
+
+// Predefined intervals covering the common cases: one minute, one hour,
+// four hours, one trading day, and one trading week. Callers needing other
+// combinations use NewInterval directly.
+var (
+	M1 = Interval{unit: UnitMinute, count: 1}
+	H1 = Interval{unit: UnitHour, count: 1}
+	H4 = Interval{unit: UnitHour, count: 4}
+	D1 = Interval{unit: UnitDay, count: 1}
+	W1 = Interval{unit: UnitWeek, count: 1}
+)

--- a/marketdata/interval_test.go
+++ b/marketdata/interval_test.go
@@ -1,0 +1,58 @@
+package marketdata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIntervalValid(t *testing.T) {
+	i, err := NewInterval(UnitHour, 4)
+	require.NoError(t, err)
+	assert.Equal(t, UnitHour, i.Unit())
+	assert.Equal(t, 4, i.Count())
+}
+
+func TestNewIntervalRejectsInvalidCount(t *testing.T) {
+	for _, count := range []int{0, -1, -100} {
+		_, err := NewInterval(UnitMinute, count)
+		assert.Error(t, err, "count %d", count)
+	}
+}
+
+func TestNewIntervalRejectsUnknownUnit(t *testing.T) {
+	_, err := NewInterval(Unit(200), 1)
+	assert.Error(t, err)
+}
+
+func TestPredefinedIntervals(t *testing.T) {
+	cases := []struct {
+		name  string
+		i     Interval
+		unit  Unit
+		count int
+		str   string
+	}{
+		{"M1", M1, UnitMinute, 1, "M1"},
+		{"H1", H1, UnitHour, 1, "H1"},
+		{"H4", H4, UnitHour, 4, "H4"},
+		{"D1", D1, UnitDay, 1, "D1"},
+		{"W1", W1, UnitWeek, 1, "W1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.unit, tc.i.Unit())
+			assert.Equal(t, tc.count, tc.i.Count())
+			assert.Equal(t, tc.str, tc.i.String())
+		})
+	}
+}
+
+func TestUnitString(t *testing.T) {
+	assert.Equal(t, "m", UnitMinute.String())
+	assert.Equal(t, "h", UnitHour.String())
+	assert.Equal(t, "d", UnitDay.String())
+	assert.Equal(t, "w", UnitWeek.String())
+	assert.Contains(t, Unit(200).String(), "200")
+}

--- a/marketdata/timerange.go
+++ b/marketdata/timerange.go
@@ -1,0 +1,52 @@
+package marketdata
+
+import (
+	"fmt"
+	"time"
+)
+
+// TimeRange is a half-open time interval [start, end): start is included,
+// end is excluded. This matches the convention used throughout Trader's
+// market-data queries and bar semantics.
+type TimeRange struct {
+	start time.Time
+	end   time.Time
+}
+
+// NewTimeRange returns the half-open range [start, end). It reports an
+// error unless end is strictly after start.
+func NewTimeRange(start, end time.Time) (TimeRange, error) {
+	if !end.After(start) {
+		return TimeRange{}, fmt.Errorf("marketdata: invalid time range: end %s is not after start %s", end, start)
+	}
+	return TimeRange{start: start, end: end}, nil
+}
+
+// Start returns r's inclusive start.
+func (r TimeRange) Start() time.Time {
+	return r.start
+}
+
+// End returns r's exclusive end.
+func (r TimeRange) End() time.Time {
+	return r.end
+}
+
+// Duration returns the elapsed time between Start and End.
+func (r TimeRange) Duration() time.Duration {
+	return r.end.Sub(r.start)
+}
+
+// Contains reports whether t falls within r's half-open range: t is
+// included at Start, excluded at End.
+func (r TimeRange) Contains(t time.Time) bool {
+	return !t.Before(r.start) && t.Before(r.end)
+}
+
+// Elapsed reports whether r has finished as of now: whether now is at or
+// past r's End. It expresses bar completeness without introducing a
+// separate concept — a bar is incomplete exactly when its range has not
+// yet elapsed.
+func (r TimeRange) Elapsed(now time.Time) bool {
+	return !now.Before(r.end)
+}

--- a/marketdata/timerange_test.go
+++ b/marketdata/timerange_test.go
@@ -1,0 +1,53 @@
+package marketdata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTimeRangeValid(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	r, err := NewTimeRange(start, end)
+	require.NoError(t, err)
+	assert.Equal(t, start, r.Start())
+	assert.Equal(t, end, r.End())
+	assert.Equal(t, time.Hour, r.Duration())
+}
+
+func TestNewTimeRangeRejectsNonPositiveSpan(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	_, err := NewTimeRange(start, start)
+	assert.Error(t, err)
+
+	_, err = NewTimeRange(start, start.Add(-time.Second))
+	assert.Error(t, err)
+}
+
+func TestTimeRangeContainsIsHalfOpen(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 17, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	r, err := NewTimeRange(start, end)
+	require.NoError(t, err)
+
+	assert.True(t, r.Contains(start), "start is inclusive")
+	assert.True(t, r.Contains(start.Add(30*time.Minute)))
+	assert.False(t, r.Contains(end), "end is exclusive")
+	assert.False(t, r.Contains(start.Add(-time.Nanosecond)))
+}
+
+func TestTimeRangeElapsed(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 17, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	r, err := NewTimeRange(start, end)
+	require.NoError(t, err)
+
+	assert.False(t, r.Elapsed(start), "not elapsed at start")
+	assert.False(t, r.Elapsed(end.Add(-time.Nanosecond)), "not elapsed just before end")
+	assert.True(t, r.Elapsed(end), "elapsed exactly at end")
+	assert.True(t, r.Elapsed(end.Add(time.Hour)), "elapsed well after end")
+}


### PR DESCRIPTION
## Summary
- Adds a new `marketdata` package: typed `Interval` (`Unit` + count, predefined `M1`/`H1`/`H4`/`D1`/`W1`), half-open `TimeRange`, and a `Calendar` interface backed by `FXCalendar` — spot FX's Sunday-open/Friday-close weekly session, daily 17:00 New York rollover, DST-correct via `time.Date`/`*time.Location` arithmetic (`time/tzdata` blank-imported for deterministic behavior regardless of host tzdata).
- Promotes ADR-012 from `Proposed` to `Accepted`, matching what was actually built (mirrors the ADR-003/ADR-016 pattern).
- Adds a `marketdata` section to `README.md`.

## Why
Closes #27 (M1-09). Plan was posted and unchallenged on the issue before implementation began.

## How tested
- `make check` (fmt, vet, `go test -race ./...`) passes.
- `go test ./marketdata/... -race -cover`: 97.6% coverage.
- Explicit DST transition tests for both the 2026 US spring-forward (23h trading day) and fall-back (25h trading day) transitions, at both day and week granularity.
- `go doc`-style `Example` functions (`Example_interval`, `ExampleFXCalendar_Bar`, `ExampleFXCalendar_Session`) verified by `go test`.

## Documentation changed
- `docs/arch/adr-decisions.org` (ADR-012 accepted)
- `README.md` (`marketdata` section)
- `marketdata/doc.go` (package doc comment)

https://claude.ai/code/session_01FsfxQH4YBP5DA1LpAafWyt