### PR TITLE
M1-10: broker-neutral order and execution vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,39 @@ See [ADR-012](docs/arch/adr-decisions.org) and the
 [package doc comment](marketdata/doc.go) for the full half-open range
 convention, DST handling, and why day/week bars use a `Calendar` seam.
 
+### order
+
+`order` defines Trader's broker-neutral order and execution vocabulary —
+what a proposal, request, accepted order, and fill are, not order-state
+transition rules or broker I/O. The stages are distinct types, not
+variations on one struct:
+
+```go
+proposal, err := order.NewProposal(order.Proposal{ /* ... */ })
+request, err := order.NewRequest(proposal, orderID) // orderID doubles as the idempotency key
+```
+
+`Order` embeds its originating `Request` (the requested values) alongside
+separate `Accepted*` fields (what the broker actually accepted, which may
+differ due to broker-side normalization); `RemainingQuantity` derives
+from the accepted quantity, never the requested one:
+
+```go
+remaining, err := acceptedOrder.RemainingQuantity() // AcceptedQuantity - FilledQuantity
+```
+
+`Fill` preserves both Trader's `FillID` and the broker's own
+`BrokerFillID`, plus its own `AccountID`, so it never requires a join
+through the parent order. `Status` and `RejectReason` reserve their zero
+value for `Unknown` — the same safe-default pattern `marketdata.Status`
+uses — so an adapter parsing an unfamiliar broker status or rejection
+code never has to crash or guess.
+
+See [ADR-017](docs/arch/adr-decisions.org) and the
+[package doc comment](order/doc.go) for the full requested-versus-accepted
+model, the idempotency-key scope, and why `Position`/`Trade` are shaped
+the way they are.
+
 ## Documentation
 
 - [Framework requirements](docs/arch/trader-framework-requirements.org)

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -82,6 +82,7 @@ believed at that time.
 | 013 | Greenfield repository with controlled legacy transplant           | Accepted   |
 | 014 | Paper trading is the safe default                                 | Accepted   |
 | 016 | Symbol and listing resolution                                     | Accepted   |
+| 017 | Broker-neutral order and execution vocabulary                     | Accepted   |
 
 * ADR-001: Modular monolith before service decomposition
 
@@ -826,6 +827,167 @@ canonical value, unchanged — an alias never becomes identity.
   constraint and Trader's broader avoidance of hidden global state (see
   ADR-002's dependency-direction rules and the architecture document's
   determinism principles).
+
+* ADR-017: Broker-neutral order and execution vocabulary
+
+** Status
+
+Accepted
+
+** Context
+
+Trader needs broker-neutral value models for the stages of trading
+activity — proposal, request, accepted order, fill, position, and
+reporting trade — without implementing a broker, execution manager, or
+order-state transition rules.  Issue #28 (M1-10) required settling this
+vocabulary: how Trader IDs, broker-native IDs, idempotency, and
+correlation metadata attach to each stage; how requested and
+broker-accepted values are distinguished; how partial fills and
+remaining quantity are represented; how an unrecognized or unsupported
+broker-reported state is handled without crashing; and where the line
+falls against issue #29 (M1-11), which owns order-state transition
+rules and depends on this issue.  A design review on the issue tightened
+three points before implementation: requested-versus-accepted values
+needed to be explicit on =Order= rather than inferred from the request,
+=Fill= needed both a broker-native execution identifier and its own
+=AccountID=, and =Trade= should not be described as gaining identity
+from =id.Metadata.EventID=.
+
+** Decision
+
+The new =order= package defines =Side=, =Type=, =TimeInForce=,
+=Status=, =RejectReason=, =Proposal=, =Request=, =Order=, =Fill=,
+=CancelRequest=/=CancelResult=, =ReplaceRequest=/=ReplaceResult=,
+=Position=, and =Trade=, depending only on =instrument=, =id=, and
+=num= — all already built.  No new =id= package kinds are introduced:
+=id.OrderID= and =id.FillID= (M1-06) are used directly as =Order=/=Fill=
+identity, and =id.Metadata= supplies correlation, causation, and
+timestamp on every stage, continuing the intent→proposal→order→fill
+chain =id/doc.go= already documents.  =Order=/=Fill=/=Position=/=Trade=
+reference accounts by =id.AccountID= only, never an =account.Snapshot=,
+since that type does not exist until M1-12, which depends on this
+issue.
+
+=Request.OrderID= is the idempotency key for *creating* an order: a
+retried submission of the same =Request= reuses the same =OrderID=, and
+a broker adapter dedupes on it as the client order ID.  This is scoped
+narrowly to initial submission — a cancel or replace against an
+existing order is a separate command, and =CancelRequest=/
+=ReplaceRequest= do not yet have their own reusable command idempotency
+key; that is deferred until a real out-of-process or unreliable-
+transport requirement makes it necessary, not solved speculatively here.
+
+=Order= embeds its originating =Request= (preserving requested identity
+and values) alongside explicit =AcceptedQuantity=,
+=AcceptedLimitPrice=, and =AcceptedStopPrice= fields, all =nil= until
+the broker accepts the order — because a broker may accept a request
+but normalize its values (tick rounding, quantity increment, venue
+rules), and inferring "accepted" from "requested" would silently hide
+that normalization.  =RemainingQuantity= is a method deriving
+=AcceptedQuantity - FilledQuantity= (reporting an error if the order has
+not yet been accepted) rather than a stored field, so it can never
+independently drift from the two values it depends on.
+
+=Fill= carries =BrokerFillID= alongside =BrokerOrderID=, preserving the
+broker's native execution identity separately from its parent order's —
+a broker execution normally has its own native identifier, which matters
+for reconciliation and deduplicating broker execution events.  =Fill=
+also carries =AccountID= directly rather than requiring a join through
+the parent =Order=, since a fill is a broker/account event in its own
+right, particularly once fills are journaled or replayed independently.
+
+=Status= and =RejectReason= both reserve their zero value —
+=StatusUnknown=, =ReasonUnknown= — for broker-reported state Trader does
+not recognize, the same pattern ADR-012 established for
+=marketdata.Status=: an adapter parsing an unfamiliar broker status or
+rejection code produces the =Unknown= value instead of crashing or
+guessing, and =Rejection.BrokerCode= preserves the broker's original
+text even then.  =Side=, =Type=, and =TimeInForce= are closed,
+Trader-controlled vocabulary instead — nothing external reports a value
+Trader doesn't already define — but their zero value is still reserved
+as invalid/unset rather than defaulting to a real value, so a forgotten
+field can never be silently mistaken for =Buy= or =Market=.
+
+=PositionSide= (=Flat=, =Long=, =Short=) is a distinct type from =Side=:
+an order =Side= is a transaction direction, a =PositionSide= is a
+holding direction, and =Flat= has no order-side equivalent.  =Flat= is
+its zero value, so an unconstructed =Position= is safely flat.
+=Position= represents one net position per account/listing pair, the
+architecture's default assumption for the initial account model.
+
+=Trade=, the derived reporting concept grouping entry and exit fills,
+has no first-class identity in this package.  =id.Metadata.EventID=
+identifies one immutable event; a derived trade can be recalculated,
+revised, or represented across multiple journal events as fills
+continue to arrive, so describing =EventID= as its identity would
+misstate what an event ID means.  A dedicated =TradeID= is additive
+future work if M5's journal/report work later finds that insufficient —
+not introduced speculatively now, consistent with the restraint already
+applied to the =id= package's deferred identifiers.
+
+Constructors in this package validate snapshot/domain invariants only:
+required fields, exact-value tick/increment divisibility, required price
+presence for a given =Type=, =FilledQuantity <= AcceptedQuantity=, and
+valid rejection/status combinations (=Rejection= non-nil exactly when
+=Status= is =StatusRejected=).  Whether a given =Status= is reachable
+from an order's prior state — legal transitions, terminal-state
+enforcement, duplicate/out-of-order event handling — is issue #29
+(M1-11)'s responsibility, not this package's.
+
+OCO/bracket order grouping and parent/child order relationships are
+deferred as capability-driven features, consistent with the
+architecture document's guidance against a lowest-common-denominator
+API.  =GTD= (good-til-date) is deferred from =TimeInForce= for the same
+reason: it needs an expiration field this issue's scope does not call
+for.
+
+** Consequences
+
+- =Order= and =Fill= make broker-side normalization and broker-native
+  identity representable without inventing new =id= package kinds or a
+  parallel broker-identifier type system.
+- =RemainingQuantity= cannot be computed before an order is accepted,
+  which is an explicit, typed signal rather than a silently wrong zero
+  value.
+- =CancelRequest=/=ReplaceRequest= idempotency across retries remains
+  unsolved until a real requirement forces the question; callers must
+  not assume retrying either is currently safe.
+- =Trade='s lack of identity means callers cannot yet reference "the
+  same trade" stably across journal events; M5 must revisit this if that
+  becomes necessary.
+- Every broker adapter built later must map its own status and
+  rejection vocabulary onto =Status=/=RejectReason=, explicitly falling
+  back to =Unknown= plus preserved raw text for anything unrecognized,
+  rather than inventing ad hoc broker-specific types.
+
+** Alternatives Considered
+
+- *Inferring accepted quantity/prices from the request instead of
+  representing them explicitly on =Order=.*  Rejected on design review:
+  it leaves no representation for broker-side normalization, which the
+  issue's "requested versus accepted price and quantity" scope item
+  requires.
+- *Fill carrying only =BrokerOrderID=, with no separate broker-native
+  fill identifier.*  Rejected on design review: a broker execution
+  normally has its own native identity distinct from its parent order,
+  and the issue's acceptance criteria require broker-native identifiers,
+  plural, to be preserved.
+- *Requiring callers to join through =Order= to find a =Fill='s
+  account.*  Rejected on design review as unnecessary coupling, since a
+  fill is a broker/account event in its own right.
+- *Describing =Trade='s identity as =Metadata.EventID=.*  Rejected on
+  design review: an event ID identifies an event/envelope, not a
+  recalculable derived concept, so the description would misstate what
+  =Trade= actually has.
+- *A single =OrderID=-based idempotency key covering cancel and replace
+  as well as initial submission.*  Rejected as overclaiming: cancel/
+  replace commands crossing an unreliable transport may eventually need
+  their own command identity, and this decision should not read as
+  having already solved that.
+- *Adding a =TradeID= kind to =id= now.*  Rejected as premature under
+  the same rule of thumb =id/doc.go= already applies to its deferred
+  identifiers — add it when a concrete, persisted consumer needs it, not
+  speculatively.
 
 * ADR Template                                                       :noexport:
 

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -927,12 +927,26 @@ applied to the =id= package's deferred identifiers.
 
 Constructors in this package validate snapshot/domain invariants only:
 required fields, exact-value tick/increment divisibility, required price
-presence for a given =Type=, =FilledQuantity <= AcceptedQuantity=, and
-valid rejection/status combinations (=Rejection= non-nil exactly when
-=Status= is =StatusRejected=).  Whether a given =Status= is reachable
-from an order's prior state — legal transitions, terminal-state
-enforcement, duplicate/out-of-order event handling — is issue #29
-(M1-11)'s responsibility, not this package's.
+presence for a given =Type=, =FilledQuantity <= AcceptedQuantity=,
+whether =Status= implies the broker has (or has not) accepted the order
+and so requires (or precludes) a non-nil =AcceptedQuantity=, and valid
+rejection/status combinations (=Rejection= non-nil exactly when =Status=
+is =StatusRejected=).  Whether a given =Status= is reachable from an
+order's prior state — legal transitions, terminal-state enforcement,
+duplicate/out-of-order event handling — is issue #29 (M1-11)'s
+responsibility, not this package's.
+
+Because =Proposal=, =Request=, and =Order= are ordinary exported structs,
+Go cannot prevent a caller from building a later stage as a bare struct
+literal that embeds an earlier, invalid stage — bypassing that earlier
+stage's own constructor entirely.  A design-review comment on the PR
+identified this as a real hole: checking only the outermost identity
+field (=Request.OrderID=, say) does not prove the embedded =Proposal= is
+valid.  Each stage's constructor therefore fully revalidates every stage
+beneath it through a shared unexported validator
+(=checkProposal=/=checkRequest=) rather than trusting an earlier stage by
+provenance — the same shared-validator shape =Order='s accepted-value
+checks reuse from =Proposal='s requested-value checks.
 
 OCO/bracket order grouping and parent/child order relationships are
 deferred as capability-driven features, consistent with the
@@ -988,6 +1002,16 @@ for.
   the same rule of thumb =id/doc.go= already applies to its deferred
   identifiers — add it when a concrete, persisted consumer needs it, not
   speculatively.
+- *=CancelResult= and =ReplaceResult= reusing =ErrInvalidCancelRequest=/
+  =ErrInvalidReplaceRequest=.*  Rejected on review: those sentinels'
+  doc comments describe request validation specifically, and reusing
+  them for result validation makes error classification imprecise for
+  callers.  Dedicated =ErrInvalidCancelResult=/=ErrInvalidReplaceResult=
+  sentinels were added instead, matching this package's existing
+  per-type sentinel granularity.
+- *Trusting an earlier stage's validity by constructor provenance
+  alone.*  Rejected on review once it was shown a bare struct literal
+  defeats it; see the shared-validator discussion above.
 
 * ADR Template                                                       :noexport:
 

--- a/order/cancel.go
+++ b/order/cancel.go
@@ -45,7 +45,7 @@ type CancelResult struct {
 // non-zero.
 func NewCancelResult(r CancelResult) (CancelResult, error) {
 	if r.OrderID.IsZero() {
-		return CancelResult{}, fmt.Errorf("%w: order id must be set", ErrInvalidCancelRequest)
+		return CancelResult{}, fmt.Errorf("%w: order id must be set", ErrInvalidCancelResult)
 	}
 	return r, nil
 }

--- a/order/cancel.go
+++ b/order/cancel.go
@@ -1,0 +1,51 @@
+package order
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/id"
+)
+
+// CancelRequest asks a broker to cancel an existing order. Its
+// Metadata.EventID identifies this specific cancel command; it is not a
+// reusable idempotency key the way Request.OrderID is for initial
+// submission — a retried CancelRequest is a separate command concern,
+// deferred until a real out-of-process or unreliable-transport
+// requirement makes it necessary.
+type CancelRequest struct {
+	// OrderID identifies the order to cancel.
+	OrderID  id.OrderID
+	Metadata id.Metadata
+}
+
+// NewCancelRequest validates and returns a CancelRequest. OrderID must
+// be non-zero.
+func NewCancelRequest(r CancelRequest) (CancelRequest, error) {
+	if r.OrderID.IsZero() {
+		return CancelRequest{}, fmt.Errorf("%w: order id must be set", ErrInvalidCancelRequest)
+	}
+	return r, nil
+}
+
+// CancelResult reports the outcome of a CancelRequest.
+type CancelResult struct {
+	OrderID id.OrderID
+	// Status is the order's resulting status: typically StatusCanceled,
+	// but a cancel can also be declined — for example if the order
+	// already filled — in which case Status reflects the order's actual
+	// state and Rejection explains why the cancel itself did not apply.
+	Status Status
+	// Rejection explains why the cancel could not be applied. Nil when
+	// the cancel succeeded.
+	Rejection *Rejection
+	Metadata  id.Metadata
+}
+
+// NewCancelResult validates and returns a CancelResult. OrderID must be
+// non-zero.
+func NewCancelResult(r CancelResult) (CancelResult, error) {
+	if r.OrderID.IsZero() {
+		return CancelResult{}, fmt.Errorf("%w: order id must be set", ErrInvalidCancelRequest)
+	}
+	return r, nil
+}

--- a/order/cancel_test.go
+++ b/order/cancel_test.go
@@ -25,7 +25,7 @@ func TestNewCancelResultValid(t *testing.T) {
 
 func TestNewCancelResultRejectsZeroOrderID(t *testing.T) {
 	_, err := NewCancelResult(CancelResult{})
-	assert.ErrorIs(t, err, ErrInvalidCancelRequest)
+	assert.ErrorIs(t, err, ErrInvalidCancelResult)
 }
 
 func TestNewCancelResultDeclinedCarriesRejection(t *testing.T) {

--- a/order/cancel_test.go
+++ b/order/cancel_test.go
@@ -1,0 +1,40 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCancelRequestValid(t *testing.T) {
+	_, err := NewCancelRequest(CancelRequest{OrderID: mustOrderID(t)})
+	require.NoError(t, err)
+}
+
+func TestNewCancelRequestRejectsZeroOrderID(t *testing.T) {
+	_, err := NewCancelRequest(CancelRequest{})
+	assert.ErrorIs(t, err, ErrInvalidCancelRequest)
+}
+
+func TestNewCancelResultValid(t *testing.T) {
+	r, err := NewCancelResult(CancelResult{OrderID: mustOrderID(t), Status: StatusCanceled})
+	require.NoError(t, err)
+	assert.Nil(t, r.Rejection)
+}
+
+func TestNewCancelResultRejectsZeroOrderID(t *testing.T) {
+	_, err := NewCancelResult(CancelResult{})
+	assert.ErrorIs(t, err, ErrInvalidCancelRequest)
+}
+
+func TestNewCancelResultDeclinedCarriesRejection(t *testing.T) {
+	r, err := NewCancelResult(CancelResult{
+		OrderID:   mustOrderID(t),
+		Status:    StatusFilled,
+		Rejection: &Rejection{Reason: ReasonUnknown, Detail: "already filled"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, r.Rejection)
+	assert.Equal(t, "already filled", r.Rejection.Detail)
+}

--- a/order/doc.go
+++ b/order/doc.go
@@ -1,0 +1,89 @@
+// Package order defines Trader's broker-neutral order and execution
+// vocabulary, as decided by issue #28 (M1-10) and ADR-017. It defines
+// what these lifecycle concepts are and what makes one well-formed; it
+// does not implement order-state transition rules (Working -> Filled,
+// terminal-state enforcement, duplicate/out-of-order event handling —
+// see issue #29/M1-11), broker I/O, or an execution manager.
+//
+// # The proposal-to-fill chain
+//
+// Proposal, Request, Order, and Fill are deliberately distinct types,
+// not variations on one struct:
+//
+//	Proposal: a candidate order before risk approval
+//	Request:  a Proposal assigned a Trader OrderID, ready for submission
+//	Order:    the broker's accepted order and its lifecycle state
+//	Fill:     one execution against an Order
+//
+// Request.OrderID (from the id package, M1-06) doubles as the
+// idempotency key for creating that order: a retried submission reuses
+// the same OrderID, and a broker adapter dedupes on it as the client
+// order ID. That covers idempotency for initial submission only — a
+// cancel or replace against an existing order is a separate command with
+// its own idempotency needs; see CancelRequest and ReplaceRequest.
+//
+// # Requested versus accepted values
+//
+// Order embeds its originating Request, preserving the requested
+// quantity and prices, alongside separately tracked AcceptedQuantity,
+// AcceptedLimitPrice, and AcceptedStopPrice: a broker may accept an
+// order but normalize its values (tick rounding, quantity increment,
+// venue rules), and Trader represents both sides of that boundary
+// explicitly rather than inferring one from the other. RemainingQuantity
+// derives from AcceptedQuantity minus FilledQuantity — never from the
+// originally requested quantity, and never stored as an independent
+// field that could drift out of sync with the two values it depends on.
+//
+// # Broker-native identifiers are preserved, not replaced
+//
+// Order carries BrokerOrderID, and Fill carries both BrokerOrderID and
+// BrokerFillID, alongside Trader's own OrderID and FillID: a broker
+// execution normally has its own native identity independent of its
+// parent order, which matters for reconciliation and deduplicating
+// broker execution events. Fill also carries AccountID directly, since a
+// fill is a broker/account event in its own right and should not require
+// a join through its parent Order to know which account it belongs to.
+//
+// # Unknown external state is representable, not fatal
+//
+// Status and RejectReason both reserve their zero value — StatusUnknown,
+// ReasonUnknown — for broker-reported state Trader does not yet
+// recognize, the same pattern marketdata.Status established: an adapter
+// parsing an unfamiliar broker status or rejection code produces the
+// Unknown value instead of crashing or guessing, and an uninitialized
+// value can never be silently mistaken for something specific.
+// Rejection.BrokerCode additionally preserves the broker's own original
+// text even when Reason can only be classified as ReasonUnknown, so
+// information is never silently dropped.
+//
+// Side, Type, and TimeInForce are different: they are closed,
+// Trader-controlled vocabulary rather than broker-reported state, so
+// there is no "unknown" case for them — construction sites reject
+// anything outside their defined values. Their zero value is still
+// reserved as invalid/unset rather than defaulting to one of the real
+// values, so a forgotten field is never silently mistaken for Buy or
+// Market.
+//
+// # Position and Trade
+//
+// Position represents one net position per account/listing pair — the
+// architecture's default assumption for the initial account model — with
+// PositionSide (Flat, Long, Short) kept as a distinct type from Side: an
+// order Side is a transaction direction, a PositionSide is a holding
+// direction, and Flat has no order-side equivalent. Trade is the derived
+// reporting concept grouping entry and exit fills into a round-trip; it
+// deliberately has no first-class identity in this package, since it can
+// be recalculated or revised as fills continue to arrive — a dedicated
+// TradeID is additive future work if the journal/report milestones later
+// need one.
+//
+// # Deferred
+//
+// OCO/bracket order grouping and parent/child order relationships are
+// capability-driven features, not part of this initial vocabulary — see
+// the architecture document's discussion of capability discovery over a
+// lowest-common-denominator API. GTD (good-til-date) is deferred from
+// TimeInForce for the same reason: it needs an expiration field this
+// issue's scope does not call for. Both are additive when a real
+// consumer needs them.
+package order

--- a/order/errors.go
+++ b/order/errors.go
@@ -1,0 +1,37 @@
+package order
+
+import "errors"
+
+var (
+	// ErrInvalidProposal reports a Proposal constructor argument that
+	// fails validation.
+	ErrInvalidProposal = errors.New("order: invalid proposal")
+
+	// ErrInvalidRequest reports a Request constructor argument that
+	// fails validation.
+	ErrInvalidRequest = errors.New("order: invalid request")
+
+	// ErrInvalidOrder reports an Order constructor argument, or a query
+	// against an Order, that fails validation.
+	ErrInvalidOrder = errors.New("order: invalid order")
+
+	// ErrInvalidFill reports a Fill constructor argument that fails
+	// validation.
+	ErrInvalidFill = errors.New("order: invalid fill")
+
+	// ErrInvalidCancelRequest reports a CancelRequest constructor
+	// argument that fails validation.
+	ErrInvalidCancelRequest = errors.New("order: invalid cancel request")
+
+	// ErrInvalidReplaceRequest reports a ReplaceRequest constructor
+	// argument that fails validation.
+	ErrInvalidReplaceRequest = errors.New("order: invalid replace request")
+
+	// ErrInvalidPosition reports a Position constructor argument that
+	// fails validation.
+	ErrInvalidPosition = errors.New("order: invalid position")
+
+	// ErrInvalidTrade reports a Trade constructor argument that fails
+	// validation.
+	ErrInvalidTrade = errors.New("order: invalid trade")
+)

--- a/order/errors.go
+++ b/order/errors.go
@@ -23,9 +23,17 @@ var (
 	// argument that fails validation.
 	ErrInvalidCancelRequest = errors.New("order: invalid cancel request")
 
+	// ErrInvalidCancelResult reports a CancelResult constructor argument
+	// that fails validation.
+	ErrInvalidCancelResult = errors.New("order: invalid cancel result")
+
 	// ErrInvalidReplaceRequest reports a ReplaceRequest constructor
 	// argument that fails validation.
 	ErrInvalidReplaceRequest = errors.New("order: invalid replace request")
+
+	// ErrInvalidReplaceResult reports a ReplaceResult constructor
+	// argument that fails validation.
+	ErrInvalidReplaceResult = errors.New("order: invalid replace result")
 
 	// ErrInvalidPosition reports a Position constructor argument that
 	// fails validation.

--- a/order/example_test.go
+++ b/order/example_test.go
@@ -1,0 +1,147 @@
+package order_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/clock"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+)
+
+func exampleListing() instrument.Listing {
+	inst, err := instrument.NewCurrencyPair(num.MustParseCurrency("EUR"), num.MustParseCurrency("USD"))
+	if err != nil {
+		panic(err)
+	}
+	spec, err := instrument.NewSpec(
+		num.MustParsePrice("0.00001"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		num.MustParseCurrency("USD"),
+	)
+	if err != nil {
+		panic(err)
+	}
+	listing, err := instrument.NewListing(instrument.ListingParams{
+		Instrument: inst,
+		Provider:   "OANDA",
+		Symbol:     "EUR_USD",
+		Spec:       spec,
+		Tradable:   true,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return listing
+}
+
+// Example_proposalToRequest shows the proposal-to-request stage: a
+// Proposal is validated on its own, then assigned a Trader OrderID to
+// become a Request ready for submission.
+func Example_proposalToRequest() {
+	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(1, 2))
+	accountID, err := id.GenerateAccountID(g)
+	if err != nil {
+		panic(err)
+	}
+
+	proposal, err := order.NewProposal(order.Proposal{
+		Listing:     exampleListing(),
+		AccountID:   accountID,
+		Side:        order.Buy,
+		Type:        order.Market,
+		TimeInForce: order.GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	orderID, err := id.GenerateOrderID(g)
+	if err != nil {
+		panic(err)
+	}
+	request, err := order.NewRequest(proposal, orderID)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(request.Side, request.Type, request.Quantity)
+	// Output:
+	// buy market 1000
+}
+
+// ExampleOrder_RemainingQuantity shows that remaining quantity derives
+// from the broker-accepted quantity, not the originally requested one —
+// a broker may accept a normalized quantity that differs from what was
+// requested.
+func ExampleOrder_RemainingQuantity() {
+	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(1, 2))
+	accountID, err := id.GenerateAccountID(g)
+	if err != nil {
+		panic(err)
+	}
+	proposal, err := order.NewProposal(order.Proposal{
+		Listing:     exampleListing(),
+		AccountID:   accountID,
+		Side:        order.Buy,
+		Type:        order.Market,
+		TimeInForce: order.GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+	})
+	if err != nil {
+		panic(err)
+	}
+	orderID, err := id.GenerateOrderID(g)
+	if err != nil {
+		panic(err)
+	}
+	request, err := order.NewRequest(proposal, orderID)
+	if err != nil {
+		panic(err)
+	}
+
+	accepted := num.MustParseQuantity("1000")
+	o, err := order.NewOrder(order.Order{
+		Request:          request,
+		AcceptedQuantity: &accepted,
+		FilledQuantity:   num.MustParseQuantity("400"),
+		Status:           order.StatusPartiallyFilled,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	remaining, err := o.RemainingQuantity()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(remaining)
+	// Output:
+	// 600
+}
+
+// Example_unknownBrokerStatus shows that an unrecognized broker status
+// or rejection code becomes the safe Unknown value rather than a crash
+// or a guess, while the broker's own text is preserved.
+func Example_unknownBrokerStatus() {
+	// parseBrokerStatus stands in for an adapter's own mapping from a
+	// broker's status vocabulary to order.Status.
+	parseBrokerStatus := func(brokerText string) order.Status {
+		switch brokerText {
+		case "OPEN":
+			return order.StatusWorking
+		default:
+			return order.StatusUnknown
+		}
+	}
+
+	fmt.Println(parseBrokerStatus("OPEN"))
+	fmt.Println(parseBrokerStatus("SOME_NEW_BROKER_STATE"))
+	// Output:
+	// working
+	// unknown
+}

--- a/order/fill.go
+++ b/order/fill.go
@@ -1,0 +1,82 @@
+package order
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+)
+
+// Fill is one execution against an Order. It preserves both Trader's own
+// FillID and the broker's native execution identifier, BrokerFillID,
+// alongside the parent order's identifiers — a broker execution normally
+// has its own native identity independent of its parent order, which
+// matters for reconciliation and deduplicating broker execution events.
+type Fill struct {
+	// FillID is Trader's own identifier for this fill.
+	FillID id.FillID
+	// OrderID is the Trader OrderID of the order this fill executed
+	// against.
+	OrderID id.OrderID
+	// BrokerOrderID is the broker's identifier for the parent order.
+	BrokerOrderID string
+	// BrokerFillID is the broker's own identifier for this specific
+	// execution, preserved without replacing FillID.
+	BrokerFillID string
+	// AccountID identifies the account this execution belongs to. It is
+	// carried directly rather than requiring a join through the parent
+	// Order, since a fill is a broker/account event in its own right.
+	AccountID id.AccountID
+	// Listing is the venue-specific tradable instrument that executed.
+	Listing instrument.Listing
+	Side    Side
+	// Price is this execution's price.
+	Price num.Price
+	// Quantity is this execution's size. It must be greater than zero.
+	Quantity num.Quantity
+	// Commission is this execution's fee, if reported. Nil if not
+	// reported.
+	Commission *num.Money
+	// Timestamp is when the execution occurred, as reported by the
+	// broker.
+	Timestamp time.Time
+	// Metadata carries this fill's correlation and causation context,
+	// typically with CausationID pointing at the parent order's
+	// EventID.
+	Metadata id.Metadata
+}
+
+// NewFill validates and returns a Fill. FillID, OrderID, and AccountID
+// must be non-zero; Listing must be constructed; Side must be one of its
+// defined values; Quantity must be positive and a multiple of Listing's
+// quantity increment; Price must be an exact multiple of Listing's tick
+// size.
+func NewFill(f Fill) (Fill, error) {
+	if f.FillID.IsZero() {
+		return Fill{}, fmt.Errorf("%w: fill id must be set", ErrInvalidFill)
+	}
+	if f.OrderID.IsZero() {
+		return Fill{}, fmt.Errorf("%w: order id must be set", ErrInvalidFill)
+	}
+	if f.AccountID.IsZero() {
+		return Fill{}, fmt.Errorf("%w: account id must be set", ErrInvalidFill)
+	}
+	if f.Listing.InstrumentID().IsZero() {
+		return Fill{}, fmt.Errorf("%w: listing must be constructed", ErrInvalidFill)
+	}
+	if !f.Side.valid() {
+		return Fill{}, fmt.Errorf("%w: invalid side %v", ErrInvalidFill, f.Side)
+	}
+	if f.Quantity.IsZero() {
+		return Fill{}, fmt.Errorf("%w: quantity must be greater than zero", ErrInvalidFill)
+	}
+	if err := f.Listing.Spec().ValidateQuantity(f.Quantity); err != nil {
+		return Fill{}, fmt.Errorf("%w: %v", ErrInvalidFill, err)
+	}
+	if err := f.Listing.Spec().ValidatePrice(f.Price); err != nil {
+		return Fill{}, fmt.Errorf("%w: %v", ErrInvalidFill, err)
+	}
+	return f, nil
+}

--- a/order/fill_test.go
+++ b/order/fill_test.go
@@ -1,0 +1,146 @@
+package order
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFillValid(t *testing.T) {
+	f, err := NewFill(Fill{
+		FillID:        mustFillID(t),
+		OrderID:       mustOrderID(t),
+		BrokerOrderID: "broker-order-1",
+		BrokerFillID:  "broker-fill-1",
+		AccountID:     mustAccountID(t),
+		Listing:       mustEurUsdListing(t),
+		Side:          Buy,
+		Price:         num.MustParsePrice("1.10000"),
+		Quantity:      num.MustParseQuantity("1000"),
+		Timestamp:     time.Now(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "broker-fill-1", f.BrokerFillID)
+}
+
+func TestNewFillRejectsZeroFillID(t *testing.T) {
+	_, err := NewFill(Fill{
+		OrderID:   mustOrderID(t),
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Buy,
+		Price:     num.MustParsePrice("1.10000"),
+		Quantity:  num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidFill)
+}
+
+func TestNewFillRejectsZeroOrderID(t *testing.T) {
+	_, err := NewFill(Fill{
+		FillID:    mustFillID(t),
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Buy,
+		Price:     num.MustParsePrice("1.10000"),
+		Quantity:  num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidFill)
+}
+
+func TestNewFillRejectsZeroAccountID(t *testing.T) {
+	_, err := NewFill(Fill{
+		FillID:   mustFillID(t),
+		OrderID:  mustOrderID(t),
+		Listing:  mustEurUsdListing(t),
+		Side:     Buy,
+		Price:    num.MustParsePrice("1.10000"),
+		Quantity: num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidFill)
+}
+
+func TestNewFillRejectsUnconstructedListing(t *testing.T) {
+	_, err := NewFill(Fill{
+		FillID:    mustFillID(t),
+		OrderID:   mustOrderID(t),
+		AccountID: mustAccountID(t),
+		Side:      Buy,
+		Price:     num.MustParsePrice("1.10000"),
+		Quantity:  num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidFill)
+}
+
+func TestNewFillRejectsInvalidSide(t *testing.T) {
+	_, err := NewFill(Fill{
+		FillID:    mustFillID(t),
+		OrderID:   mustOrderID(t),
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Price:     num.MustParsePrice("1.10000"),
+		Quantity:  num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidFill)
+}
+
+func TestNewFillRejectsZeroQuantity(t *testing.T) {
+	_, err := NewFill(Fill{
+		FillID:    mustFillID(t),
+		OrderID:   mustOrderID(t),
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Buy,
+		Price:     num.MustParsePrice("1.10000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidFill)
+}
+
+func TestNewFillRejectsPriceNotOnTick(t *testing.T) {
+	_, err := NewFill(Fill{
+		FillID:    mustFillID(t),
+		OrderID:   mustOrderID(t),
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Buy,
+		Price:     num.MustParsePrice("1.10000123"),
+		Quantity:  num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidFill)
+}
+
+func TestNewFillRejectsQuantityNotOnIncrement(t *testing.T) {
+	_, err := NewFill(Fill{
+		FillID:    mustFillID(t),
+		OrderID:   mustOrderID(t),
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Buy,
+		Price:     num.MustParsePrice("1.10000"),
+		Quantity:  num.MustParseQuantity("1000.5"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidFill)
+}
+
+func TestFillPreservesBothBrokerAndTraderIdentifiers(t *testing.T) {
+	f, err := NewFill(Fill{
+		FillID:        mustFillID(t),
+		OrderID:       mustOrderID(t),
+		BrokerOrderID: "bo-1",
+		BrokerFillID:  "bf-1",
+		AccountID:     mustAccountID(t),
+		Listing:       mustEurUsdListing(t),
+		Side:          Sell,
+		Price:         num.MustParsePrice("1.10000"),
+		Quantity:      num.MustParseQuantity("1000"),
+		Metadata:      id.Metadata{EventID: mustEventID(t)},
+	})
+	require.NoError(t, err)
+	assert.False(t, f.FillID.IsZero())
+	assert.False(t, f.OrderID.IsZero())
+	assert.Equal(t, "bo-1", f.BrokerOrderID)
+	assert.Equal(t, "bf-1", f.BrokerFillID)
+}

--- a/order/helpers_test.go
+++ b/order/helpers_test.go
@@ -1,0 +1,100 @@
+package order
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rustyeddy/trader/clock"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/require"
+)
+
+func testGenerator() *id.Generator {
+	return id.NewGenerator(clock.NewSimulated(time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)), id.NewDeterministic(1, 2))
+}
+
+func mustOrderID(t *testing.T) id.OrderID {
+	t.Helper()
+	oid, err := id.GenerateOrderID(testGenerator())
+	require.NoError(t, err)
+	return oid
+}
+
+func mustFillID(t *testing.T) id.FillID {
+	t.Helper()
+	fid, err := id.GenerateFillID(testGenerator())
+	require.NoError(t, err)
+	return fid
+}
+
+func mustAccountID(t *testing.T) id.AccountID {
+	t.Helper()
+	aid, err := id.GenerateAccountID(testGenerator())
+	require.NoError(t, err)
+	return aid
+}
+
+func mustEurUsdListing(t *testing.T) instrument.Listing {
+	t.Helper()
+	inst, err := instrument.NewCurrencyPair(num.MustParseCurrency("EUR"), num.MustParseCurrency("USD"))
+	require.NoError(t, err)
+	spec, err := instrument.NewSpec(
+		num.MustParsePrice("0.00001"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		num.MustParseCurrency("USD"),
+	)
+	require.NoError(t, err)
+	listing, err := instrument.NewListing(instrument.ListingParams{
+		Instrument: inst,
+		Provider:   "OANDA",
+		Symbol:     "EUR_USD",
+		Spec:       spec,
+		Tradable:   true,
+	})
+	require.NoError(t, err)
+	return listing
+}
+
+func mustProposal(t *testing.T) Proposal {
+	t.Helper()
+	p, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        Market,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		Metadata:    id.Metadata{EventID: mustEventID(t)},
+	})
+	require.NoError(t, err)
+	return p
+}
+
+func mustEventID(t *testing.T) id.EventID {
+	t.Helper()
+	eid, err := id.GenerateEventID(testGenerator())
+	require.NoError(t, err)
+	return eid
+}
+
+func mustRequest(t *testing.T) Request {
+	t.Helper()
+	r, err := NewRequest(mustProposal(t), mustOrderID(t))
+	require.NoError(t, err)
+	return r
+}
+
+func price(t *testing.T, s string) *num.Price {
+	t.Helper()
+	p := num.MustParsePrice(s)
+	return &p
+}
+
+func qty(t *testing.T, s string) *num.Quantity {
+	t.Helper()
+	q := num.MustParseQuantity(s)
+	return &q
+}

--- a/order/order.go
+++ b/order/order.go
@@ -1,0 +1,108 @@
+package order
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/num"
+)
+
+// Order is a broker-recognized order and its lifecycle state. It embeds
+// the originating Request — preserving the requested identity and
+// values Trader submitted — alongside the broker's separately tracked
+// accepted/effective values, since a broker may accept a request but
+// normalize it (tick rounding, quantity increment, venue rules).
+// Accepted* fields are nil until the broker has accepted the order.
+type Order struct {
+	// Request is the request that created this order, preserving its
+	// requested quantity and prices for comparison and audit.
+	Request Request
+	// BrokerOrderID is the broker's own identifier for this order,
+	// preserved without replacing OrderID. It is empty until the
+	// broker acknowledges the order.
+	BrokerOrderID string
+
+	// AcceptedQuantity is the quantity the broker actually accepted,
+	// which may differ from Request.Quantity. Nil until accepted.
+	AcceptedQuantity *num.Quantity
+	// AcceptedLimitPrice is the limit price the broker actually
+	// accepted. Present or nil exactly as Request.Type requires, once
+	// AcceptedQuantity is set.
+	AcceptedLimitPrice *num.Price
+	// AcceptedStopPrice is the stop price the broker actually accepted.
+	// Present or nil exactly as Request.Type requires, once
+	// AcceptedQuantity is set.
+	AcceptedStopPrice *num.Price
+
+	Status Status
+	// FilledQuantity is the cumulative quantity executed so far. It can
+	// only be non-zero once AcceptedQuantity is set, and never exceeds
+	// it.
+	FilledQuantity num.Quantity
+	// AvgFillPrice is the quantity-weighted average price across all
+	// fills so far. Nil until the first fill.
+	AvgFillPrice *num.Price
+	// Rejection explains why the broker declined this order. Non-nil
+	// exactly when Status is StatusRejected.
+	Rejection *Rejection
+
+	// UpdatedAt is when this Order value was last observed to change.
+	UpdatedAt time.Time
+}
+
+// NewOrder validates and returns an Order. o.Request must already be a
+// validated Request. If o.AcceptedQuantity is non-nil, it must be
+// positive, a multiple of the listing's quantity increment, and
+// AcceptedLimitPrice/AcceptedStopPrice must be present or nil exactly as
+// o.Request.Type requires; if non-nil, they must be exact multiples of
+// the listing's tick size. o.FilledQuantity must not exceed
+// AcceptedQuantity, and must be zero if AcceptedQuantity is nil.
+// o.Rejection must be non-nil exactly when o.Status is StatusRejected.
+//
+// NewOrder validates this snapshot's internal consistency only. Whether
+// a given Status is reachable from the order's prior state is issue #29
+// (M1-11)'s responsibility, not this constructor's.
+func NewOrder(o Order) (Order, error) {
+	if o.Request.OrderID.IsZero() {
+		return Order{}, fmt.Errorf("%w: request must be constructed", ErrInvalidOrder)
+	}
+
+	if o.AcceptedQuantity != nil {
+		if o.AcceptedQuantity.IsZero() {
+			return Order{}, fmt.Errorf("%w: accepted quantity must be greater than zero", ErrInvalidOrder)
+		}
+		if err := validatePricePresence(o.Request.Type, o.AcceptedLimitPrice, o.AcceptedStopPrice); err != nil {
+			return Order{}, fmt.Errorf("%w: accepted %v", ErrInvalidOrder, err)
+		}
+		if err := validatePriceAndQuantity(o.Request.Listing, *o.AcceptedQuantity, o.AcceptedLimitPrice, o.AcceptedStopPrice); err != nil {
+			return Order{}, fmt.Errorf("%w: accepted %v", ErrInvalidOrder, err)
+		}
+		if _, err := o.AcceptedQuantity.Sub(o.FilledQuantity); err != nil {
+			return Order{}, fmt.Errorf("%w: filled quantity exceeds accepted quantity: %v", ErrInvalidOrder, err)
+		}
+	} else if !o.FilledQuantity.IsZero() {
+		return Order{}, fmt.Errorf("%w: filled quantity requires an accepted quantity", ErrInvalidOrder)
+	} else if o.AcceptedLimitPrice != nil || o.AcceptedStopPrice != nil {
+		return Order{}, fmt.Errorf("%w: accepted prices require an accepted quantity", ErrInvalidOrder)
+	}
+
+	if o.Status == StatusRejected && o.Rejection == nil {
+		return Order{}, fmt.Errorf("%w: rejected order requires a Rejection", ErrInvalidOrder)
+	}
+	if o.Status != StatusRejected && o.Rejection != nil {
+		return Order{}, fmt.Errorf("%w: only a rejected order may carry a Rejection", ErrInvalidOrder)
+	}
+
+	return o, nil
+}
+
+// RemainingQuantity returns AcceptedQuantity minus FilledQuantity. It
+// reports ErrInvalidOrder if the order has not yet been accepted, so
+// remaining quantity is never confused with the originally requested
+// quantity.
+func (o Order) RemainingQuantity() (num.Quantity, error) {
+	if o.AcceptedQuantity == nil {
+		return num.Quantity{}, fmt.Errorf("%w: order has not been accepted", ErrInvalidOrder)
+	}
+	return o.AcceptedQuantity.Sub(o.FilledQuantity)
+}

--- a/order/order.go
+++ b/order/order.go
@@ -50,21 +50,32 @@ type Order struct {
 	UpdatedAt time.Time
 }
 
-// NewOrder validates and returns an Order. o.Request must already be a
-// validated Request. If o.AcceptedQuantity is non-nil, it must be
-// positive, a multiple of the listing's quantity increment, and
-// AcceptedLimitPrice/AcceptedStopPrice must be present or nil exactly as
-// o.Request.Type requires; if non-nil, they must be exact multiples of
-// the listing's tick size. o.FilledQuantity must not exceed
-// AcceptedQuantity, and must be zero if AcceptedQuantity is nil.
-// o.Rejection must be non-nil exactly when o.Status is StatusRejected.
+// NewOrder validates and returns an Order. o.Request is fully
+// revalidated, including its embedded Proposal — not merely trusted by
+// provenance, since Request's exported fields let a caller build one as
+// a bare struct literal. o.Status must be one of its defined values. If
+// o.AcceptedQuantity is non-nil, it must be positive, a multiple of the
+// listing's quantity increment, and AcceptedLimitPrice/AcceptedStopPrice
+// must be present or nil exactly as o.Request.Type requires; if non-nil,
+// they must be exact multiples of the listing's tick size.
+// o.FilledQuantity must not exceed AcceptedQuantity, and must be zero if
+// AcceptedQuantity is nil. A Status that implies the broker has accepted
+// the order (StatusWorking, StatusPartiallyFilled, StatusFilled,
+// StatusPendingCancel, StatusCanceled, StatusPendingReplace,
+// StatusExpired) requires a non-nil AcceptedQuantity; a Status that
+// implies it has not (StatusPendingSubmit, StatusRejected) requires a
+// nil one. o.Rejection must be non-nil exactly when o.Status is
+// StatusRejected.
 //
 // NewOrder validates this snapshot's internal consistency only. Whether
 // a given Status is reachable from the order's prior state is issue #29
 // (M1-11)'s responsibility, not this constructor's.
 func NewOrder(o Order) (Order, error) {
-	if o.Request.OrderID.IsZero() {
-		return Order{}, fmt.Errorf("%w: request must be constructed", ErrInvalidOrder)
+	if err := checkRequest(o.Request); err != nil {
+		return Order{}, fmt.Errorf("%w: request: %v", ErrInvalidOrder, err)
+	}
+	if !o.Status.valid() {
+		return Order{}, fmt.Errorf("%w: invalid status %v", ErrInvalidOrder, o.Status)
 	}
 
 	if o.AcceptedQuantity != nil {
@@ -84,6 +95,13 @@ func NewOrder(o Order) (Order, error) {
 		return Order{}, fmt.Errorf("%w: filled quantity requires an accepted quantity", ErrInvalidOrder)
 	} else if o.AcceptedLimitPrice != nil || o.AcceptedStopPrice != nil {
 		return Order{}, fmt.Errorf("%w: accepted prices require an accepted quantity", ErrInvalidOrder)
+	}
+
+	if o.Status.requiresAcceptance() && o.AcceptedQuantity == nil {
+		return Order{}, fmt.Errorf("%w: status %s requires an accepted quantity", ErrInvalidOrder, o.Status)
+	}
+	if o.Status.precludesAcceptance() && o.AcceptedQuantity != nil {
+		return Order{}, fmt.Errorf("%w: status %s must not have an accepted quantity", ErrInvalidOrder, o.Status)
 	}
 
 	if o.Status == StatusRejected && o.Rejection == nil {

--- a/order/order_test.go
+++ b/order/order_test.go
@@ -1,0 +1,170 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOrderValidPendingSubmit(t *testing.T) {
+	o, err := NewOrder(Order{
+		Request: mustRequest(t),
+		Status:  StatusPendingSubmit,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, o.AcceptedQuantity)
+}
+
+func TestNewOrderValidAccepted(t *testing.T) {
+	accepted := num.MustParseQuantity("1000")
+	o, err := NewOrder(Order{
+		Request:          mustRequest(t),
+		BrokerOrderID:    "broker-123",
+		AcceptedQuantity: &accepted,
+		Status:           StatusWorking,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, o.AcceptedQuantity)
+	assert.True(t, o.AcceptedQuantity.Equal(accepted))
+}
+
+func TestNewOrderRejectsUnconstructedRequest(t *testing.T) {
+	_, err := NewOrder(Order{})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsZeroAcceptedQuantity(t *testing.T) {
+	zero := num.Quantity{}
+	_, err := NewOrder(Order{
+		Request:          mustRequest(t),
+		AcceptedQuantity: &zero,
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsFilledQuantityWithoutAcceptedQuantity(t *testing.T) {
+	_, err := NewOrder(Order{
+		Request:        mustRequest(t),
+		FilledQuantity: num.MustParseQuantity("100"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsAcceptedPricesWithoutAcceptedQuantity(t *testing.T) {
+	_, err := NewOrder(Order{
+		Request:            mustRequest(t),
+		AcceptedLimitPrice: price(t, "1.10000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsFilledQuantityExceedingAcceptedQuantity(t *testing.T) {
+	accepted := num.MustParseQuantity("1000")
+	_, err := NewOrder(Order{
+		Request:          mustRequest(t),
+		AcceptedQuantity: &accepted,
+		FilledQuantity:   num.MustParseQuantity("1000.00000001"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderAllowsFullyFilled(t *testing.T) {
+	accepted := num.MustParseQuantity("1000")
+	o, err := NewOrder(Order{
+		Request:          mustRequest(t),
+		AcceptedQuantity: &accepted,
+		FilledQuantity:   num.MustParseQuantity("1000"),
+		Status:           StatusFilled,
+	})
+	require.NoError(t, err)
+	remaining, err := o.RemainingQuantity()
+	require.NoError(t, err)
+	assert.True(t, remaining.IsZero())
+}
+
+func TestNewOrderRejectsWrongAcceptedPricePresenceForType(t *testing.T) {
+	proposal, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        Limit,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		LimitPrice:  price(t, "1.10000"),
+	})
+	require.NoError(t, err)
+	req, err := NewRequest(proposal, mustOrderID(t))
+	require.NoError(t, err)
+
+	accepted := num.MustParseQuantity("1000")
+	// A Limit order's accepted state must also carry an accepted limit
+	// price.
+	_, err = NewOrder(Order{
+		Request:          req,
+		AcceptedQuantity: &accepted,
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsAcceptedQuantityNotOnIncrement(t *testing.T) {
+	accepted := num.MustParseQuantity("1000.5")
+	_, err := NewOrder(Order{
+		Request:          mustRequest(t),
+		AcceptedQuantity: &accepted,
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsRejectedStatusWithoutRejection(t *testing.T) {
+	_, err := NewOrder(Order{
+		Request: mustRequest(t),
+		Status:  StatusRejected,
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsRejectionOnNonRejectedStatus(t *testing.T) {
+	_, err := NewOrder(Order{
+		Request:   mustRequest(t),
+		Status:    StatusWorking,
+		Rejection: &Rejection{Reason: ReasonMarketClosed},
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderAllowsRejectedWithRejection(t *testing.T) {
+	o, err := NewOrder(Order{
+		Request:   mustRequest(t),
+		Status:    StatusRejected,
+		Rejection: &Rejection{Reason: ReasonRiskRejected},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, o.Rejection)
+	assert.Equal(t, ReasonRiskRejected, o.Rejection.Reason)
+}
+
+func TestOrderRemainingQuantityRequiresAcceptance(t *testing.T) {
+	o, err := NewOrder(Order{
+		Request: mustRequest(t),
+		Status:  StatusPendingSubmit,
+	})
+	require.NoError(t, err)
+	_, err = o.RemainingQuantity()
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestOrderRemainingQuantityPartialFill(t *testing.T) {
+	accepted := num.MustParseQuantity("1000")
+	o, err := NewOrder(Order{
+		Request:          mustRequest(t),
+		AcceptedQuantity: &accepted,
+		FilledQuantity:   num.MustParseQuantity("400"),
+		Status:           StatusPartiallyFilled,
+	})
+	require.NoError(t, err)
+	remaining, err := o.RemainingQuantity()
+	require.NoError(t, err)
+	assert.True(t, remaining.Equal(num.MustParseQuantity("600")))
+}

--- a/order/order_test.go
+++ b/order/order_test.go
@@ -35,6 +35,63 @@ func TestNewOrderRejectsUnconstructedRequest(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidOrder)
 }
 
+// NewOrder must fully revalidate its embedded Request (and, through it,
+// the embedded Proposal), not merely trust it by provenance: Request's
+// exported fields let a caller build one as a bare struct literal,
+// bypassing both NewProposal and NewRequest entirely.
+func TestNewOrderRevalidatesRequestBuiltAsStructLiteral(t *testing.T) {
+	bypassed := Request{
+		Proposal: Proposal{
+			Listing: mustEurUsdListing(t),
+			// AccountID deliberately left zero.
+			Side:        Buy,
+			Type:        Market,
+			TimeInForce: GTC,
+			Quantity:    num.MustParseQuantity("1000"),
+		},
+		OrderID: mustOrderID(t),
+	}
+	_, err := NewOrder(Order{Request: bypassed})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsInvalidStatus(t *testing.T) {
+	_, err := NewOrder(Order{
+		Request: mustRequest(t),
+		Status:  Status(200),
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsWorkingStatusWithoutAcceptedQuantity(t *testing.T) {
+	_, err := NewOrder(Order{
+		Request: mustRequest(t),
+		Status:  StatusWorking,
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsPendingSubmitWithAcceptedQuantity(t *testing.T) {
+	accepted := num.MustParseQuantity("1000")
+	_, err := NewOrder(Order{
+		Request:          mustRequest(t),
+		AcceptedQuantity: &accepted,
+		Status:           StatusPendingSubmit,
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsRejectedWithAcceptedQuantity(t *testing.T) {
+	accepted := num.MustParseQuantity("1000")
+	_, err := NewOrder(Order{
+		Request:          mustRequest(t),
+		AcceptedQuantity: &accepted,
+		Status:           StatusRejected,
+		Rejection:        &Rejection{Reason: ReasonRiskRejected},
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
 func TestNewOrderRejectsZeroAcceptedQuantity(t *testing.T) {
 	zero := num.Quantity{}
 	_, err := NewOrder(Order{
@@ -126,10 +183,12 @@ func TestNewOrderRejectsRejectedStatusWithoutRejection(t *testing.T) {
 }
 
 func TestNewOrderRejectsRejectionOnNonRejectedStatus(t *testing.T) {
+	accepted := num.MustParseQuantity("1000")
 	_, err := NewOrder(Order{
-		Request:   mustRequest(t),
-		Status:    StatusWorking,
-		Rejection: &Rejection{Reason: ReasonMarketClosed},
+		Request:          mustRequest(t),
+		AcceptedQuantity: &accepted,
+		Status:           StatusWorking,
+		Rejection:        &Rejection{Reason: ReasonMarketClosed},
 	})
 	assert.ErrorIs(t, err, ErrInvalidOrder)
 }

--- a/order/ordertype.go
+++ b/order/ordertype.go
@@ -1,0 +1,57 @@
+package order
+
+import "fmt"
+
+// Type is an order's execution type.
+type Type uint8
+
+const (
+	typeUnset Type = iota
+	// Market executes immediately at the best available price; it
+	// carries no limit or stop price.
+	Market
+	// Limit executes at LimitPrice or better; it requires a limit price
+	// and carries no stop price.
+	Limit
+	// Stop becomes a market order once StopPrice trades; it requires a
+	// stop price and carries no limit price.
+	Stop
+	// StopLimit becomes a limit order once StopPrice trades; it
+	// requires both a stop price and a limit price.
+	StopLimit
+)
+
+// String returns a human-readable Type name.
+func (t Type) String() string {
+	switch t {
+	case Market:
+		return "market"
+	case Limit:
+		return "limit"
+	case Stop:
+		return "stop"
+	case StopLimit:
+		return "stop_limit"
+	default:
+		return fmt.Sprintf("Type(%d)", uint8(t))
+	}
+}
+
+func (t Type) valid() bool {
+	switch t {
+	case Market, Limit, Stop, StopLimit:
+		return true
+	default:
+		return false
+	}
+}
+
+// requiresLimitPrice reports whether t requires a non-nil limit price.
+func (t Type) requiresLimitPrice() bool {
+	return t == Limit || t == StopLimit
+}
+
+// requiresStopPrice reports whether t requires a non-nil stop price.
+func (t Type) requiresStopPrice() bool {
+	return t == Stop || t == StopLimit
+}

--- a/order/ordertype_test.go
+++ b/order/ordertype_test.go
@@ -1,0 +1,42 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypeString(t *testing.T) {
+	assert.Equal(t, "market", Market.String())
+	assert.Equal(t, "limit", Limit.String())
+	assert.Equal(t, "stop", Stop.String())
+	assert.Equal(t, "stop_limit", StopLimit.String())
+	assert.Contains(t, Type(200).String(), "200")
+}
+
+func TestTypeValid(t *testing.T) {
+	assert.True(t, Market.valid())
+	assert.True(t, Limit.valid())
+	assert.True(t, Stop.valid())
+	assert.True(t, StopLimit.valid())
+	assert.False(t, typeUnset.valid())
+	assert.False(t, Type(200).valid())
+}
+
+func TestTypeRequiredPrices(t *testing.T) {
+	cases := []struct {
+		typ                 Type
+		wantLimit, wantStop bool
+	}{
+		{Market, false, false},
+		{Limit, true, false},
+		{Stop, false, true},
+		{StopLimit, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.typ.String(), func(t *testing.T) {
+			assert.Equal(t, tc.wantLimit, tc.typ.requiresLimitPrice())
+			assert.Equal(t, tc.wantStop, tc.typ.requiresStopPrice())
+		})
+	}
+}

--- a/order/position.go
+++ b/order/position.go
@@ -1,0 +1,97 @@
+package order
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+)
+
+// PositionSide is a position's holding direction: Flat, Long, or Short.
+// It is deliberately a separate type from Side: an order Side is a
+// transaction direction (what an order does), while PositionSide is a
+// holding direction (what an account has), and Flat has no order-side
+// equivalent. Flat is PositionSide's zero value, so an unconstructed
+// Position is safely flat rather than silently long or short.
+type PositionSide uint8
+
+const (
+	// Flat means no net exposure.
+	Flat PositionSide = iota
+	// Long means net exposure is held via buying.
+	Long
+	// Short means net exposure is held via selling.
+	Short
+)
+
+// String returns a human-readable PositionSide name.
+func (s PositionSide) String() string {
+	switch s {
+	case Flat:
+		return "flat"
+	case Long:
+		return "long"
+	case Short:
+		return "short"
+	default:
+		return fmt.Sprintf("PositionSide(%d)", uint8(s))
+	}
+}
+
+func (s PositionSide) valid() bool {
+	switch s {
+	case Flat, Long, Short:
+		return true
+	default:
+		return false
+	}
+}
+
+// Position is one account's net exposure in one Listing: one net
+// position per account/listing pair, not a hedged or per-order
+// breakdown. Quantity is always non-negative; direction lives in Side,
+// matching the same convention num.Quantity itself uses.
+type Position struct {
+	AccountID id.AccountID
+	Listing   instrument.Listing
+	Side      PositionSide
+	// Quantity is the position's size. It must be zero when Side is
+	// Flat, and greater than zero otherwise.
+	Quantity num.Quantity
+	// AvgPrice is the position's volume-weighted average entry price.
+	// Nil when Side is Flat.
+	AvgPrice *num.Price
+}
+
+// NewPosition validates and returns a Position. AccountID must be
+// non-zero and Listing must be constructed. Side must be one of its
+// defined values. Quantity must be zero exactly when Side is Flat, and
+// AvgPrice must be nil exactly when Side is Flat.
+func NewPosition(p Position) (Position, error) {
+	if p.AccountID.IsZero() {
+		return Position{}, fmt.Errorf("%w: account id must be set", ErrInvalidPosition)
+	}
+	if p.Listing.InstrumentID().IsZero() {
+		return Position{}, fmt.Errorf("%w: listing must be constructed", ErrInvalidPosition)
+	}
+	if !p.Side.valid() {
+		return Position{}, fmt.Errorf("%w: invalid side %v", ErrInvalidPosition, p.Side)
+	}
+	if p.Side == Flat {
+		if !p.Quantity.IsZero() {
+			return Position{}, fmt.Errorf("%w: a flat position must have zero quantity", ErrInvalidPosition)
+		}
+		if p.AvgPrice != nil {
+			return Position{}, fmt.Errorf("%w: a flat position must not have an average price", ErrInvalidPosition)
+		}
+	} else {
+		if p.Quantity.IsZero() {
+			return Position{}, fmt.Errorf("%w: a %s position must have a positive quantity", ErrInvalidPosition, p.Side)
+		}
+		if p.AvgPrice == nil {
+			return Position{}, fmt.Errorf("%w: a %s position must have an average price", ErrInvalidPosition, p.Side)
+		}
+	}
+	return p, nil
+}

--- a/order/position_test.go
+++ b/order/position_test.go
@@ -1,0 +1,103 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPositionValidFlat(t *testing.T) {
+	p, err := NewPosition(Position{
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Flat,
+	})
+	require.NoError(t, err)
+	assert.True(t, p.Quantity.IsZero())
+	assert.Nil(t, p.AvgPrice)
+}
+
+func TestNewPositionValidLong(t *testing.T) {
+	p, err := NewPosition(Position{
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Long,
+		Quantity:  num.MustParseQuantity("1000"),
+		AvgPrice:  price(t, "1.10000"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, Long, p.Side)
+}
+
+func TestNewPositionRejectsZeroAccountID(t *testing.T) {
+	_, err := NewPosition(Position{Listing: mustEurUsdListing(t), Side: Flat})
+	assert.ErrorIs(t, err, ErrInvalidPosition)
+}
+
+func TestNewPositionRejectsUnconstructedListing(t *testing.T) {
+	_, err := NewPosition(Position{AccountID: mustAccountID(t), Side: Flat})
+	assert.ErrorIs(t, err, ErrInvalidPosition)
+}
+
+func TestNewPositionRejectsInvalidSide(t *testing.T) {
+	_, err := NewPosition(Position{
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      PositionSide(200),
+	})
+	assert.ErrorIs(t, err, ErrInvalidPosition)
+}
+
+func TestNewPositionRejectsFlatWithNonZeroQuantity(t *testing.T) {
+	_, err := NewPosition(Position{
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Flat,
+		Quantity:  num.MustParseQuantity("1"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidPosition)
+}
+
+func TestNewPositionRejectsFlatWithAvgPrice(t *testing.T) {
+	_, err := NewPosition(Position{
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Flat,
+		AvgPrice:  price(t, "1.10000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidPosition)
+}
+
+func TestNewPositionRejectsLongWithZeroQuantity(t *testing.T) {
+	_, err := NewPosition(Position{
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Long,
+		AvgPrice:  price(t, "1.10000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidPosition)
+}
+
+func TestNewPositionRejectsShortWithoutAvgPrice(t *testing.T) {
+	_, err := NewPosition(Position{
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Short,
+		Quantity:  num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidPosition)
+}
+
+func TestPositionSideString(t *testing.T) {
+	assert.Equal(t, "flat", Flat.String())
+	assert.Equal(t, "long", Long.String())
+	assert.Equal(t, "short", Short.String())
+	assert.Contains(t, PositionSide(200).String(), "200")
+}
+
+func TestPositionSideZeroValueIsFlat(t *testing.T) {
+	var s PositionSide
+	assert.Equal(t, Flat, s)
+}

--- a/order/prices.go
+++ b/order/prices.go
@@ -1,0 +1,52 @@
+package order
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+)
+
+// validatePricePresence reports an error unless limit and stop are
+// present exactly when t requires them: neither for Market, limit only
+// for Limit, stop only for Stop, both for StopLimit. It is shared by
+// Proposal's requested prices and Order's accepted prices so the two
+// stay consistent with each other.
+func validatePricePresence(t Type, limit, stop *num.Price) error {
+	if t.requiresLimitPrice() && limit == nil {
+		return fmt.Errorf("%s order requires a limit price", t)
+	}
+	if !t.requiresLimitPrice() && limit != nil {
+		return fmt.Errorf("%s order must not have a limit price", t)
+	}
+	if t.requiresStopPrice() && stop == nil {
+		return fmt.Errorf("%s order requires a stop price", t)
+	}
+	if !t.requiresStopPrice() && stop != nil {
+		return fmt.Errorf("%s order must not have a stop price", t)
+	}
+	return nil
+}
+
+// validatePriceAndQuantity reports an error if qty is not a positive
+// multiple of listing's quantity increment, or if a non-nil limit/stop
+// price is not an exact multiple of listing's tick size.
+func validatePriceAndQuantity(listing instrument.Listing, qty num.Quantity, limit, stop *num.Price) error {
+	if qty.IsZero() {
+		return fmt.Errorf("quantity must be greater than zero")
+	}
+	if err := listing.Spec().ValidateQuantity(qty); err != nil {
+		return err
+	}
+	if limit != nil {
+		if err := listing.Spec().ValidatePrice(*limit); err != nil {
+			return fmt.Errorf("limit price: %w", err)
+		}
+	}
+	if stop != nil {
+		if err := listing.Spec().ValidatePrice(*stop); err != nil {
+			return fmt.Errorf("stop price: %w", err)
+		}
+	}
+	return nil
+}

--- a/order/proposal.go
+++ b/order/proposal.go
@@ -1,0 +1,72 @@
+package order
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+)
+
+// Proposal is a concrete order candidate before risk approval: what
+// execution planning wants to submit, not yet validated against risk or
+// assigned a Trader order identity. See Request for the next stage.
+type Proposal struct {
+	// Listing is the venue-specific tradable instrument this proposal
+	// targets.
+	Listing instrument.Listing
+	// AccountID identifies the Trader-managed account this proposal
+	// would trade against.
+	AccountID id.AccountID
+	Side      Side
+	Type      Type
+	// TimeInForce controls how long the resulting order would remain
+	// eligible for execution.
+	TimeInForce TimeInForce
+	// Quantity is the requested order size. It must be greater than
+	// zero and a multiple of Listing's quantity increment.
+	Quantity num.Quantity
+	// LimitPrice is required for Limit and StopLimit, and must be nil
+	// otherwise.
+	LimitPrice *num.Price
+	// StopPrice is required for Stop and StopLimit, and must be nil
+	// otherwise.
+	StopPrice *num.Price
+	// ReduceOnly, when true, means this proposal may only reduce an
+	// existing position, never open or increase one.
+	ReduceOnly bool
+	// Metadata carries this proposal's correlation and causation
+	// context.
+	Metadata id.Metadata
+}
+
+// NewProposal validates and returns a Proposal. Listing must be a
+// constructed Listing; AccountID must be non-zero; Side, Type, and
+// TimeInForce must be one of their defined values; Quantity must be
+// positive and a multiple of Listing's quantity increment; LimitPrice
+// and StopPrice must be present or nil exactly as Type requires, and
+// when present must be exact multiples of Listing's tick size.
+func NewProposal(p Proposal) (Proposal, error) {
+	if p.Listing.InstrumentID().IsZero() {
+		return Proposal{}, fmt.Errorf("%w: listing must be constructed", ErrInvalidProposal)
+	}
+	if p.AccountID.IsZero() {
+		return Proposal{}, fmt.Errorf("%w: account id must be set", ErrInvalidProposal)
+	}
+	if !p.Side.valid() {
+		return Proposal{}, fmt.Errorf("%w: invalid side %v", ErrInvalidProposal, p.Side)
+	}
+	if !p.Type.valid() {
+		return Proposal{}, fmt.Errorf("%w: invalid type %v", ErrInvalidProposal, p.Type)
+	}
+	if !p.TimeInForce.valid() {
+		return Proposal{}, fmt.Errorf("%w: invalid time in force %v", ErrInvalidProposal, p.TimeInForce)
+	}
+	if err := validatePricePresence(p.Type, p.LimitPrice, p.StopPrice); err != nil {
+		return Proposal{}, fmt.Errorf("%w: %v", ErrInvalidProposal, err)
+	}
+	if err := validatePriceAndQuantity(p.Listing, p.Quantity, p.LimitPrice, p.StopPrice); err != nil {
+		return Proposal{}, fmt.Errorf("%w: %v", ErrInvalidProposal, err)
+	}
+	return p, nil
+}

--- a/order/proposal.go
+++ b/order/proposal.go
@@ -47,26 +47,39 @@ type Proposal struct {
 // and StopPrice must be present or nil exactly as Type requires, and
 // when present must be exact multiples of Listing's tick size.
 func NewProposal(p Proposal) (Proposal, error) {
-	if p.Listing.InstrumentID().IsZero() {
-		return Proposal{}, fmt.Errorf("%w: listing must be constructed", ErrInvalidProposal)
-	}
-	if p.AccountID.IsZero() {
-		return Proposal{}, fmt.Errorf("%w: account id must be set", ErrInvalidProposal)
-	}
-	if !p.Side.valid() {
-		return Proposal{}, fmt.Errorf("%w: invalid side %v", ErrInvalidProposal, p.Side)
-	}
-	if !p.Type.valid() {
-		return Proposal{}, fmt.Errorf("%w: invalid type %v", ErrInvalidProposal, p.Type)
-	}
-	if !p.TimeInForce.valid() {
-		return Proposal{}, fmt.Errorf("%w: invalid time in force %v", ErrInvalidProposal, p.TimeInForce)
-	}
-	if err := validatePricePresence(p.Type, p.LimitPrice, p.StopPrice); err != nil {
-		return Proposal{}, fmt.Errorf("%w: %v", ErrInvalidProposal, err)
-	}
-	if err := validatePriceAndQuantity(p.Listing, p.Quantity, p.LimitPrice, p.StopPrice); err != nil {
+	if err := checkProposal(p); err != nil {
 		return Proposal{}, fmt.Errorf("%w: %v", ErrInvalidProposal, err)
 	}
 	return p, nil
+}
+
+// checkProposal validates p's fields and returns a plain, unwrapped
+// error describing the first problem found, or nil. It is shared by
+// NewProposal and every later stage (NewRequest, NewOrder) that embeds a
+// Proposal, so a Proposal built as a bare struct literal — bypassing
+// NewProposal entirely — cannot slip an invalid value past a later
+// stage's constructor.
+func checkProposal(p Proposal) error {
+	if p.Listing.InstrumentID().IsZero() {
+		return fmt.Errorf("listing must be constructed")
+	}
+	if p.AccountID.IsZero() {
+		return fmt.Errorf("account id must be set")
+	}
+	if !p.Side.valid() {
+		return fmt.Errorf("invalid side %v", p.Side)
+	}
+	if !p.Type.valid() {
+		return fmt.Errorf("invalid type %v", p.Type)
+	}
+	if !p.TimeInForce.valid() {
+		return fmt.Errorf("invalid time in force %v", p.TimeInForce)
+	}
+	if err := validatePricePresence(p.Type, p.LimitPrice, p.StopPrice); err != nil {
+		return err
+	}
+	if err := validatePriceAndQuantity(p.Listing, p.Quantity, p.LimitPrice, p.StopPrice); err != nil {
+		return err
+	}
+	return nil
 }

--- a/order/proposal_test.go
+++ b/order/proposal_test.go
@@ -1,0 +1,208 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProposalValidMarket(t *testing.T) {
+	p, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        Market,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		Metadata:    id.Metadata{EventID: mustEventID(t)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, Market, p.Type)
+}
+
+func TestNewProposalValidLimit(t *testing.T) {
+	p, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        Limit,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		LimitPrice:  price(t, "1.10000"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, p.LimitPrice)
+}
+
+func TestNewProposalValidStopLimit(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Sell,
+		Type:        StopLimit,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		LimitPrice:  price(t, "1.09000"),
+		StopPrice:   price(t, "1.09500"),
+	})
+	require.NoError(t, err)
+}
+
+func TestNewProposalRejectsUnconstructedListing(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        Market,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsZeroAccountID(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		Side:        Buy,
+		Type:        Market,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsInvalidSide(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Type:        Market,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsInvalidType(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsInvalidTimeInForce(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:   mustEurUsdListing(t),
+		AccountID: mustAccountID(t),
+		Side:      Buy,
+		Type:      Market,
+		Quantity:  num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsZeroQuantity(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        Market,
+		TimeInForce: GTC,
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsMarketWithLimitPrice(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        Market,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		LimitPrice:  price(t, "1.10000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsLimitWithoutLimitPrice(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        Limit,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsStopWithoutStopPrice(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Sell,
+		Type:        Stop,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsLimitWithStopPrice(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        Limit,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		LimitPrice:  price(t, "1.10000"),
+		StopPrice:   price(t, "1.09000"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsStopPriceNotOnTick(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Sell,
+		Type:        Stop,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		StopPrice:   price(t, "1.09000123"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsQuantityNotOnIncrement(t *testing.T) {
+	// mustEurUsdListing's Spec has a quantity increment of 1.
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        Market,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000.5"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}
+
+func TestNewProposalRejectsPriceNotOnTick(t *testing.T) {
+	_, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        Limit,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		LimitPrice:  price(t, "1.10000123"),
+	})
+	assert.ErrorIs(t, err, ErrInvalidProposal)
+}

--- a/order/rejection.go
+++ b/order/rejection.go
@@ -1,0 +1,84 @@
+package order
+
+import "fmt"
+
+// RejectReason classifies why a broker declined an order, cancel, or
+// replace request. Like Status, it reflects external, broker-reported
+// information Trader cannot fully enumerate in advance, so it reserves
+// its zero value for ReasonUnknown rather than guessing or failing to
+// construct. The set of named reasons is expected to grow additively as
+// broker adapters are built; ReasonUnknown plus Rejection.BrokerCode
+// keeps every rejection representable even before its reason has a
+// dedicated case.
+type RejectReason uint8
+
+const (
+	// ReasonUnknown is RejectReason's zero value: an unrecognized or
+	// unclassified rejection.
+	ReasonUnknown RejectReason = iota
+	// ReasonInsufficientMargin means the account lacks the margin or
+	// buying power the order requires.
+	ReasonInsufficientMargin
+	// ReasonInvalidPrice means the requested price violates the
+	// listing's tick size or another price rule.
+	ReasonInvalidPrice
+	// ReasonInvalidQuantity means the requested quantity violates the
+	// listing's quantity increment or another size rule.
+	ReasonInvalidQuantity
+	// ReasonMarketClosed means the listing is not currently tradable.
+	ReasonMarketClosed
+	// ReasonUnsupportedOrderType means the broker or account does not
+	// support the requested Type/TimeInForce combination.
+	ReasonUnsupportedOrderType
+	// ReasonDuplicateOrderID means the broker already has an order for
+	// this OrderID (or its broker-native equivalent) on file.
+	ReasonDuplicateOrderID
+	// ReasonRiskRejected means Trader's own risk stage rejected the
+	// order before it reached a broker.
+	ReasonRiskRejected
+	// ReasonUnsupportedCapability means the request used a feature the
+	// broker or account does not support.
+	ReasonUnsupportedCapability
+)
+
+// String returns a human-readable RejectReason name.
+func (r RejectReason) String() string {
+	switch r {
+	case ReasonUnknown:
+		return "unknown"
+	case ReasonInsufficientMargin:
+		return "insufficient_margin"
+	case ReasonInvalidPrice:
+		return "invalid_price"
+	case ReasonInvalidQuantity:
+		return "invalid_quantity"
+	case ReasonMarketClosed:
+		return "market_closed"
+	case ReasonUnsupportedOrderType:
+		return "unsupported_order_type"
+	case ReasonDuplicateOrderID:
+		return "duplicate_order_id"
+	case ReasonRiskRejected:
+		return "risk_rejected"
+	case ReasonUnsupportedCapability:
+		return "unsupported_capability"
+	default:
+		return fmt.Sprintf("RejectReason(%d)", uint8(r))
+	}
+}
+
+// Rejection explains why a broker declined a request. BrokerCode
+// preserves the broker's own original rejection text even when Reason
+// can only be classified as ReasonUnknown, so information is never
+// silently dropped when Trader doesn't yet recognize a broker's specific
+// rejection vocabulary.
+type Rejection struct {
+	// Reason is Trader's classification of the rejection.
+	Reason RejectReason
+	// Detail is a human-readable explanation, Trader- or broker-
+	// authored.
+	Detail string
+	// BrokerCode is the broker's own rejection code or text, preserved
+	// verbatim for diagnostics and future reclassification.
+	BrokerCode string
+}

--- a/order/rejection_test.go
+++ b/order/rejection_test.go
@@ -1,0 +1,37 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRejectReasonZeroValueIsUnknown(t *testing.T) {
+	var r RejectReason
+	assert.Equal(t, ReasonUnknown, r)
+}
+
+func TestRejectReasonString(t *testing.T) {
+	cases := map[RejectReason]string{
+		ReasonUnknown:               "unknown",
+		ReasonInsufficientMargin:    "insufficient_margin",
+		ReasonInvalidPrice:          "invalid_price",
+		ReasonInvalidQuantity:       "invalid_quantity",
+		ReasonMarketClosed:          "market_closed",
+		ReasonUnsupportedOrderType:  "unsupported_order_type",
+		ReasonDuplicateOrderID:      "duplicate_order_id",
+		ReasonRiskRejected:          "risk_rejected",
+		ReasonUnsupportedCapability: "unsupported_capability",
+	}
+	for reason, want := range cases {
+		assert.Equal(t, want, reason.String())
+	}
+	assert.Contains(t, RejectReason(200).String(), "200")
+}
+
+func TestRejectionPreservesBrokerCodeEvenWhenUnknown(t *testing.T) {
+	r := Rejection{Reason: ReasonUnknown, BrokerCode: "MARKET_HALTED_XYZ", Detail: "unrecognized broker code"}
+	assert.Equal(t, ReasonUnknown, r.Reason)
+	assert.Equal(t, "MARKET_HALTED_XYZ", r.BrokerCode)
+	assert.Equal(t, "unrecognized broker code", r.Detail)
+}

--- a/order/replace.go
+++ b/order/replace.go
@@ -1,0 +1,62 @@
+package order
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+)
+
+// ReplaceRequest asks a broker to modify an existing order's quantity
+// and/or prices in place. As with CancelRequest, its Metadata.EventID
+// identifies this specific replace command rather than serving as a
+// reusable idempotency key across retries.
+type ReplaceRequest struct {
+	// OrderID identifies the order to replace.
+	OrderID id.OrderID
+	// NewQuantity, when non-nil, replaces the order's accepted
+	// quantity.
+	NewQuantity *num.Quantity
+	// NewLimitPrice, when non-nil, replaces the order's accepted limit
+	// price.
+	NewLimitPrice *num.Price
+	// NewStopPrice, when non-nil, replaces the order's accepted stop
+	// price.
+	NewStopPrice *num.Price
+	Metadata     id.Metadata
+}
+
+// NewReplaceRequest validates and returns a ReplaceRequest. OrderID must
+// be non-zero, and at least one of NewQuantity, NewLimitPrice, or
+// NewStopPrice must be set — otherwise there is nothing to replace.
+func NewReplaceRequest(r ReplaceRequest) (ReplaceRequest, error) {
+	if r.OrderID.IsZero() {
+		return ReplaceRequest{}, fmt.Errorf("%w: order id must be set", ErrInvalidReplaceRequest)
+	}
+	if r.NewQuantity == nil && r.NewLimitPrice == nil && r.NewStopPrice == nil {
+		return ReplaceRequest{}, fmt.Errorf("%w: at least one of NewQuantity, NewLimitPrice, or NewStopPrice must be set", ErrInvalidReplaceRequest)
+	}
+	return r, nil
+}
+
+// ReplaceResult reports the outcome of a ReplaceRequest.
+type ReplaceResult struct {
+	OrderID id.OrderID
+	// Status is the order's resulting status: typically StatusWorking
+	// with the new values in effect, but a replace can also be
+	// declined, in which case Rejection explains why.
+	Status Status
+	// Rejection explains why the replace could not be applied. Nil when
+	// the replace succeeded.
+	Rejection *Rejection
+	Metadata  id.Metadata
+}
+
+// NewReplaceResult validates and returns a ReplaceResult. OrderID must
+// be non-zero.
+func NewReplaceResult(r ReplaceResult) (ReplaceResult, error) {
+	if r.OrderID.IsZero() {
+		return ReplaceResult{}, fmt.Errorf("%w: order id must be set", ErrInvalidReplaceRequest)
+	}
+	return r, nil
+}

--- a/order/replace.go
+++ b/order/replace.go
@@ -28,13 +28,18 @@ type ReplaceRequest struct {
 
 // NewReplaceRequest validates and returns a ReplaceRequest. OrderID must
 // be non-zero, and at least one of NewQuantity, NewLimitPrice, or
-// NewStopPrice must be set — otherwise there is nothing to replace.
+// NewStopPrice must be set — otherwise there is nothing to replace. A
+// non-nil NewQuantity must be greater than zero, consistent with every
+// other quantity in this package's vocabulary.
 func NewReplaceRequest(r ReplaceRequest) (ReplaceRequest, error) {
 	if r.OrderID.IsZero() {
 		return ReplaceRequest{}, fmt.Errorf("%w: order id must be set", ErrInvalidReplaceRequest)
 	}
 	if r.NewQuantity == nil && r.NewLimitPrice == nil && r.NewStopPrice == nil {
 		return ReplaceRequest{}, fmt.Errorf("%w: at least one of NewQuantity, NewLimitPrice, or NewStopPrice must be set", ErrInvalidReplaceRequest)
+	}
+	if r.NewQuantity != nil && r.NewQuantity.IsZero() {
+		return ReplaceRequest{}, fmt.Errorf("%w: new quantity must be greater than zero", ErrInvalidReplaceRequest)
 	}
 	return r, nil
 }
@@ -56,7 +61,7 @@ type ReplaceResult struct {
 // be non-zero.
 func NewReplaceResult(r ReplaceResult) (ReplaceResult, error) {
 	if r.OrderID.IsZero() {
-		return ReplaceResult{}, fmt.Errorf("%w: order id must be set", ErrInvalidReplaceRequest)
+		return ReplaceResult{}, fmt.Errorf("%w: order id must be set", ErrInvalidReplaceResult)
 	}
 	return r, nil
 }

--- a/order/replace_test.go
+++ b/order/replace_test.go
@@ -1,0 +1,41 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewReplaceRequestValidQuantityOnly(t *testing.T) {
+	_, err := NewReplaceRequest(ReplaceRequest{OrderID: mustOrderID(t), NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+}
+
+func TestNewReplaceRequestValidPricesOnly(t *testing.T) {
+	_, err := NewReplaceRequest(ReplaceRequest{
+		OrderID:       mustOrderID(t),
+		NewLimitPrice: price(t, "1.10500"),
+	})
+	require.NoError(t, err)
+}
+
+func TestNewReplaceRequestRejectsZeroOrderID(t *testing.T) {
+	_, err := NewReplaceRequest(ReplaceRequest{NewQuantity: qty(t, "2000")})
+	assert.ErrorIs(t, err, ErrInvalidReplaceRequest)
+}
+
+func TestNewReplaceRequestRejectsNoChanges(t *testing.T) {
+	_, err := NewReplaceRequest(ReplaceRequest{OrderID: mustOrderID(t)})
+	assert.ErrorIs(t, err, ErrInvalidReplaceRequest)
+}
+
+func TestNewReplaceResultValid(t *testing.T) {
+	_, err := NewReplaceResult(ReplaceResult{OrderID: mustOrderID(t), Status: StatusWorking})
+	require.NoError(t, err)
+}
+
+func TestNewReplaceResultRejectsZeroOrderID(t *testing.T) {
+	_, err := NewReplaceResult(ReplaceResult{})
+	assert.ErrorIs(t, err, ErrInvalidReplaceRequest)
+}

--- a/order/replace_test.go
+++ b/order/replace_test.go
@@ -3,6 +3,7 @@ package order
 import (
 	"testing"
 
+	"github.com/rustyeddy/trader/num"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,5 +38,11 @@ func TestNewReplaceResultValid(t *testing.T) {
 
 func TestNewReplaceResultRejectsZeroOrderID(t *testing.T) {
 	_, err := NewReplaceResult(ReplaceResult{})
+	assert.ErrorIs(t, err, ErrInvalidReplaceResult)
+}
+
+func TestNewReplaceRequestRejectsZeroQuantity(t *testing.T) {
+	zero := num.Quantity{}
+	_, err := NewReplaceRequest(ReplaceRequest{OrderID: mustOrderID(t), NewQuantity: &zero})
 	assert.ErrorIs(t, err, ErrInvalidReplaceRequest)
 }

--- a/order/request.go
+++ b/order/request.go
@@ -1,0 +1,34 @@
+package order
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/id"
+)
+
+// Request is a Proposal that has been assigned a Trader order identity
+// and is ready for broker submission. OrderID doubles as the
+// idempotency key for that initial submission: a retried submission of
+// the same Request reuses the same OrderID, and a broker adapter dedupes
+// on it as the client order ID. This covers idempotency for creating the
+// order — a later cancel or replace against it is a separate command
+// with its own idempotency needs; see CancelRequest and ReplaceRequest.
+type Request struct {
+	Proposal
+	// OrderID is Trader's own identifier for the order this request
+	// would create.
+	OrderID id.OrderID
+}
+
+// NewRequest validates and returns a Request for proposal, which must
+// already be a validated Proposal (see NewProposal), and orderID, which
+// must be non-zero.
+func NewRequest(proposal Proposal, orderID id.OrderID) (Request, error) {
+	if proposal.Listing.InstrumentID().IsZero() {
+		return Request{}, fmt.Errorf("%w: proposal must be constructed", ErrInvalidRequest)
+	}
+	if orderID.IsZero() {
+		return Request{}, fmt.Errorf("%w: order id must be set", ErrInvalidRequest)
+	}
+	return Request{Proposal: proposal, OrderID: orderID}, nil
+}

--- a/order/request.go
+++ b/order/request.go
@@ -20,15 +20,28 @@ type Request struct {
 	OrderID id.OrderID
 }
 
-// NewRequest validates and returns a Request for proposal, which must
-// already be a validated Proposal (see NewProposal), and orderID, which
-// must be non-zero.
+// NewRequest validates and returns a Request for proposal and orderID.
+// proposal is fully revalidated against the same rules NewProposal
+// applies — not merely trusted by provenance — since Proposal's exported
+// fields let a caller build one as a bare struct literal, bypassing
+// NewProposal entirely. orderID must be non-zero.
 func NewRequest(proposal Proposal, orderID id.OrderID) (Request, error) {
-	if proposal.Listing.InstrumentID().IsZero() {
-		return Request{}, fmt.Errorf("%w: proposal must be constructed", ErrInvalidRequest)
+	r := Request{Proposal: proposal, OrderID: orderID}
+	if err := checkRequest(r); err != nil {
+		return Request{}, fmt.Errorf("%w: %v", ErrInvalidRequest, err)
 	}
-	if orderID.IsZero() {
-		return Request{}, fmt.Errorf("%w: order id must be set", ErrInvalidRequest)
+	return r, nil
+}
+
+// checkRequest validates r's fields, including its embedded Proposal,
+// and returns a plain, unwrapped error, or nil. Shared with NewOrder for
+// the same reason checkProposal is shared with NewRequest.
+func checkRequest(r Request) error {
+	if err := checkProposal(r.Proposal); err != nil {
+		return fmt.Errorf("proposal: %w", err)
 	}
-	return Request{Proposal: proposal, OrderID: orderID}, nil
+	if r.OrderID.IsZero() {
+		return fmt.Errorf("order id must be set")
+	}
+	return nil
 }

--- a/order/request_test.go
+++ b/order/request_test.go
@@ -1,0 +1,26 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRequestValid(t *testing.T) {
+	r, err := NewRequest(mustProposal(t), mustOrderID(t))
+	require.NoError(t, err)
+	assert.False(t, r.OrderID.IsZero())
+	assert.Equal(t, Market, r.Type, "proposal fields are promoted")
+}
+
+func TestNewRequestRejectsUnconstructedProposal(t *testing.T) {
+	_, err := NewRequest(Proposal{}, mustOrderID(t))
+	assert.ErrorIs(t, err, ErrInvalidRequest)
+}
+
+func TestNewRequestRejectsZeroOrderID(t *testing.T) {
+	_, err := NewRequest(mustProposal(t), id.OrderID{})
+	assert.ErrorIs(t, err, ErrInvalidRequest)
+}

--- a/order/request_test.go
+++ b/order/request_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,5 +23,22 @@ func TestNewRequestRejectsUnconstructedProposal(t *testing.T) {
 
 func TestNewRequestRejectsZeroOrderID(t *testing.T) {
 	_, err := NewRequest(mustProposal(t), id.OrderID{})
+	assert.ErrorIs(t, err, ErrInvalidRequest)
+}
+
+// NewRequest must fully revalidate its Proposal, not merely trust it by
+// provenance: Proposal's exported fields let a caller build one as a
+// bare struct literal, bypassing NewProposal entirely.
+func TestNewRequestRevalidatesProposalBuiltAsStructLiteral(t *testing.T) {
+	bypassed := Proposal{
+		Listing: mustEurUsdListing(t),
+		// AccountID deliberately left zero, which NewProposal would
+		// have rejected.
+		Side:        Buy,
+		Type:        Market,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+	}
+	_, err := NewRequest(bypassed, mustOrderID(t))
 	assert.ErrorIs(t, err, ErrInvalidRequest)
 }

--- a/order/side.go
+++ b/order/side.go
@@ -1,0 +1,32 @@
+package order
+
+import "fmt"
+
+// Side is the transaction direction of an order or fill: Buy or Sell.
+// Side is Trader-controlled, closed vocabulary — unlike Status or
+// RejectReason, nothing external reports a Side Trader doesn't already
+// know about, so there is no "unknown" sentinel; construction sites
+// reject anything outside the two defined values.
+type Side uint8
+
+const (
+	sideUnset Side = iota
+	Buy
+	Sell
+)
+
+// String returns a human-readable Side name.
+func (s Side) String() string {
+	switch s {
+	case Buy:
+		return "buy"
+	case Sell:
+		return "sell"
+	default:
+		return fmt.Sprintf("Side(%d)", uint8(s))
+	}
+}
+
+func (s Side) valid() bool {
+	return s == Buy || s == Sell
+}

--- a/order/side_test.go
+++ b/order/side_test.go
@@ -1,0 +1,25 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSideString(t *testing.T) {
+	assert.Equal(t, "buy", Buy.String())
+	assert.Equal(t, "sell", Sell.String())
+	assert.Contains(t, Side(200).String(), "200")
+}
+
+func TestSideValid(t *testing.T) {
+	assert.True(t, Buy.valid())
+	assert.True(t, Sell.valid())
+	assert.False(t, sideUnset.valid())
+	assert.False(t, Side(200).valid())
+}
+
+func TestSideZeroValueIsInvalid(t *testing.T) {
+	var s Side
+	assert.False(t, s.valid())
+}

--- a/order/status.go
+++ b/order/status.go
@@ -1,0 +1,78 @@
+package order
+
+import "fmt"
+
+// Status is an Order's broker-reported lifecycle state. Unlike Side,
+// Type, and TimeInForce — closed vocabulary Trader itself controls —
+// Status reflects what a broker reports back, so it reserves its zero
+// value for StatusUnknown rather than defaulting to something
+// permissive: an adapter parsing an unrecognized broker status string
+// produces StatusUnknown instead of guessing or crashing, and an
+// uninitialized Status can never be silently mistaken for a working or
+// filled order.
+//
+// This package defines Status's values only. Which transitions between
+// them are legal — Working -> Filled, Canceled being terminal, and so
+// on — is issue #29 (M1-11)'s responsibility, not this package's.
+type Status uint8
+
+const (
+	// StatusUnknown is Status's zero value: an unrecognized or not-yet-
+	// determined state.
+	StatusUnknown Status = iota
+	// StatusPendingSubmit means Trader has built the order but it has
+	// not yet been acknowledged by a broker.
+	StatusPendingSubmit
+	// StatusWorking means the broker has accepted the order and it is
+	// eligible for execution.
+	StatusWorking
+	// StatusPartiallyFilled means the broker has accepted the order and
+	// executed part, but not all, of its accepted quantity.
+	StatusPartiallyFilled
+	// StatusFilled means the order's entire accepted quantity has
+	// executed. This is a terminal state.
+	StatusFilled
+	// StatusPendingCancel means a cancel request has been submitted but
+	// not yet confirmed by the broker.
+	StatusPendingCancel
+	// StatusCanceled means the broker confirmed the order was canceled
+	// before it fully filled. This is a terminal state.
+	StatusCanceled
+	// StatusPendingReplace means a replace request has been submitted
+	// but not yet confirmed by the broker.
+	StatusPendingReplace
+	// StatusRejected means the broker declined the order outright; see
+	// Order.Rejection for why. This is a terminal state.
+	StatusRejected
+	// StatusExpired means the order's TimeInForce elapsed before it
+	// fully filled. This is a terminal state.
+	StatusExpired
+)
+
+// String returns a human-readable Status name.
+func (s Status) String() string {
+	switch s {
+	case StatusUnknown:
+		return "unknown"
+	case StatusPendingSubmit:
+		return "pending_submit"
+	case StatusWorking:
+		return "working"
+	case StatusPartiallyFilled:
+		return "partially_filled"
+	case StatusFilled:
+		return "filled"
+	case StatusPendingCancel:
+		return "pending_cancel"
+	case StatusCanceled:
+		return "canceled"
+	case StatusPendingReplace:
+		return "pending_replace"
+	case StatusRejected:
+		return "rejected"
+	case StatusExpired:
+		return "expired"
+	default:
+		return fmt.Sprintf("Status(%d)", uint8(s))
+	}
+}

--- a/order/status.go
+++ b/order/status.go
@@ -76,3 +76,43 @@ func (s Status) String() string {
 		return fmt.Sprintf("Status(%d)", uint8(s))
 	}
 }
+
+// valid reports whether s is one of Status's defined values, including
+// StatusUnknown: unlike Side/Type/TimeInForce's zero value, StatusUnknown
+// is itself a legitimate, storable value for broker-reported state
+// Trader does not recognize — valid rejects only out-of-range values
+// such as Status(200).
+func (s Status) valid() bool {
+	switch s {
+	case StatusUnknown, StatusPendingSubmit, StatusWorking, StatusPartiallyFilled,
+		StatusFilled, StatusPendingCancel, StatusCanceled, StatusPendingReplace,
+		StatusRejected, StatusExpired:
+		return true
+	default:
+		return false
+	}
+}
+
+// requiresAcceptance reports whether s implies the broker has accepted
+// the order, and therefore that Order.AcceptedQuantity must be non-nil.
+func (s Status) requiresAcceptance() bool {
+	switch s {
+	case StatusWorking, StatusPartiallyFilled, StatusFilled, StatusPendingCancel,
+		StatusCanceled, StatusPendingReplace, StatusExpired:
+		return true
+	default:
+		return false
+	}
+}
+
+// precludesAcceptance reports whether s implies the broker has not (or
+// has not yet) accepted the order, and therefore that
+// Order.AcceptedQuantity must be nil.
+func (s Status) precludesAcceptance() bool {
+	switch s {
+	case StatusPendingSubmit, StatusRejected:
+		return true
+	default:
+		return false
+	}
+}

--- a/order/status_test.go
+++ b/order/status_test.go
@@ -1,0 +1,31 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusZeroValueIsUnknown(t *testing.T) {
+	var s Status
+	assert.Equal(t, StatusUnknown, s)
+}
+
+func TestStatusString(t *testing.T) {
+	cases := map[Status]string{
+		StatusUnknown:         "unknown",
+		StatusPendingSubmit:   "pending_submit",
+		StatusWorking:         "working",
+		StatusPartiallyFilled: "partially_filled",
+		StatusFilled:          "filled",
+		StatusPendingCancel:   "pending_cancel",
+		StatusCanceled:        "canceled",
+		StatusPendingReplace:  "pending_replace",
+		StatusRejected:        "rejected",
+		StatusExpired:         "expired",
+	}
+	for status, want := range cases {
+		assert.Equal(t, want, status.String())
+	}
+	assert.Contains(t, Status(200).String(), "200")
+}

--- a/order/status_test.go
+++ b/order/status_test.go
@@ -29,3 +29,33 @@ func TestStatusString(t *testing.T) {
 	}
 	assert.Contains(t, Status(200).String(), "200")
 }
+
+func TestStatusValid(t *testing.T) {
+	for _, s := range []Status{
+		StatusUnknown, StatusPendingSubmit, StatusWorking, StatusPartiallyFilled,
+		StatusFilled, StatusPendingCancel, StatusCanceled, StatusPendingReplace,
+		StatusRejected, StatusExpired,
+	} {
+		assert.True(t, s.valid(), "%s should be valid", s)
+	}
+	assert.False(t, Status(200).valid())
+}
+
+func TestStatusRequiresAcceptance(t *testing.T) {
+	for _, s := range []Status{
+		StatusWorking, StatusPartiallyFilled, StatusFilled, StatusPendingCancel,
+		StatusCanceled, StatusPendingReplace, StatusExpired,
+	} {
+		assert.True(t, s.requiresAcceptance(), "%s should require acceptance", s)
+	}
+	for _, s := range []Status{StatusUnknown, StatusPendingSubmit, StatusRejected} {
+		assert.False(t, s.requiresAcceptance(), "%s should not require acceptance", s)
+	}
+}
+
+func TestStatusPrecludesAcceptance(t *testing.T) {
+	assert.True(t, StatusPendingSubmit.precludesAcceptance())
+	assert.True(t, StatusRejected.precludesAcceptance())
+	assert.False(t, StatusUnknown.precludesAcceptance())
+	assert.False(t, StatusWorking.precludesAcceptance())
+}

--- a/order/timeinforce.go
+++ b/order/timeinforce.go
@@ -1,0 +1,51 @@
+package order
+
+import "fmt"
+
+// TimeInForce controls how long an order remains eligible for execution.
+//
+// GTD (good-til-date) is deliberately not included: it needs an
+// expiration field this package's initial scope does not call for.
+// Adding it later is additive, not a breaking change.
+type TimeInForce uint8
+
+const (
+	tifUnset TimeInForce = iota
+	// GTC (good-til-canceled) remains working until filled or
+	// explicitly canceled.
+	GTC
+	// DAY remains working only for the trading session it was
+	// submitted in.
+	DAY
+	// IOC (immediate-or-cancel) fills whatever quantity it can
+	// immediately and cancels the remainder.
+	IOC
+	// FOK (fill-or-kill) fills its entire quantity immediately or is
+	// canceled in full.
+	FOK
+)
+
+// String returns a human-readable TimeInForce name.
+func (f TimeInForce) String() string {
+	switch f {
+	case GTC:
+		return "gtc"
+	case DAY:
+		return "day"
+	case IOC:
+		return "ioc"
+	case FOK:
+		return "fok"
+	default:
+		return fmt.Sprintf("TimeInForce(%d)", uint8(f))
+	}
+}
+
+func (f TimeInForce) valid() bool {
+	switch f {
+	case GTC, DAY, IOC, FOK:
+		return true
+	default:
+		return false
+	}
+}

--- a/order/timeinforce_test.go
+++ b/order/timeinforce_test.go
@@ -1,0 +1,24 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeInForceString(t *testing.T) {
+	assert.Equal(t, "gtc", GTC.String())
+	assert.Equal(t, "day", DAY.String())
+	assert.Equal(t, "ioc", IOC.String())
+	assert.Equal(t, "fok", FOK.String())
+	assert.Contains(t, TimeInForce(200).String(), "200")
+}
+
+func TestTimeInForceValid(t *testing.T) {
+	assert.True(t, GTC.valid())
+	assert.True(t, DAY.valid())
+	assert.True(t, IOC.valid())
+	assert.True(t, FOK.valid())
+	assert.False(t, tifUnset.valid())
+	assert.False(t, TimeInForce(200).valid())
+}

--- a/order/trade.go
+++ b/order/trade.go
@@ -38,7 +38,10 @@ type Trade struct {
 // NewTrade validates and returns a Trade. AccountID must be non-zero,
 // Listing must be constructed, Side must be Long or Short (never Flat —
 // a trade with no direction has nothing to report), at least one entry
-// fill must be present, and OpenedAt must be non-zero.
+// fill must be present, and OpenedAt must be non-zero. If ClosedAt is
+// set, it must not precede OpenedAt; ClosedAt is not otherwise required
+// merely because ExitFillIDs is non-empty, since partial exits are
+// legitimate for a still-open trade.
 func NewTrade(t Trade) (Trade, error) {
 	if t.AccountID.IsZero() {
 		return Trade{}, fmt.Errorf("%w: account id must be set", ErrInvalidTrade)
@@ -64,6 +67,9 @@ func NewTrade(t Trade) (Trade, error) {
 	}
 	if t.OpenedAt.IsZero() {
 		return Trade{}, fmt.Errorf("%w: opened at must be set", ErrInvalidTrade)
+	}
+	if !t.ClosedAt.IsZero() && t.ClosedAt.Before(t.OpenedAt) {
+		return Trade{}, fmt.Errorf("%w: closed at must not precede opened at", ErrInvalidTrade)
 	}
 	return t, nil
 }

--- a/order/trade.go
+++ b/order/trade.go
@@ -1,0 +1,69 @@
+package order
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+)
+
+// Trade is a derived reporting concept grouping the entry and exit fills
+// of one round-trip position, distinct from a broker's own notion of an
+// order or execution. Trade deliberately has no first-class identity in
+// this package: it can be recalculated, revised, or represented across
+// multiple journal events as fills continue to arrive, unlike an EventID
+// or FillID, which identifies one immutable event. A dedicated TradeID
+// is additive future work if M5's journal/report work later finds that
+// insufficient — not introduced speculatively here.
+type Trade struct {
+	AccountID id.AccountID
+	Listing   instrument.Listing
+	// Side is the trade's holding direction while it was open.
+	Side PositionSide
+	// EntryFillIDs are the fills that opened or added to the position.
+	EntryFillIDs []id.FillID
+	// ExitFillIDs are the fills that reduced or closed the position.
+	ExitFillIDs []id.FillID
+	// OpenedAt is the timestamp of the first entry fill.
+	OpenedAt time.Time
+	// ClosedAt is the timestamp of the last exit fill. It is the zero
+	// time for a trade that has not fully closed.
+	ClosedAt time.Time
+	// RealizedPnL is this trade's realized profit or loss so far.
+	RealizedPnL num.Money
+}
+
+// NewTrade validates and returns a Trade. AccountID must be non-zero,
+// Listing must be constructed, Side must be Long or Short (never Flat —
+// a trade with no direction has nothing to report), at least one entry
+// fill must be present, and OpenedAt must be non-zero.
+func NewTrade(t Trade) (Trade, error) {
+	if t.AccountID.IsZero() {
+		return Trade{}, fmt.Errorf("%w: account id must be set", ErrInvalidTrade)
+	}
+	if t.Listing.InstrumentID().IsZero() {
+		return Trade{}, fmt.Errorf("%w: listing must be constructed", ErrInvalidTrade)
+	}
+	if t.Side != Long && t.Side != Short {
+		return Trade{}, fmt.Errorf("%w: side must be long or short, got %v", ErrInvalidTrade, t.Side)
+	}
+	if len(t.EntryFillIDs) == 0 {
+		return Trade{}, fmt.Errorf("%w: at least one entry fill is required", ErrInvalidTrade)
+	}
+	for _, fillID := range t.EntryFillIDs {
+		if fillID.IsZero() {
+			return Trade{}, fmt.Errorf("%w: entry fill ids must be non-zero", ErrInvalidTrade)
+		}
+	}
+	for _, fillID := range t.ExitFillIDs {
+		if fillID.IsZero() {
+			return Trade{}, fmt.Errorf("%w: exit fill ids must be non-zero", ErrInvalidTrade)
+		}
+	}
+	if t.OpenedAt.IsZero() {
+		return Trade{}, fmt.Errorf("%w: opened at must be set", ErrInvalidTrade)
+	}
+	return t, nil
+}

--- a/order/trade_test.go
+++ b/order/trade_test.go
@@ -101,6 +101,31 @@ func TestNewTradeRejectsZeroExitFillID(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidTrade)
 }
 
+func TestNewTradeRejectsClosedAtBeforeOpenedAt(t *testing.T) {
+	opened := time.Now()
+	_, err := NewTrade(Trade{
+		AccountID:    mustAccountID(t),
+		Listing:      mustEurUsdListing(t),
+		Side:         Long,
+		EntryFillIDs: []id.FillID{mustFillID(t)},
+		OpenedAt:     opened,
+		ClosedAt:     opened.Add(-time.Hour),
+	})
+	assert.ErrorIs(t, err, ErrInvalidTrade)
+}
+
+func TestNewTradeAllowsOpenTradeWithPartialExitFillsAndNoClosedAt(t *testing.T) {
+	_, err := NewTrade(Trade{
+		AccountID:    mustAccountID(t),
+		Listing:      mustEurUsdListing(t),
+		Side:         Long,
+		EntryFillIDs: []id.FillID{mustFillID(t)},
+		ExitFillIDs:  []id.FillID{mustFillID(t)},
+		OpenedAt:     time.Now(),
+	})
+	require.NoError(t, err)
+}
+
 func TestNewTradeRejectsZeroOpenedAt(t *testing.T) {
 	_, err := NewTrade(Trade{
 		AccountID:    mustAccountID(t),

--- a/order/trade_test.go
+++ b/order/trade_test.go
@@ -1,0 +1,112 @@
+package order
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTradeValidOpen(t *testing.T) {
+	tr, err := NewTrade(Trade{
+		AccountID:    mustAccountID(t),
+		Listing:      mustEurUsdListing(t),
+		Side:         Long,
+		EntryFillIDs: []id.FillID{mustFillID(t)},
+		OpenedAt:     time.Now(),
+		RealizedPnL:  num.MustParseMoney("0", num.MustParseCurrency("USD")),
+	})
+	require.NoError(t, err)
+	assert.True(t, tr.ClosedAt.IsZero(), "still open")
+}
+
+func TestNewTradeValidClosed(t *testing.T) {
+	_, err := NewTrade(Trade{
+		AccountID:    mustAccountID(t),
+		Listing:      mustEurUsdListing(t),
+		Side:         Short,
+		EntryFillIDs: []id.FillID{mustFillID(t)},
+		ExitFillIDs:  []id.FillID{mustFillID(t)},
+		OpenedAt:     time.Now(),
+		ClosedAt:     time.Now(),
+		RealizedPnL:  num.MustParseMoney("125.50", num.MustParseCurrency("USD")),
+	})
+	require.NoError(t, err)
+}
+
+func TestNewTradeRejectsZeroAccountID(t *testing.T) {
+	_, err := NewTrade(Trade{
+		Listing:      mustEurUsdListing(t),
+		Side:         Long,
+		EntryFillIDs: []id.FillID{mustFillID(t)},
+		OpenedAt:     time.Now(),
+	})
+	assert.ErrorIs(t, err, ErrInvalidTrade)
+}
+
+func TestNewTradeRejectsUnconstructedListing(t *testing.T) {
+	_, err := NewTrade(Trade{
+		AccountID:    mustAccountID(t),
+		Side:         Long,
+		EntryFillIDs: []id.FillID{mustFillID(t)},
+		OpenedAt:     time.Now(),
+	})
+	assert.ErrorIs(t, err, ErrInvalidTrade)
+}
+
+func TestNewTradeRejectsFlatSide(t *testing.T) {
+	_, err := NewTrade(Trade{
+		AccountID:    mustAccountID(t),
+		Listing:      mustEurUsdListing(t),
+		Side:         Flat,
+		EntryFillIDs: []id.FillID{mustFillID(t)},
+		OpenedAt:     time.Now(),
+	})
+	assert.ErrorIs(t, err, ErrInvalidTrade)
+}
+
+func TestNewTradeRejectsNoEntryFills(t *testing.T) {
+	_, err := NewTrade(Trade{
+		AccountID: mustAccountID(t),
+		Listing:   mustEurUsdListing(t),
+		Side:      Long,
+		OpenedAt:  time.Now(),
+	})
+	assert.ErrorIs(t, err, ErrInvalidTrade)
+}
+
+func TestNewTradeRejectsZeroEntryFillID(t *testing.T) {
+	_, err := NewTrade(Trade{
+		AccountID:    mustAccountID(t),
+		Listing:      mustEurUsdListing(t),
+		Side:         Long,
+		EntryFillIDs: []id.FillID{{}},
+		OpenedAt:     time.Now(),
+	})
+	assert.ErrorIs(t, err, ErrInvalidTrade)
+}
+
+func TestNewTradeRejectsZeroExitFillID(t *testing.T) {
+	_, err := NewTrade(Trade{
+		AccountID:    mustAccountID(t),
+		Listing:      mustEurUsdListing(t),
+		Side:         Long,
+		EntryFillIDs: []id.FillID{mustFillID(t)},
+		ExitFillIDs:  []id.FillID{{}},
+		OpenedAt:     time.Now(),
+	})
+	assert.ErrorIs(t, err, ErrInvalidTrade)
+}
+
+func TestNewTradeRejectsZeroOpenedAt(t *testing.T) {
+	_, err := NewTrade(Trade{
+		AccountID:    mustAccountID(t),
+		Listing:      mustEurUsdListing(t),
+		Side:         Long,
+		EntryFillIDs: []id.FillID{mustFillID(t)},
+	})
+	assert.ErrorIs(t, err, ErrInvalidTrade)
+}


### PR DESCRIPTION
## Summary
- Adds a new `order` package: `Side`/`Type`/`TimeInForce` (closed, Trader-controlled vocabulary), `Status`/`RejectReason` (broker-reported, zero-value-safe `Unknown`), and the `Proposal` → `Request` → `Order` → `Fill` chain plus `CancelRequest`/`CancelResult`, `ReplaceRequest`/`ReplaceResult`, `Position`, and reporting `Trade`.
- Incorporates the design-review feedback posted on issue #28 before implementation began: `Order` now distinguishes requested (embedded `Request`) from broker-accepted values (`AcceptedQuantity`/`AcceptedLimitPrice`/`AcceptedStopPrice`), `RemainingQuantity` derives from accepted minus filled, `Fill` carries both `BrokerFillID` and its own `AccountID`, and `Trade` is documented as having no first-class identity yet (rather than borrowing `Metadata.EventID`).
- Reuses `id.OrderID`/`id.FillID`/`id.Metadata` and `num`'s exact types — no new `id` package kinds.
- Adds ADR-017 (Accepted) and an `order` README section.

## Why
Closes #28 (M1-10). Plan and design review were posted and resolved on the issue before implementation began; scope is explicitly drawn against #29 (M1-11), which owns order-state transition rules.

## How tested
- `make check` (fmt, vet, `go test -race ./...`) passes.
- `go test ./order/... -race -cover`: 100% coverage.
- `go doc`-style `Example` functions (`Example_proposalToRequest`, `ExampleOrder_RemainingQuantity`, `Example_unknownBrokerStatus`) verified by `go test`.

## Documentation changed
- `docs/arch/adr-decisions.org` (new ADR-017, Accepted)
- `README.md` (`order` section)
- `order/doc.go` (package doc comment)

https://claude.ai/code/session_01FsfxQH4YBP5DA1LpAafWyt