### PR TITLE
M1-11: order lifecycle transition rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,23 @@ See [ADR-017](docs/arch/adr-decisions.org) and the
 model, the idempotency-key scope, and why `Position`/`Trade` are shaped
 the way they are.
 
+`order` also validates lifecycle transitions: `Status.CanTransitionTo`
+is the legal transition graph, and named `Apply*` functions
+(`ApplyAcceptance`, `ApplyFill`, `ApplyCancelRequest`/`ApplyCancelResult`,
+`ApplyReplaceRequest`/`ApplyReplaceResult`, `ApplyExpiration`,
+`ApplyRejection`) apply one event to an `Order`, checking both the graph
+and that the event's identity actually matches the order:
+
+```go
+o, err = order.ApplyFill(o, fill) // rejects a Fill belonging to a different order
+```
+
+Redelivering an unchanged status is always a safe no-op; a duplicate
+`Fill` (by `BrokerFillID` or `FillID`) is detected and returns the order
+unchanged. See [ADR-018](docs/arch/adr-decisions.org) for the full
+transition graph, the in-place-amendment model for replace, and why
+`AvgFillPrice` is cleared rather than maintained.
+
 ## Documentation
 
 - [Framework requirements](docs/arch/trader-framework-requirements.org)

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -1036,7 +1036,13 @@ assumed adapters reuse the same Trader =FillID= across redelivery, the
 issue's "replaced/superseded" vocabulary not being modeled or explicitly
 decided against, =AvgFillPrice= being left to go stale after a fill, and
 a same-status-idempotent rule that conflicted with =StatusUnknown= never
-being a legal target.
+being a legal target.  A second review round on the resulting pull
+request found two further gaps: matching only =OrderID= does not prove a
+=CancelResult=/=ReplaceResult= belongs to the *currently outstanding*
+cancel/replace cycle rather than a delayed result from an earlier cycle
+on the same order, and treating "not rejected" as synonymous with
+"replace succeeded" let a non-rejected =Canceled= result apply the
+replace's new accepted terms immediately before canceling the order.
 
 ** Decision
 
@@ -1151,6 +1157,51 @@ example, "already filled"); =Order.Rejection= (ADR-017) means the
 invariant the moment a cancel is declined against, say, an already-
 =Filled= order.
 
+Matching =OrderID= alone does not prove a =CancelResult=/=ReplaceResult=
+belongs to the *currently outstanding* command: a delayed result from an
+earlier cancel/replace cycle on the same order could otherwise be
+misapplied during a later cycle.  =Order= gains a new
+=PendingCommandID id.EventID= field, set to the request's
+=Metadata.EventID= by =ApplyCancelRequest=/=ApplyReplaceRequest= and
+required, non-zero, on that request (=ErrIllegalTransition= otherwise,
+since without it nothing could ever correlate a later result).  Whenever
+=PendingCommandID= is set, =ApplyCancelResult=/=ApplyReplaceResult=
+require the result's =Metadata.CausationID= to match it exactly —
+=ErrStaleResult= otherwise, a new sentinel distinct from
+=ErrOrderMismatch= since the event does belong to this order, just not
+to its current command.  =PendingCommandID= is cleared whenever =Status=
+leaves =StatusPendingCancel=/=StatusPendingReplace=, including when
+=ApplyFill= overrides a pending cancel/replace with a complete fill.
+=NewOrder= enforces that =PendingCommandID= is non-zero exactly when
+=Status= is =StatusPendingCancel=/=StatusPendingReplace=, the same
+paired-field pattern ADR-017 already established for =AcceptedQuantity=
+and =Status=.
+
+Once =PendingCommandID= is unset — most notably after =ApplyFill= has
+already overridden a pending cancel/replace with a complete fill — there
+is no outstanding command left to correlate a result against.  In that
+case =ApplyCancelResult=/=ApplyReplaceResult= fall back to validating the
+result purely against the transition graph: a result whose =Status=
+matches the =Order='s current =Status= is accepted as an idempotent
+no-op (satisfying redelivery of the same broker confirmation after the
+order has already reached that state), while a result naming any other
+status is rejected as unreachable through the graph's existing terminal-
+state and adjacency rules.  This single mechanism resolves both review
+findings without their being in tension: correlation is enforced exactly
+while a command is genuinely outstanding, and idempotent redelivery is
+still safe once it is not.
+
+=ApplyReplaceResult= no longer infers "the replacement took effect" from
+=result.Rejection == nil= alone.  The new accepted values are applied
+only when =result.Rejection= is =nil= *and* =result.Status= is
+=StatusWorking= or =StatusPartiallyFilled= — the only two outcomes that
+actually mean the order remains live under the amended terms.  A
+non-rejected =StatusCanceled= or =StatusFilled= result still transitions
+=Order.Status=, but leaves =AcceptedQuantity=/=AcceptedLimitPrice=/
+=AcceptedStopPrice= untouched, since the order's life resolved a
+different way around the same time as the replace, and applying new
+terms first would misrepresent what actually happened.
+
 ** Consequences
 
 - Every lifecycle transition is validated against one shared graph,
@@ -1172,6 +1223,18 @@ invariant the moment a cancel is declined against, say, an already-
 - Reconciliation of out-of-order terminal events that skip the local
   pending-state step remains unimplemented and is explicitly deferred to
   the future =live= package.
+- Every =CancelRequest=/=ReplaceRequest= submitted through
+  =ApplyCancelRequest=/=ApplyReplaceRequest= must carry a non-zero
+  =Metadata.EventID=; a caller that omits it can never have its cancel
+  or replace applied, by design, since there would be nothing for the
+  eventual result to correlate against.
+- A caller cannot mistake a delayed result from an earlier cancel/
+  replace cycle on the same order for a result belonging to the current
+  cycle — =ErrStaleResult= makes that distinction explicit rather than
+  silently applying whichever result arrives first.
+- A non-rejected =Canceled=/=Filled= replace result no longer risks
+  silently amending accepted terms moments before the order's life ends
+  a different way.
 
 ** Alternatives Considered
 
@@ -1202,6 +1265,21 @@ invariant the moment a cancel is declined against, say, an already-
   review: it would implicitly discard a still-outstanding broker
   cancel/replace confirmation, which a later terminal event might still
   legitimately reference.
+- *Requiring =Order.Status= to remain exactly =StatusPendingCancel=/
+  =StatusPendingReplace= before =ApplyCancelResult=/=ApplyReplaceResult=
+  will accept anything.*  This was the original implementation, but a
+  PR review round showed it made a common race impossible to handle
+  correctly: once =ApplyFill= overrides a pending cancel/replace to
+  =StatusFilled=, a later matching confirmation for that same terminal
+  state would always fail with =ErrIllegalTransition= even though it is
+  exactly the redelivery the same-status idempotent rule is meant to
+  absorb.  Replaced with the =PendingCommandID=-based correlation check
+  plus a graph-only fallback once no command is outstanding.
+- *Correlating cancel/replace results by embedding the request itself on
+  =Order= instead of just its =Metadata.EventID=.*  Rejected as carrying
+  more state than the correlation check needs; a single
+  =id.EventID= is sufficient to detect a stale result and imposes no
+  obligation to keep a full, possibly-stale copy of the request around.
 
 * ADR Template                                                       :noexport:
 

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -83,6 +83,7 @@ believed at that time.
 | 014 | Paper trading is the safe default                                 | Accepted   |
 | 016 | Symbol and listing resolution                                     | Accepted   |
 | 017 | Broker-neutral order and execution vocabulary                     | Accepted   |
+| 018 | Order lifecycle transition rules                                  | Accepted   |
 
 * ADR-001: Modular monolith before service decomposition
 
@@ -1012,6 +1013,195 @@ for.
 - *Trusting an earlier stage's validity by constructor provenance
   alone.*  Rejected on review once it was shown a bare struct literal
   defeats it; see the shared-validator discussion above.
+
+* ADR-018: Order lifecycle transition rules
+
+** Status
+
+Accepted
+
+** Context
+
+ADR-017 defined =order.Status='s values but explicitly deferred which
+transitions between them are legal to issue #29 (M1-11), which depends
+on it.  Issue #29 required: a classifiable error for an illegal
+transition; filled quantity never exceeding accepted quantity; explicit,
+enforced terminal states; thoroughly tested partial-fill sequences;
+detectable-or-safely-idempotent duplicate application; and documented
+handling of out-of-order events — all without broker I/O, an execution
+manager, or a simulated broker.  A design review on the issue identified
+five gaps in the initial plan before implementation began: missing
+event/order identity verification, a duplicate-fill key that silently
+assumed adapters reuse the same Trader =FillID= across redelivery, the
+issue's "replaced/superseded" vocabulary not being modeled or explicitly
+decided against, =AvgFillPrice= being left to go stale after a fill, and
+a same-status-idempotent rule that conflicted with =StatusUnknown= never
+being a legal target.
+
+** Decision
+
+Lifecycle transitions live in the same =order= package as the M1-10
+vocabulary, in a new =transition.go=, rather than a new package — the
+rules operate directly on =order.Order=/=order.Status=, and M1-10's own
+=NewOrder= doc comment already assigned this responsibility to M1-11.
+
+=Status.CanTransitionTo(to Status) bool= is the transition graph:
+
+#+BEGIN_EXAMPLE
+PendingSubmit   -> Working, Rejected
+Working         -> PartiallyFilled, Filled, PendingCancel, PendingReplace, Expired
+PartiallyFilled -> Filled, PendingCancel, PendingReplace, Expired
+PendingCancel   -> Canceled, Working, PartiallyFilled, Filled
+PendingReplace  -> Working, PartiallyFilled, Filled, Canceled
+Filled, Canceled, Rejected, Expired -> (terminal: nothing)
+#+END_EXAMPLE
+
+=to == from= is always legal for any valid, known Status, including a
+terminal one — this is what makes redelivery of an unchanged status
+event a safe no-op rather than an error, matching the architecture
+document's at-least-once delivery assumption, and it is how duplicate
+*status* events are handled (duplicate *fills* are handled separately,
+below).  =StatusUnknown= is never a legal target, including
+=StatusUnknown -> StatusUnknown=: the same-status rule is stated as
+applying only to "valid, known" statuses specifically to resolve the
+conflict a design-review comment identified, keeping =Unknown='s
+safe-value-for-external-parsing role (ADR-017) separate from the
+validated lifecycle graph — an =Unknown= target signals "needs operator
+attention," not "safe to no-op."  Reaching =Canceled=, or a replace's
+resulting status, requires having passed through
+=PendingCancel=/=PendingReplace= first; there is no direct
+=Working -> Canceled= edge.  A terminal confirmation arriving without
+Trader ever having locally recorded the pending step is treated as an
+out-of-order event and rejected by the graph — reconciling that gap is a
+=live=-package concern, not this package's.  =Rejected= is reachable
+only from =PendingSubmit=, and =Expired= only from
+=Working=/=PartiallyFilled=, matching real broker semantics rather than
+leaving the graph permissive by default.
+
+Named functions apply one event to an =Order= each: =ApplyAcceptance=,
+=ApplyRejection=, =ApplyFill=, =ApplyCancelRequest=/=ApplyCancelResult=,
+=ApplyReplaceRequest=/=ApplyReplaceResult=, =ApplyExpiration=.  There is
+no generic =ApplyTransition=: each real transition carries its own
+associated data (a fill's quantity, a rejection reason, a replace's new
+terms), which a generic mutator would force callers to pre-populate
+correctly by convention rather than by the type system.  Every function
+that takes an external event (=Fill=, =CancelResult=, =ReplaceRequest=,
+=ReplaceResult=) verifies the event's identifying fields match the
+=Order= before applying it, reporting the new =ErrOrderMismatch= —
+distinct from =ErrIllegalTransition= — if they do not: =ApplyFill=
+checks =OrderID=, =AccountID=, =Listing=, =Side=, and (when both are
+non-empty) =BrokerOrderID=; the cancel/replace appliers check =OrderID=,
+and =ApplyReplaceResult= additionally checks that the supplied
+=ReplaceRequest= and =ReplaceResult= refer to the same order.  An event
+that belongs to a different order entirely is a more serious failure
+than an otherwise-valid but unreachable state change, so it gets its own
+sentinel.
+
+=ApplyFill= detects duplicate delivery of the same broker execution
+before accumulating: =fill.BrokerFillID= is checked first, against a new
+=Order.AppliedBrokerFillIDs= field, since an adapter is not guaranteed to
+reuse the same Trader =FillID= across redelivery of one broker
+execution, while broker state is architecturally authoritative (per the
+architecture document); =fill.FillID= against a new
+=Order.AppliedFillIDs= field is the fallback for adapters that do not
+report a =BrokerFillID=.  A detected duplicate returns the =Order=
+unchanged alongside the new =ErrDuplicateFill=, satisfying "detectable
+or safely idempotent" as both: detectable via =errors.Is=, but not a
+fatal error, since the returned =Order= remains valid and current.  Both
+fields are additive changes to M1-10's =order.go=; =NewOrder= rejects a
+zero or duplicate entry in either.
+
+Issue #29's "replaced/superseded" vocabulary is resolved as *in-place
+amendment*: a successful replace updates the same =Order='s
+=AcceptedQuantity=/=AcceptedLimitPrice=/=AcceptedStopPrice= fields and
+returns to =Working=/=PartiallyFilled=, under the same Trader =OrderID=
+throughout.  Trader does not model =Replaced=/=Superseded= as a
+persistent =Status= or give the amended order a new identity.  This
+choice is recorded explicitly, per the design review's request, rather
+than silently dropped: a cancel/replace-as-new-order model remains
+available as a future alternative if a broker's native behavior proves
+difficult to normalize into in-place amendment, but is not needed by any
+current adapter.
+
+A fill that exactly completes =AcceptedQuantity= moves an =Order= to
+=StatusFilled= regardless of its prior status, including
+=PendingCancel=/=PendingReplace= — there is nothing left to cancel or
+replace once an order is fully filled.  A *partial* fill arriving while
+a cancel or replace is pending instead preserves
+=PendingCancel=/=PendingReplace= rather than downgrading to
+=PartiallyFilled=, since the broker's pending confirmation may still
+arrive and should not be implicitly discarded by a race with a partial
+execution.
+
+=ApplyFill= clears =AvgFillPrice= to =nil= on every fill rather than
+compute or preserve it.  =num= has no Price-by-Quantity multiplication
+yet, so a correct quantity-weighted average cannot be maintained here
+without expanding =num='s API outside this issue's scope; the design
+review's alternative of adding the minimal needed operation was
+considered and deferred (see Alternatives Considered) in favor of making
+the gap explicit — a cleared field signals "not currently tracked,"
+where a stale value would look like a valid, false snapshot.
+
+=ApplyCancelResult= never copies =CancelResult.Rejection= into
+=Order.Rejection=: those are distinct concepts.
+=CancelResult.Rejection= explains why the *cancel* was declined (for
+example, "already filled"); =Order.Rejection= (ADR-017) means the
+*order* itself was declined and is non-nil exactly when =Status= is
+=StatusRejected= — copying one into the other would violate that
+invariant the moment a cancel is declined against, say, an already-
+=Filled= order.
+
+** Consequences
+
+- Every lifecycle transition is validated against one shared graph,
+  so backtest, paper, and future live adapters cannot each invent
+  slightly different transition rules.
+- A caller cannot accidentally apply one order's fill, cancel result, or
+  replace result to a different order — identity mismatches fail loudly
+  as =ErrOrderMismatch= rather than silently corrupting state.
+- Duplicate fill delivery is safe by default without requiring every
+  broker adapter to implement its own deduplication layer, as long as
+  the adapter reports either a stable =FillID= or a =BrokerFillID=.
+- =AvgFillPrice= is not usable from this package alone; any consumer
+  needing it must compute it elsewhere (or =num= must grow
+  Price-by-Quantity arithmetic first) until a later ADR revisits this.
+- In-place replace amendment means Trader never needs to track a
+  "superseded" order's lineage in M1, but an adapter for a broker whose
+  native replace semantics are closer to cancel-and-resubmit-as-new-order
+  must normalize that behavior into this model at the adapter boundary.
+- Reconciliation of out-of-order terminal events that skip the local
+  pending-state step remains unimplemented and is explicitly deferred to
+  the future =live= package.
+
+** Alternatives Considered
+
+- *One generic =ApplyTransition(o, to)=.*  Rejected: it would force
+  callers to hand-populate accepted values, rejections, and fill
+  quantities correctly before calling it, with no type-level help,
+  instead of each named function owning its own associated data.
+- *Deduplicating fills by Trader =FillID= alone.*  Rejected on design
+  review: it silently assumes an adapter always reuses the same
+  =FillID= for a redelivered broker execution, an unstated convention
+  this package cannot enforce.  Checking =BrokerFillID= first when
+  present removes that assumption.
+- *Modeling replace as cancel-and-resubmit, with the old order becoming
+  =Superseded= and the replacement getting its own identity.*  Considered
+  as the more broker-native model for some venues, but rejected for M1
+  as more machinery than currently needed; in-place amendment is
+  simpler and sufficient until a real adapter's behavior forces the
+  question.
+- *Adding the minimal Price-by-Quantity =num= operation now so
+  =AvgFillPrice= can be correctly maintained.*  Considered, per the
+  design review's stated preference, but deferred: it reopens =num='s
+  public API outside this issue's scope and dependency chain (M1-11
+  depends only on M1-10, =id=, and =num= as they exist today).  Clearing
+  the field is the safe interim choice; adding the operation is a
+  natural, separate follow-up.
+- *Allowing partial fills while =PendingCancel=/=PendingReplace= to
+  downgrade the status to =PartiallyFilled=.*  Rejected on design
+  review: it would implicitly discard a still-outstanding broker
+  cancel/replace confirmation, which a later terminal event might still
+  legitimately reference.
 
 * ADR Template                                                       :noexport:
 

--- a/order/doc.go
+++ b/order/doc.go
@@ -1,9 +1,9 @@
 // Package order defines Trader's broker-neutral order and execution
-// vocabulary, as decided by issue #28 (M1-10) and ADR-017. It defines
-// what these lifecycle concepts are and what makes one well-formed; it
-// does not implement order-state transition rules (Working -> Filled,
-// terminal-state enforcement, duplicate/out-of-order event handling —
-// see issue #29/M1-11), broker I/O, or an execution manager.
+// vocabulary (issue #28, M1-10, ADR-017) and its lifecycle transition
+// rules (issue #29, M1-11, ADR-018). It defines what these lifecycle
+// concepts are, what makes one well-formed, and which transitions
+// between them are legal; it does not implement broker I/O or an
+// execution manager.
 //
 // # The proposal-to-fill chain
 //
@@ -76,6 +76,71 @@
 // be recalculated or revised as fills continue to arrive — a dedicated
 // TradeID is additive future work if the journal/report milestones later
 // need one.
+//
+// # Lifecycle transitions
+//
+// Status.CanTransitionTo names the legal transition graph, and Terminal
+// names StatusFilled, StatusCanceled, StatusRejected, and StatusExpired
+// as states nothing follows. Named functions — ApplyAcceptance,
+// ApplyRejection, ApplyFill, ApplyCancelRequest/ApplyCancelResult,
+// ApplyReplaceRequest/ApplyReplaceResult, ApplyExpiration — apply one
+// event to an Order, each checking the graph and its own identity
+// requirements before mutating, then revalidating the result through
+// NewOrder. There is no single generic ApplyTransition: each real
+// transition carries its own associated data (a fill's quantity, a
+// rejection reason, a replace's new terms), which a generic mutator
+// would force callers to pre-populate correctly by convention instead of
+// by the type system.
+//
+// Two rules make redelivered and out-of-order events safe rather than
+// merely detected:
+//
+//   - Redelivering an unchanged Status (a broker resending "Filled" for
+//     an already-Filled Order) is always legal — CanTransitionTo(s, s)
+//     is true for every valid, known Status, including terminal ones.
+//     StatusUnknown is the one exception: it is never a legal target,
+//     not even from itself, since Unknown means "needs operator
+//     attention," not "safe to no-op."
+//   - Reaching StatusCanceled, or a replace's resulting status, requires
+//     having passed through StatusPendingCancel/StatusPendingReplace
+//     first. A terminal confirmation arriving without Trader ever having
+//     locally recorded the pending step is treated as an out-of-order
+//     event and rejected by the graph, not silently absorbed;
+//     reconciling that gap is a live-package concern.
+//
+// Every Apply* function that takes an external event (Fill, CancelResult,
+// ReplaceRequest, ReplaceResult) verifies the event's identifying fields
+// match the Order before applying it — ErrOrderMismatch, distinct from
+// ErrIllegalTransition, since an event that belongs to a different order
+// entirely is a more serious failure than an otherwise-valid but
+// unreachable state change.
+//
+// ApplyFill additionally detects duplicate delivery of the same broker
+// execution: fill.BrokerFillID is checked first, against
+// Order.AppliedBrokerFillIDs, since an adapter is not guaranteed to
+// reuse the same Trader FillID across redelivery of one broker
+// execution, while broker state is architecturally authoritative;
+// fill.FillID against Order.AppliedFillIDs is the fallback for adapters
+// that do not report a BrokerFillID. A detected duplicate returns the
+// Order unchanged alongside ErrDuplicateFill — detectable, but not
+// fatal.
+//
+// A partial fill arriving while a cancel or replace is pending preserves
+// StatusPendingCancel/StatusPendingReplace rather than downgrading to
+// StatusPartiallyFilled, since the broker's pending confirmation may
+// still arrive; only a fill that exactly completes AcceptedQuantity
+// overrides the pending status to StatusFilled, since there is nothing
+// left to cancel or replace once an order is fully filled.
+//
+// A successful replace amends Order in place — same Trader OrderID,
+// updated Accepted* fields — rather than modeling "replaced/superseded"
+// as a distinct persistent state or a new order identity; see ADR-018
+// for why.
+//
+// ApplyFill clears AvgFillPrice to nil on every fill rather than
+// maintain it: num has no Price-by-Quantity multiplication yet, and
+// leaving a stale average computed against an earlier, smaller
+// FilledQuantity would be a false snapshot.
 //
 // # Deferred
 //

--- a/order/doc.go
+++ b/order/doc.go
@@ -115,6 +115,21 @@
 // entirely is a more serious failure than an otherwise-valid but
 // unreachable state change.
 //
+// Matching OrderID is not enough to prove a CancelResult/ReplaceResult
+// belongs to the *currently outstanding* cancel/replace cycle: a delayed
+// result from an earlier cycle on the same order could otherwise be
+// misapplied during a later one. ApplyCancelRequest/ApplyReplaceRequest
+// record the request's Metadata.EventID as Order.PendingCommandID, and
+// ApplyCancelResult/ApplyReplaceResult require a result's
+// Metadata.CausationID to match it — ErrStaleResult otherwise — whenever
+// PendingCommandID is set. Once no command is outstanding (for example,
+// because ApplyFill already overrode a pending cancel/replace with a
+// complete fill), there is nothing left to correlate against, and the
+// result is validated purely against the transition graph instead: a
+// result matching the Order's current status is accepted as an
+// idempotent no-op, satisfying redelivery of the same confirmation,
+// while a result naming anything else is rejected as unreachable.
+//
 // ApplyFill additionally detects duplicate delivery of the same broker
 // execution: fill.BrokerFillID is checked first, against
 // Order.AppliedBrokerFillIDs, since an adapter is not guaranteed to
@@ -132,10 +147,16 @@
 // overrides the pending status to StatusFilled, since there is nothing
 // left to cancel or replace once an order is fully filled.
 //
-// A successful replace amends Order in place — same Trader OrderID,
-// updated Accepted* fields — rather than modeling "replaced/superseded"
-// as a distinct persistent state or a new order identity; see ADR-018
-// for why.
+// A replace result amends Order in place — same Trader OrderID, updated
+// Accepted* fields — rather than modeling "replaced/superseded" as a
+// distinct persistent state or a new order identity; see ADR-018 for
+// why. The amendment only applies when result.Rejection is nil AND
+// result.Status is StatusWorking or StatusPartiallyFilled: those are
+// the only outcomes that actually mean "the replacement took effect and
+// the order remains live." A non-rejected StatusCanceled or
+// StatusFilled result still transitions Order.Status, but leaves the
+// accepted values untouched, since the order's life resolved a
+// different way around the same time as the replace.
 //
 // ApplyFill clears AvgFillPrice to nil on every fill rather than
 // maintain it: num has no Price-by-Quantity multiplication yet, and

--- a/order/errors.go
+++ b/order/errors.go
@@ -42,4 +42,24 @@ var (
 	// ErrInvalidTrade reports a Trade constructor argument that fails
 	// validation.
 	ErrInvalidTrade = errors.New("order: invalid trade")
+
+	// ErrIllegalTransition reports an Apply* lifecycle function call
+	// whose requested Status is not reachable from the Order's current
+	// Status — see order/transition.go's transition graph.
+	ErrIllegalTransition = errors.New("order: illegal status transition")
+
+	// ErrOrderMismatch reports an Apply* lifecycle function called with
+	// an event (Fill, CancelResult, ReplaceRequest, ReplaceResult) whose
+	// identifying fields (OrderID, AccountID, Listing, Side,
+	// BrokerOrderID) do not match the Order it was applied to. This is
+	// distinct from ErrIllegalTransition: the requested state change
+	// might otherwise be legal, but the event does not belong to this
+	// order at all.
+	ErrOrderMismatch = errors.New("order: event does not match order identity")
+
+	// ErrDuplicateFill reports that ApplyFill was called with a Fill
+	// already recorded on the Order (by FillID or BrokerFillID). The
+	// returned Order is unchanged and remains valid; callers may treat
+	// this as a safe no-op rather than a fatal error.
+	ErrDuplicateFill = errors.New("order: fill already applied")
 )

--- a/order/errors.go
+++ b/order/errors.go
@@ -62,4 +62,13 @@ var (
 	// returned Order is unchanged and remains valid; callers may treat
 	// this as a safe no-op rather than a fatal error.
 	ErrDuplicateFill = errors.New("order: fill already applied")
+
+	// ErrStaleResult reports that ApplyCancelResult or ApplyReplaceResult
+	// was called with a result whose Metadata.CausationID does not match
+	// Order.PendingCommandID: the result does not correlate to the
+	// currently outstanding cancel/replace command, typically because it
+	// is a delayed result from an earlier cancel/replace cycle on the
+	// same order. This is distinct from ErrOrderMismatch, which means
+	// the event belongs to a different order entirely.
+	ErrStaleResult = errors.New("order: result does not correlate to the outstanding command")
 )

--- a/order/example_test.go
+++ b/order/example_test.go
@@ -145,3 +145,80 @@ func Example_unknownBrokerStatus() {
 	// working
 	// unknown
 }
+
+// Example_lifecycle walks an order from submission through acceptance
+// and two partial fills to StatusFilled, using the named Apply*
+// functions rather than setting Status directly.
+func Example_lifecycle() {
+	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(3, 4))
+	accountID, err := id.GenerateAccountID(g)
+	if err != nil {
+		panic(err)
+	}
+	listing := exampleListing()
+
+	proposal, err := order.NewProposal(order.Proposal{
+		Listing:     listing,
+		AccountID:   accountID,
+		Side:        order.Buy,
+		Type:        order.Market,
+		TimeInForce: order.GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+	})
+	if err != nil {
+		panic(err)
+	}
+	orderID, err := id.GenerateOrderID(g)
+	if err != nil {
+		panic(err)
+	}
+	request, err := order.NewRequest(proposal, orderID)
+	if err != nil {
+		panic(err)
+	}
+	o, err := order.NewOrder(order.Order{Request: request, Status: order.StatusPendingSubmit})
+	if err != nil {
+		panic(err)
+	}
+
+	o, err = order.ApplyAcceptance(o, "broker-order-1", num.MustParseQuantity("1000"), nil, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	fill := func(quantity string) order.Fill {
+		fillID, ferr := id.GenerateFillID(g)
+		if ferr != nil {
+			panic(ferr)
+		}
+		f, ferr := order.NewFill(order.Fill{
+			FillID:        fillID,
+			OrderID:       o.Request.OrderID,
+			BrokerOrderID: o.BrokerOrderID,
+			AccountID:     o.Request.AccountID,
+			Listing:       listing,
+			Side:          o.Request.Side,
+			Price:         num.MustParsePrice("1.10000"),
+			Quantity:      num.MustParseQuantity(quantity),
+		})
+		if ferr != nil {
+			panic(ferr)
+		}
+		return f
+	}
+
+	o, err = order.ApplyFill(o, fill("400"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(o.Status, o.FilledQuantity)
+
+	o, err = order.ApplyFill(o, fill("600"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(o.Status, o.FilledQuantity)
+	// Output:
+	// partially_filled 400
+	// filled 1000
+}

--- a/order/helpers_test.go
+++ b/order/helpers_test.go
@@ -157,6 +157,21 @@ func mustFillFor(t *testing.T, o Order, quantity string) Fill {
 	return f
 }
 
+// mustCommandMetadata returns Metadata for a new CancelRequest/
+// ReplaceRequest, with a fresh non-zero EventID that ApplyCancelRequest/
+// ApplyReplaceRequest will record as the order's PendingCommandID.
+func mustCommandMetadata(t *testing.T) id.Metadata {
+	t.Helper()
+	return id.Metadata{EventID: mustEventID(t)}
+}
+
+// resultMetadataFor returns Metadata for a CancelResult/ReplaceResult
+// that correlates to o's currently outstanding command
+// (o.PendingCommandID), as ApplyCancelResult/ApplyReplaceResult require.
+func resultMetadataFor(o Order) id.Metadata {
+	return id.Metadata{CausationID: o.PendingCommandID}
+}
+
 func price(t *testing.T, s string) *num.Price {
 	t.Helper()
 	p := num.MustParsePrice(s)

--- a/order/helpers_test.go
+++ b/order/helpers_test.go
@@ -11,8 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// sharedTestGenerator is package-level and reused across every helper
+// call in this package's tests: a Deterministic entropy source combined
+// with a Simulated clock that never advances only produces distinct
+// values across successive Generate calls on the *same* Generator — a
+// fresh Generator per call would replay the identical first value every
+// time, silently making every "distinct" test fixture equal.
+var sharedTestGenerator = id.NewGenerator(clock.NewSimulated(time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)), id.NewDeterministic(1, 2))
+
 func testGenerator() *id.Generator {
-	return id.NewGenerator(clock.NewSimulated(time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)), id.NewDeterministic(1, 2))
+	return sharedTestGenerator
 }
 
 func mustOrderID(t *testing.T) id.OrderID {
@@ -58,6 +66,27 @@ func mustEurUsdListing(t *testing.T) instrument.Listing {
 	return listing
 }
 
+func instrumentEquityListing(t *testing.T) (instrument.Listing, error) {
+	t.Helper()
+	inst, err := instrument.NewEquity("NASDAQ", "AAPL")
+	require.NoError(t, err)
+	spec, err := instrument.NewSpec(
+		num.MustParsePrice("0.01"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		num.MustParseCurrency("USD"),
+	)
+	require.NoError(t, err)
+	return instrument.NewListing(instrument.ListingParams{
+		Instrument: inst,
+		Provider:   "IBKR",
+		Venue:      "NASDAQ",
+		Symbol:     "AAPL",
+		Spec:       spec,
+		Tradable:   true,
+	})
+}
+
 func mustProposal(t *testing.T) Proposal {
 	t.Helper()
 	p, err := NewProposal(Proposal{
@@ -85,6 +114,47 @@ func mustRequest(t *testing.T) Request {
 	r, err := NewRequest(mustProposal(t), mustOrderID(t))
 	require.NoError(t, err)
 	return r
+}
+
+func mustPendingSubmitOrder(t *testing.T) Order {
+	t.Helper()
+	o, err := NewOrder(Order{
+		Request: mustRequest(t),
+		Status:  StatusPendingSubmit,
+	})
+	require.NoError(t, err)
+	return o
+}
+
+func mustWorkingOrder(t *testing.T, quantity string) Order {
+	t.Helper()
+	accepted := num.MustParseQuantity(quantity)
+	o, err := NewOrder(Order{
+		Request:          mustRequest(t),
+		BrokerOrderID:    "broker-order-1",
+		AcceptedQuantity: &accepted,
+		Status:           StatusWorking,
+	})
+	require.NoError(t, err)
+	return o
+}
+
+// mustFillFor builds a Fill whose identifying fields match o, so it
+// passes ApplyFill's identity checks.
+func mustFillFor(t *testing.T, o Order, quantity string) Fill {
+	t.Helper()
+	f, err := NewFill(Fill{
+		FillID:        mustFillID(t),
+		OrderID:       o.Request.OrderID,
+		BrokerOrderID: o.BrokerOrderID,
+		AccountID:     o.Request.AccountID,
+		Listing:       o.Request.Listing,
+		Side:          o.Request.Side,
+		Price:         num.MustParsePrice("1.10000"),
+		Quantity:      num.MustParseQuantity(quantity),
+	})
+	require.NoError(t, err)
+	return f
 }
 
 func price(t *testing.T, s string) *num.Price {

--- a/order/order.go
+++ b/order/order.go
@@ -36,6 +36,17 @@ type Order struct {
 	AcceptedStopPrice *num.Price
 
 	Status Status
+	// PendingCommandID identifies the CancelRequest or ReplaceRequest
+	// (by its Metadata.EventID) currently outstanding while Status is
+	// StatusPendingCancel or StatusPendingReplace; the zero value
+	// otherwise. ApplyCancelResult/ApplyReplaceResult require a result
+	// to correlate to this exact command before applying it, so a stale
+	// result from an earlier cancel/replace cycle on this same order
+	// cannot be mistaken for the currently outstanding one. Cleared
+	// whenever Status leaves StatusPendingCancel/StatusPendingReplace,
+	// including when ApplyFill overrides a pending cancel/replace with
+	// a complete fill.
+	PendingCommandID id.EventID
 	// FilledQuantity is the cumulative quantity executed so far. It can
 	// only be non-zero once AcceptedQuantity is set, and never exceeds
 	// it.
@@ -127,6 +138,14 @@ func NewOrder(o Order) (Order, error) {
 	}
 	if o.Status != StatusRejected && o.Rejection != nil {
 		return Order{}, fmt.Errorf("%w: only a rejected order may carry a Rejection", ErrInvalidOrder)
+	}
+
+	pending := o.Status == StatusPendingCancel || o.Status == StatusPendingReplace
+	if pending && o.PendingCommandID.IsZero() {
+		return Order{}, fmt.Errorf("%w: status %s requires a PendingCommandID", ErrInvalidOrder, o.Status)
+	}
+	if !pending && !o.PendingCommandID.IsZero() {
+		return Order{}, fmt.Errorf("%w: PendingCommandID requires status StatusPendingCancel or StatusPendingReplace, got %s", ErrInvalidOrder, o.Status)
 	}
 
 	if err := checkNoDuplicateFillIDs(o.AppliedFillIDs); err != nil {

--- a/order/order.go
+++ b/order/order.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rustyeddy/trader/id"
 	"github.com/rustyeddy/trader/num"
 )
 
@@ -39,12 +40,29 @@ type Order struct {
 	// only be non-zero once AcceptedQuantity is set, and never exceeds
 	// it.
 	FilledQuantity num.Quantity
-	// AvgFillPrice is the quantity-weighted average price across all
-	// fills so far. Nil until the first fill.
+	// AvgFillPrice is reserved for a quantity-weighted average price
+	// across all fills so far, but is not currently maintained by
+	// ApplyFill (see order/transition.go): num has no Price-by-Quantity
+	// multiplication yet, so ApplyFill clears this to nil on every fill
+	// rather than let it silently go stale relative to FilledQuantity.
 	AvgFillPrice *num.Price
 	// Rejection explains why the broker declined this order. Non-nil
 	// exactly when Status is StatusRejected.
 	Rejection *Rejection
+
+	// AppliedFillIDs records every Fill.FillID already applied via
+	// ApplyFill, and AppliedBrokerFillIDs every non-empty
+	// Fill.BrokerFillID, so a redelivered fill can be detected as a
+	// duplicate and safely ignored rather than double-counted. Broker
+	// execution identity (BrokerFillID) is checked first, since an
+	// adapter is not guaranteed to reuse the same Trader FillID across
+	// redelivery of the same broker execution, while broker state is
+	// architecturally authoritative; Trader's own FillID is the
+	// fallback for adapters that do not report a BrokerFillID. Both are
+	// maintained only by ApplyFill; NewOrder does not otherwise
+	// interpret them beyond rejecting duplicate or zero entries.
+	AppliedFillIDs       []id.FillID
+	AppliedBrokerFillIDs []string
 
 	// UpdatedAt is when this Order value was last observed to change.
 	UpdatedAt time.Time
@@ -111,7 +129,42 @@ func NewOrder(o Order) (Order, error) {
 		return Order{}, fmt.Errorf("%w: only a rejected order may carry a Rejection", ErrInvalidOrder)
 	}
 
+	if err := checkNoDuplicateFillIDs(o.AppliedFillIDs); err != nil {
+		return Order{}, fmt.Errorf("%w: applied fill ids: %v", ErrInvalidOrder, err)
+	}
+	if err := checkNoDuplicateBrokerFillIDs(o.AppliedBrokerFillIDs); err != nil {
+		return Order{}, fmt.Errorf("%w: applied broker fill ids: %v", ErrInvalidOrder, err)
+	}
+
 	return o, nil
+}
+
+func checkNoDuplicateFillIDs(ids []id.FillID) error {
+	seen := make(map[id.FillID]struct{}, len(ids))
+	for _, fillID := range ids {
+		if fillID.IsZero() {
+			return fmt.Errorf("entries must be non-zero")
+		}
+		if _, ok := seen[fillID]; ok {
+			return fmt.Errorf("duplicate entry %s", fillID)
+		}
+		seen[fillID] = struct{}{}
+	}
+	return nil
+}
+
+func checkNoDuplicateBrokerFillIDs(ids []string) error {
+	seen := make(map[string]struct{}, len(ids))
+	for _, brokerFillID := range ids {
+		if brokerFillID == "" {
+			return fmt.Errorf("entries must be non-empty")
+		}
+		if _, ok := seen[brokerFillID]; ok {
+			return fmt.Errorf("duplicate entry %q", brokerFillID)
+		}
+		seen[brokerFillID] = struct{}{}
+	}
+	return nil
 }
 
 // RemainingQuantity returns AcceptedQuantity minus FilledQuantity. It

--- a/order/order_test.go
+++ b/order/order_test.go
@@ -3,6 +3,7 @@ package order
 import (
 	"testing"
 
+	"github.com/rustyeddy/trader/id"
 	"github.com/rustyeddy/trader/num"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -211,6 +212,43 @@ func TestOrderRemainingQuantityRequiresAcceptance(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_, err = o.RemainingQuantity()
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsZeroAppliedFillID(t *testing.T) {
+	_, err := NewOrder(Order{
+		Request:        mustRequest(t),
+		Status:         StatusPendingSubmit,
+		AppliedFillIDs: []id.FillID{{}},
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsDuplicateAppliedFillID(t *testing.T) {
+	fid := mustFillID(t)
+	_, err := NewOrder(Order{
+		Request:        mustRequest(t),
+		Status:         StatusPendingSubmit,
+		AppliedFillIDs: []id.FillID{fid, fid},
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsEmptyAppliedBrokerFillID(t *testing.T) {
+	_, err := NewOrder(Order{
+		Request:              mustRequest(t),
+		Status:               StatusPendingSubmit,
+		AppliedBrokerFillIDs: []string{""},
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsDuplicateAppliedBrokerFillID(t *testing.T) {
+	_, err := NewOrder(Order{
+		Request:              mustRequest(t),
+		Status:               StatusPendingSubmit,
+		AppliedBrokerFillIDs: []string{"broker-exec-1", "broker-exec-1"},
+	})
 	assert.ErrorIs(t, err, ErrInvalidOrder)
 }
 

--- a/order/order_test.go
+++ b/order/order_test.go
@@ -215,6 +215,27 @@ func TestOrderRemainingQuantityRequiresAcceptance(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidOrder)
 }
 
+func TestNewOrderRejectsPendingStatusWithoutPendingCommandID(t *testing.T) {
+	accepted := num.MustParseQuantity("1000")
+	_, err := NewOrder(Order{
+		Request:          mustRequest(t),
+		AcceptedQuantity: &accepted,
+		Status:           StatusPendingCancel,
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestNewOrderRejectsPendingCommandIDWithoutPendingStatus(t *testing.T) {
+	accepted := num.MustParseQuantity("1000")
+	_, err := NewOrder(Order{
+		Request:          mustRequest(t),
+		AcceptedQuantity: &accepted,
+		Status:           StatusWorking,
+		PendingCommandID: mustEventID(t),
+	})
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
 func TestNewOrderRejectsZeroAppliedFillID(t *testing.T) {
 	_, err := NewOrder(Order{
 		Request:        mustRequest(t),

--- a/order/transition.go
+++ b/order/transition.go
@@ -1,0 +1,325 @@
+package order
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+)
+
+// transitionGraph names every legal Status transition, keyed by the
+// current Status. A Status absent as a key (StatusFilled, StatusCanceled,
+// StatusRejected, StatusExpired) is terminal: nothing may follow it,
+// except the always-legal idempotent same-status case CanTransitionTo
+// handles separately.
+//
+// Two decisions this graph encodes deliberately:
+//
+//   - Reaching StatusCanceled, or a replace's resulting status, requires
+//     having passed through StatusPendingCancel/StatusPendingReplace
+//     first — there is no direct StatusWorking -> StatusCanceled edge.
+//     A terminal cancel confirmation arriving without Trader ever having
+//     locally recorded the pending cancel is treated as an out-of-order
+//     event and rejected; reconciling that gap is a live-package
+//     concern, not this package's.
+//   - StatusRejected is reachable only from StatusPendingSubmit, and
+//     StatusExpired only from StatusWorking/StatusPartiallyFilled,
+//     matching real broker semantics (rejection happens pre-acceptance;
+//     expiration happens to a still-live order) rather than leaving the
+//     graph permissive by default.
+var transitionGraph = map[Status][]Status{
+	StatusPendingSubmit:   {StatusWorking, StatusRejected},
+	StatusWorking:         {StatusPartiallyFilled, StatusFilled, StatusPendingCancel, StatusPendingReplace, StatusExpired},
+	StatusPartiallyFilled: {StatusFilled, StatusPendingCancel, StatusPendingReplace, StatusExpired},
+	StatusPendingCancel:   {StatusCanceled, StatusWorking, StatusPartiallyFilled, StatusFilled},
+	StatusPendingReplace:  {StatusWorking, StatusPartiallyFilled, StatusFilled, StatusCanceled},
+}
+
+// CanTransitionTo reports whether an Order currently in Status from may
+// legally move to Status to.
+//
+// to == from is always legal for any valid, known Status — including a
+// terminal one — which is what makes redelivery of an unchanged status
+// event (a broker resending "Filled" for an already-Filled order) a safe
+// no-op rather than an error, matching the architecture document's
+// at-least-once delivery assumption.
+//
+// StatusUnknown is never a legal transition target, including
+// StatusUnknown -> StatusUnknown: M1-10 already made Unknown a safe
+// value for an adapter to produce when it cannot classify a broker
+// status, but this graph validates known, classifiable transitions —
+// an Unknown target signals "this needs operator attention," not
+// something to silently fold into the state machine.
+func (from Status) CanTransitionTo(to Status) bool {
+	if !from.valid() || !to.valid() || to == StatusUnknown {
+		return false
+	}
+	if to == from {
+		return true
+	}
+	return slices.Contains(transitionGraph[from], to)
+}
+
+// Terminal reports whether s is a terminal Status: no Apply* function
+// moves an Order out of it, except the idempotent same-status case.
+func (s Status) Terminal() bool {
+	switch s {
+	case StatusFilled, StatusCanceled, StatusRejected, StatusExpired:
+		return true
+	default:
+		return false
+	}
+}
+
+// ApplyAcceptance transitions o from StatusPendingSubmit to
+// StatusWorking, recording the broker's own order identifier and its
+// accepted quantity and prices. Unlike the result-applying functions
+// below, ApplyAcceptance requires o to be exactly StatusPendingSubmit —
+// not idempotently re-appliable from StatusWorking — since a redelivered
+// acceptance carrying different accepted values would otherwise silently
+// mutate an already-working order.
+func ApplyAcceptance(o Order, brokerOrderID string, acceptedQuantity num.Quantity, acceptedLimitPrice, acceptedStopPrice *num.Price) (Order, error) {
+	if o.Status != StatusPendingSubmit {
+		return Order{}, fmt.Errorf("%w: cannot accept order in status %s", ErrIllegalTransition, o.Status)
+	}
+	o.BrokerOrderID = brokerOrderID
+	o.AcceptedQuantity = &acceptedQuantity
+	o.AcceptedLimitPrice = acceptedLimitPrice
+	o.AcceptedStopPrice = acceptedStopPrice
+	o.Status = StatusWorking
+	return NewOrder(o)
+}
+
+// ApplyRejection transitions o from StatusPendingSubmit to
+// StatusRejected, recording why the broker declined the order outright.
+func ApplyRejection(o Order, rejection Rejection) (Order, error) {
+	if o.Status != StatusPendingSubmit {
+		return Order{}, fmt.Errorf("%w: cannot reject order in status %s", ErrIllegalTransition, o.Status)
+	}
+	o.Status = StatusRejected
+	o.Rejection = &rejection
+	return NewOrder(o)
+}
+
+// ApplyExpiration transitions o from StatusWorking or
+// StatusPartiallyFilled to StatusExpired: its TimeInForce elapsed before
+// it fully filled.
+func ApplyExpiration(o Order) (Order, error) {
+	if o.Status != StatusWorking && o.Status != StatusPartiallyFilled {
+		return Order{}, fmt.Errorf("%w: cannot expire order in status %s", ErrIllegalTransition, o.Status)
+	}
+	o.Status = StatusExpired
+	return NewOrder(o)
+}
+
+// ApplyCancelRequest transitions o from StatusWorking or
+// StatusPartiallyFilled to StatusPendingCancel, marking a cancel as
+// locally in flight before the broker confirms it. req.OrderID must
+// match o.
+func ApplyCancelRequest(o Order, req CancelRequest) (Order, error) {
+	if err := checkOrderIDMatch(o, req.OrderID); err != nil {
+		return Order{}, err
+	}
+	if o.Status != StatusWorking && o.Status != StatusPartiallyFilled {
+		return Order{}, fmt.Errorf("%w: cannot request cancel for order in status %s", ErrIllegalTransition, o.Status)
+	}
+	o.Status = StatusPendingCancel
+	return NewOrder(o)
+}
+
+// ApplyCancelResult transitions o from StatusPendingCancel to
+// result.Status: typically StatusCanceled, but a cancel can also be
+// declined (result.Rejection explains why), in which case result.Status
+// reflects the order's actual resulting state. result.OrderID must
+// match o.
+//
+// ApplyCancelResult never copies result.Rejection into o.Rejection:
+// those are distinct concepts. result.Rejection explains why the cancel
+// itself was declined (for example, "already filled"); o.Rejection
+// (see NewOrder) means the order itself was declined and is non-nil
+// exactly when o.Status is StatusRejected — copying one into the other
+// would violate that invariant the moment a cancel is declined against,
+// say, a StatusFilled order.
+func ApplyCancelResult(o Order, result CancelResult) (Order, error) {
+	if err := checkOrderIDMatch(o, result.OrderID); err != nil {
+		return Order{}, err
+	}
+	if o.Status != StatusPendingCancel {
+		return Order{}, fmt.Errorf("%w: cannot apply cancel result to order in status %s", ErrIllegalTransition, o.Status)
+	}
+	if !o.Status.CanTransitionTo(result.Status) {
+		return Order{}, fmt.Errorf("%w: cancel result status %s not reachable from %s", ErrIllegalTransition, result.Status, o.Status)
+	}
+	o.Status = result.Status
+	return NewOrder(o)
+}
+
+// ApplyReplaceRequest transitions o from StatusWorking or
+// StatusPartiallyFilled to StatusPendingReplace, marking a replace as
+// locally in flight before the broker confirms it. req.OrderID must
+// match o. The requested new values are not applied yet — only
+// ApplyReplaceResult applies them, once the broker has actually
+// confirmed the replace.
+func ApplyReplaceRequest(o Order, req ReplaceRequest) (Order, error) {
+	if err := checkOrderIDMatch(o, req.OrderID); err != nil {
+		return Order{}, err
+	}
+	if o.Status != StatusWorking && o.Status != StatusPartiallyFilled {
+		return Order{}, fmt.Errorf("%w: cannot request replace for order in status %s", ErrIllegalTransition, o.Status)
+	}
+	o.Status = StatusPendingReplace
+	return NewOrder(o)
+}
+
+// ApplyReplaceResult transitions o from StatusPendingReplace to
+// result.Status. request and result must both refer to o (their
+// OrderIDs must match o.Request.OrderID and each other). On success
+// (result.Rejection == nil), request's non-nil NewQuantity/
+// NewLimitPrice/NewStopPrice replace o's corresponding Accepted* fields
+// — modeling replace as in-place amendment of the same Trader OrderID,
+// not as a distinct "superseded" order with its own identity; see
+// ADR-018. On decline, o's accepted values are left unchanged.
+func ApplyReplaceResult(o Order, request ReplaceRequest, result ReplaceResult) (Order, error) {
+	if err := checkOrderIDMatch(o, request.OrderID); err != nil {
+		return Order{}, err
+	}
+	if request.OrderID != result.OrderID {
+		return Order{}, fmt.Errorf("%w: replace request order id %s does not match result order id %s", ErrOrderMismatch, request.OrderID, result.OrderID)
+	}
+	if o.Status != StatusPendingReplace {
+		return Order{}, fmt.Errorf("%w: cannot apply replace result to order in status %s", ErrIllegalTransition, o.Status)
+	}
+	if !o.Status.CanTransitionTo(result.Status) {
+		return Order{}, fmt.Errorf("%w: replace result status %s not reachable from %s", ErrIllegalTransition, result.Status, o.Status)
+	}
+	if result.Rejection == nil {
+		if request.NewQuantity != nil {
+			o.AcceptedQuantity = request.NewQuantity
+		}
+		if request.NewLimitPrice != nil {
+			o.AcceptedLimitPrice = request.NewLimitPrice
+		}
+		if request.NewStopPrice != nil {
+			o.AcceptedStopPrice = request.NewStopPrice
+		}
+	}
+	o.Status = result.Status
+	return NewOrder(o)
+}
+
+// ApplyFill applies fill to o, accumulating FilledQuantity and
+// recomputing Status. o must currently be StatusWorking,
+// StatusPartiallyFilled, StatusPendingCancel, or StatusPendingReplace —
+// live and accepted.
+//
+// fill's identifying fields must match o: OrderID, AccountID, Listing,
+// and Side, and BrokerOrderID when both are non-empty. This rejects a
+// perfectly valid Fill that simply belongs to a different order, which
+// is a more serious failure mode than an illegal status transition.
+//
+// Duplicate delivery of the same broker execution is detected and
+// safely ignored: fill.BrokerFillID is checked first, against
+// o.AppliedBrokerFillIDs, since an adapter is not guaranteed to reuse
+// the same Trader FillID across redelivery of one broker execution,
+// while broker state is architecturally authoritative; fill.FillID
+// against o.AppliedFillIDs is the fallback for adapters that do not
+// report a BrokerFillID. On a detected duplicate, ApplyFill returns o
+// unchanged alongside ErrDuplicateFill — detectable via errors.Is, but
+// not a fatal error: the returned Order remains valid and current.
+//
+// A fill that would take FilledQuantity beyond AcceptedQuantity is
+// rejected. A fill that exactly completes AcceptedQuantity moves o to
+// StatusFilled regardless of its prior status, including
+// StatusPendingCancel/StatusPendingReplace — there is nothing left to
+// cancel or replace once the order is fully filled. A partial fill
+// arriving while a cancel or replace is pending instead preserves
+// StatusPendingCancel/StatusPendingReplace rather than downgrading to
+// StatusPartiallyFilled, since the broker's pending cancel/replace
+// confirmation may still arrive and should not be implicitly discarded.
+//
+// AvgFillPrice is cleared to nil, not recomputed: num has no
+// Price-by-Quantity multiplication yet, so ApplyFill cannot correctly
+// maintain a quantity-weighted average, and leaving a stale value from
+// an earlier, smaller FilledQuantity would be a false snapshot.
+func ApplyFill(o Order, fill Fill) (Order, error) {
+	if err := checkFillIdentity(o, fill); err != nil {
+		return Order{}, err
+	}
+	switch o.Status {
+	case StatusWorking, StatusPartiallyFilled, StatusPendingCancel, StatusPendingReplace:
+	default:
+		return Order{}, fmt.Errorf("%w: cannot apply fill to order in status %s", ErrIllegalTransition, o.Status)
+	}
+	if o.hasAppliedFill(fill) {
+		return o, ErrDuplicateFill
+	}
+	if o.AcceptedQuantity == nil {
+		return Order{}, fmt.Errorf("%w: order has no accepted quantity to fill against", ErrIllegalTransition)
+	}
+
+	newFilled, err := o.FilledQuantity.Add(fill.Quantity)
+	if err != nil {
+		return Order{}, fmt.Errorf("%w: %v", ErrInvalidOrder, err)
+	}
+	if _, err := o.AcceptedQuantity.Sub(newFilled); err != nil {
+		return Order{}, fmt.Errorf("%w: fill would exceed accepted quantity: %v", ErrInvalidOrder, err)
+	}
+
+	target := StatusPartiallyFilled
+	switch {
+	case newFilled.Equal(*o.AcceptedQuantity):
+		target = StatusFilled
+	case o.Status == StatusPendingCancel || o.Status == StatusPendingReplace:
+		target = o.Status
+	}
+	// target is always one of StatusFilled, StatusPartiallyFilled, or
+	// o.Status itself, and the switch above already restricts o.Status
+	// to Working/PartiallyFilled/PendingCancel/PendingReplace — every
+	// combination is already legal per transitionGraph, so there is no
+	// CanTransitionTo check left to make here.
+
+	o.FilledQuantity = newFilled
+	o.AvgFillPrice = nil
+	o.Status = target
+	o.AppliedFillIDs = append(append([]id.FillID(nil), o.AppliedFillIDs...), fill.FillID)
+	if fill.BrokerFillID != "" {
+		o.AppliedBrokerFillIDs = append(append([]string(nil), o.AppliedBrokerFillIDs...), fill.BrokerFillID)
+	}
+	return NewOrder(o)
+}
+
+// checkOrderIDMatch reports ErrOrderMismatch if eventOrderID does not
+// identify the same order as o.
+func checkOrderIDMatch(o Order, eventOrderID id.OrderID) error {
+	if eventOrderID != o.Request.OrderID {
+		return fmt.Errorf("%w: event order id %s does not match order %s", ErrOrderMismatch, eventOrderID, o.Request.OrderID)
+	}
+	return nil
+}
+
+func checkFillIdentity(o Order, fill Fill) error {
+	if fill.OrderID != o.Request.OrderID {
+		return fmt.Errorf("%w: fill order id %s does not match order %s", ErrOrderMismatch, fill.OrderID, o.Request.OrderID)
+	}
+	if fill.AccountID != o.Request.AccountID {
+		return fmt.Errorf("%w: fill account id %s does not match order account id %s", ErrOrderMismatch, fill.AccountID, o.Request.AccountID)
+	}
+	if fill.Listing != o.Request.Listing {
+		return fmt.Errorf("%w: fill listing does not match order listing", ErrOrderMismatch)
+	}
+	if fill.Side != o.Request.Side {
+		return fmt.Errorf("%w: fill side %s does not match order side %s", ErrOrderMismatch, fill.Side, o.Request.Side)
+	}
+	if o.BrokerOrderID != "" && fill.BrokerOrderID != "" && fill.BrokerOrderID != o.BrokerOrderID {
+		return fmt.Errorf("%w: fill broker order id %q does not match order broker order id %q", ErrOrderMismatch, fill.BrokerOrderID, o.BrokerOrderID)
+	}
+	return nil
+}
+
+func (o Order) hasAppliedFill(fill Fill) bool {
+	if fill.BrokerFillID != "" && slices.Contains(o.AppliedBrokerFillIDs, fill.BrokerFillID) {
+		return true
+	}
+	return slices.Contains(o.AppliedFillIDs, fill.FillID)
+}

--- a/order/transition.go
+++ b/order/transition.go
@@ -116,23 +116,40 @@ func ApplyExpiration(o Order) (Order, error) {
 // ApplyCancelRequest transitions o from StatusWorking or
 // StatusPartiallyFilled to StatusPendingCancel, marking a cancel as
 // locally in flight before the broker confirms it. req.OrderID must
-// match o.
+// match o, and req.Metadata.EventID must be non-zero: it becomes
+// o.PendingCommandID, the correlation key ApplyCancelResult requires a
+// result to match before applying it.
 func ApplyCancelRequest(o Order, req CancelRequest) (Order, error) {
 	if err := checkOrderIDMatch(o, req.OrderID); err != nil {
 		return Order{}, err
+	}
+	if req.Metadata.EventID.IsZero() {
+		return Order{}, fmt.Errorf("%w: cancel request must have a non-zero Metadata.EventID to correlate its result", ErrIllegalTransition)
 	}
 	if o.Status != StatusWorking && o.Status != StatusPartiallyFilled {
 		return Order{}, fmt.Errorf("%w: cannot request cancel for order in status %s", ErrIllegalTransition, o.Status)
 	}
 	o.Status = StatusPendingCancel
+	o.PendingCommandID = req.Metadata.EventID
 	return NewOrder(o)
 }
 
-// ApplyCancelResult transitions o from StatusPendingCancel to
-// result.Status: typically StatusCanceled, but a cancel can also be
-// declined (result.Rejection explains why), in which case result.Status
-// reflects the order's actual resulting state. result.OrderID must
-// match o.
+// ApplyCancelResult transitions o to result.Status: typically
+// StatusCanceled, but a cancel can also be declined (result.Rejection
+// explains why), in which case result.Status reflects the order's
+// actual resulting state. result.OrderID must match o.
+//
+// If o.PendingCommandID is set (o is currently StatusPendingCancel with
+// an outstanding command), result.Metadata.CausationID must match it —
+// ErrStaleResult otherwise. This is what prevents a delayed result from
+// an earlier cancel cycle on this same order from being misapplied
+// during a later one. If o.PendingCommandID is unset — for example
+// because ApplyFill already overrode a pending cancel with a complete
+// fill — there is no outstanding command to correlate against, and
+// result is validated purely against the transition graph: a result
+// matching o's current (possibly terminal) Status is accepted as an
+// idempotent no-op, satisfying redelivery of the same confirmation,
+// while a result naming any other status is rejected as unreachable.
 //
 // ApplyCancelResult never copies result.Rejection into o.Rejection:
 // those are distinct concepts. result.Rejection explains why the cancel
@@ -145,41 +162,67 @@ func ApplyCancelResult(o Order, result CancelResult) (Order, error) {
 	if err := checkOrderIDMatch(o, result.OrderID); err != nil {
 		return Order{}, err
 	}
-	if o.Status != StatusPendingCancel {
-		return Order{}, fmt.Errorf("%w: cannot apply cancel result to order in status %s", ErrIllegalTransition, o.Status)
+	if !o.PendingCommandID.IsZero() && result.Metadata.CausationID != o.PendingCommandID {
+		return Order{}, fmt.Errorf("%w: cancel result causation id %s does not match outstanding command %s", ErrStaleResult, result.Metadata.CausationID, o.PendingCommandID)
 	}
 	if !o.Status.CanTransitionTo(result.Status) {
 		return Order{}, fmt.Errorf("%w: cancel result status %s not reachable from %s", ErrIllegalTransition, result.Status, o.Status)
 	}
 	o.Status = result.Status
+	if o.Status != StatusPendingCancel {
+		o.PendingCommandID = id.EventID{}
+	}
 	return NewOrder(o)
 }
 
 // ApplyReplaceRequest transitions o from StatusWorking or
 // StatusPartiallyFilled to StatusPendingReplace, marking a replace as
 // locally in flight before the broker confirms it. req.OrderID must
-// match o. The requested new values are not applied yet — only
-// ApplyReplaceResult applies them, once the broker has actually
-// confirmed the replace.
+// match o, and req.Metadata.EventID must be non-zero: it becomes
+// o.PendingCommandID, the correlation key ApplyReplaceResult requires a
+// result to match before applying it. The requested new values are not
+// applied yet — only ApplyReplaceResult applies them, once the broker
+// has actually confirmed the replace.
 func ApplyReplaceRequest(o Order, req ReplaceRequest) (Order, error) {
 	if err := checkOrderIDMatch(o, req.OrderID); err != nil {
 		return Order{}, err
+	}
+	if req.Metadata.EventID.IsZero() {
+		return Order{}, fmt.Errorf("%w: replace request must have a non-zero Metadata.EventID to correlate its result", ErrIllegalTransition)
 	}
 	if o.Status != StatusWorking && o.Status != StatusPartiallyFilled {
 		return Order{}, fmt.Errorf("%w: cannot request replace for order in status %s", ErrIllegalTransition, o.Status)
 	}
 	o.Status = StatusPendingReplace
+	o.PendingCommandID = req.Metadata.EventID
 	return NewOrder(o)
 }
 
-// ApplyReplaceResult transitions o from StatusPendingReplace to
-// result.Status. request and result must both refer to o (their
-// OrderIDs must match o.Request.OrderID and each other). On success
-// (result.Rejection == nil), request's non-nil NewQuantity/
-// NewLimitPrice/NewStopPrice replace o's corresponding Accepted* fields
-// — modeling replace as in-place amendment of the same Trader OrderID,
-// not as a distinct "superseded" order with its own identity; see
-// ADR-018. On decline, o's accepted values are left unchanged.
+// ApplyReplaceResult transitions o to result.Status. request and result
+// must both refer to o (their OrderIDs must match o.Request.OrderID and
+// each other).
+//
+// If o.PendingCommandID is set, result.Metadata.CausationID must match
+// it — ErrStaleResult otherwise — for the same reason as
+// ApplyCancelResult: a delayed result from an earlier replace cycle on
+// this same order must not be applied during a later one. If
+// o.PendingCommandID is unset, result is validated purely against the
+// transition graph, allowing a redelivered confirmation matching o's
+// current status as an idempotent no-op.
+//
+// The replace is only treated as having taken effect — request's
+// non-nil NewQuantity/NewLimitPrice/NewStopPrice replacing o's
+// corresponding Accepted* fields — when result.Rejection is nil AND
+// result.Status is StatusWorking or StatusPartiallyFilled: the order
+// remaining live is what "the replacement took effect" actually means.
+// A non-rejected result of StatusCanceled or StatusFilled means the
+// order's life resolved a different way around the same time, and
+// applying new accepted terms first would be misleading even though
+// nothing was technically rejected. This model replace as in-place
+// amendment of the same Trader OrderID, never as a distinct
+// "superseded" order with its own identity; see ADR-018. On decline, or
+// when the result does not mean success, o's accepted values are left
+// unchanged.
 func ApplyReplaceResult(o Order, request ReplaceRequest, result ReplaceResult) (Order, error) {
 	if err := checkOrderIDMatch(o, request.OrderID); err != nil {
 		return Order{}, err
@@ -187,13 +230,15 @@ func ApplyReplaceResult(o Order, request ReplaceRequest, result ReplaceResult) (
 	if request.OrderID != result.OrderID {
 		return Order{}, fmt.Errorf("%w: replace request order id %s does not match result order id %s", ErrOrderMismatch, request.OrderID, result.OrderID)
 	}
-	if o.Status != StatusPendingReplace {
-		return Order{}, fmt.Errorf("%w: cannot apply replace result to order in status %s", ErrIllegalTransition, o.Status)
+	if !o.PendingCommandID.IsZero() && result.Metadata.CausationID != o.PendingCommandID {
+		return Order{}, fmt.Errorf("%w: replace result causation id %s does not match outstanding command %s", ErrStaleResult, result.Metadata.CausationID, o.PendingCommandID)
 	}
 	if !o.Status.CanTransitionTo(result.Status) {
 		return Order{}, fmt.Errorf("%w: replace result status %s not reachable from %s", ErrIllegalTransition, result.Status, o.Status)
 	}
-	if result.Rejection == nil {
+
+	amended := result.Rejection == nil && (result.Status == StatusWorking || result.Status == StatusPartiallyFilled)
+	if amended {
 		if request.NewQuantity != nil {
 			o.AcceptedQuantity = request.NewQuantity
 		}
@@ -205,6 +250,9 @@ func ApplyReplaceResult(o Order, request ReplaceRequest, result ReplaceResult) (
 		}
 	}
 	o.Status = result.Status
+	if o.Status != StatusPendingReplace {
+		o.PendingCommandID = id.EventID{}
+	}
 	return NewOrder(o)
 }
 
@@ -282,6 +330,9 @@ func ApplyFill(o Order, fill Fill) (Order, error) {
 	o.FilledQuantity = newFilled
 	o.AvgFillPrice = nil
 	o.Status = target
+	if o.Status != StatusPendingCancel && o.Status != StatusPendingReplace {
+		o.PendingCommandID = id.EventID{}
+	}
 	o.AppliedFillIDs = append(append([]id.FillID(nil), o.AppliedFillIDs...), fill.FillID)
 	if fill.BrokerFillID != "" {
 		o.AppliedBrokerFillIDs = append(append([]string(nil), o.AppliedBrokerFillIDs...), fill.BrokerFillID)

--- a/order/transition_test.go
+++ b/order/transition_test.go
@@ -3,6 +3,7 @@ package order
 import (
 	"testing"
 
+	"github.com/rustyeddy/trader/id"
 	"github.com/rustyeddy/trader/num"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -165,24 +166,33 @@ func TestApplyExpirationIsTerminal(t *testing.T) {
 
 func TestApplyCancelRequestValid(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID, Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyCancelRequest(o, req)
 	require.NoError(t, err)
 	assert.Equal(t, StatusPendingCancel, o.Status)
+	assert.Equal(t, req.Metadata.EventID, o.PendingCommandID)
 }
 
 func TestApplyCancelRequestRejectsMismatchedOrderID(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewCancelRequest(CancelRequest{OrderID: mustOrderID(t)})
+	req, err := NewCancelRequest(CancelRequest{OrderID: mustOrderID(t), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	_, err = ApplyCancelRequest(o, req)
 	assert.ErrorIs(t, err, ErrOrderMismatch)
 }
 
+func TestApplyCancelRequestRejectsZeroEventID(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	require.NoError(t, err)
+	_, err = ApplyCancelRequest(o, req)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
 func TestApplyCancelRequestRejectsWrongSourceStatus(t *testing.T) {
 	o := mustPendingSubmitOrder(t)
-	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID, Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	_, err = ApplyCancelRequest(o, req)
 	assert.ErrorIs(t, err, ErrIllegalTransition)
@@ -190,25 +200,32 @@ func TestApplyCancelRequestRejectsWrongSourceStatus(t *testing.T) {
 
 func TestApplyCancelResultSuccess(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID, Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyCancelRequest(o, req)
 	require.NoError(t, err)
 
-	result, err := NewCancelResult(CancelResult{OrderID: o.Request.OrderID, Status: StatusCanceled})
+	result, err := NewCancelResult(CancelResult{OrderID: o.Request.OrderID, Status: StatusCanceled, Metadata: resultMetadataFor(o)})
 	require.NoError(t, err)
 	o, err = ApplyCancelResult(o, result)
 	require.NoError(t, err)
 	assert.Equal(t, StatusCanceled, o.Status)
 	assert.Nil(t, o.Rejection, "a declined cancel must never set Order.Rejection")
+	assert.True(t, o.PendingCommandID.IsZero(), "PendingCommandID must clear once the cycle resolves")
 }
 
 func TestApplyCancelResultDeclinedDoesNotSetOrderRejection(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID, Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyCancelRequest(o, req)
 	require.NoError(t, err)
+
+	// The order is not actually fully filled in this fixture, so
+	// completing the transition also requires FilledQuantity to match.
+	accepted := num.MustParseQuantity("1000")
+	o.AcceptedQuantity = &accepted
+	o.FilledQuantity = accepted
 
 	// The cancel was declined because the order was already fully
 	// filled by the time the broker processed it.
@@ -216,15 +233,9 @@ func TestApplyCancelResultDeclinedDoesNotSetOrderRejection(t *testing.T) {
 		OrderID:   o.Request.OrderID,
 		Status:    StatusFilled,
 		Rejection: &Rejection{Reason: ReasonUnknown, Detail: "already filled"},
+		Metadata:  resultMetadataFor(o),
 	})
 	require.NoError(t, err)
-
-	// The order is not actually fully filled in this fixture, so
-	// completing the transition also requires FilledQuantity to match;
-	// use a fresh order where FilledQuantity already equals accepted.
-	accepted := num.MustParseQuantity("1000")
-	o.AcceptedQuantity = &accepted
-	o.FilledQuantity = accepted
 
 	o, err = ApplyCancelResult(o, result)
 	require.NoError(t, err)
@@ -234,12 +245,12 @@ func TestApplyCancelResultDeclinedDoesNotSetOrderRejection(t *testing.T) {
 
 func TestApplyCancelResultRejectsMismatchedOrderID(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID, Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyCancelRequest(o, req)
 	require.NoError(t, err)
 
-	result, err := NewCancelResult(CancelResult{OrderID: mustOrderID(t), Status: StatusCanceled})
+	result, err := NewCancelResult(CancelResult{OrderID: mustOrderID(t), Status: StatusCanceled, Metadata: resultMetadataFor(o)})
 	require.NoError(t, err)
 	_, err = ApplyCancelResult(o, result)
 	assert.ErrorIs(t, err, ErrOrderMismatch)
@@ -247,7 +258,7 @@ func TestApplyCancelResultRejectsMismatchedOrderID(t *testing.T) {
 
 func TestApplyCancelResultRejectsIllegalResultStatus(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID, Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyCancelRequest(o, req)
 	require.NoError(t, err)
@@ -257,6 +268,7 @@ func TestApplyCancelResultRejectsIllegalResultStatus(t *testing.T) {
 		OrderID:   o.Request.OrderID,
 		Status:    StatusRejected,
 		Rejection: &Rejection{Reason: ReasonUnknown},
+		Metadata:  resultMetadataFor(o),
 	})
 	require.NoError(t, err)
 	_, err = ApplyCancelResult(o, result)
@@ -271,28 +283,108 @@ func TestApplyCancelResultRejectsWithoutPendingCancel(t *testing.T) {
 	assert.ErrorIs(t, err, ErrIllegalTransition)
 }
 
+// Regression coverage for the delayed-result race a design review
+// flagged: a stale CancelResult from an earlier cancel cycle on the
+// same order must not be applied during a later cancel cycle.
+func TestApplyCancelResultRejectsStaleResultFromEarlierCycle(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+
+	// First cancel cycle: declined, order reverts to Working.
+	firstReq, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID, Metadata: mustCommandMetadata(t)})
+	require.NoError(t, err)
+	o, err = ApplyCancelRequest(o, firstReq)
+	require.NoError(t, err)
+	firstResult, err := NewCancelResult(CancelResult{
+		OrderID:   o.Request.OrderID,
+		Status:    StatusWorking,
+		Rejection: &Rejection{Reason: ReasonUnknown},
+		Metadata:  resultMetadataFor(o),
+	})
+	require.NoError(t, err)
+	o, err = ApplyCancelResult(o, firstResult)
+	require.NoError(t, err)
+	assert.Equal(t, StatusWorking, o.Status)
+
+	// Second cancel cycle begins.
+	secondReq, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID, Metadata: mustCommandMetadata(t)})
+	require.NoError(t, err)
+	o, err = ApplyCancelRequest(o, secondReq)
+	require.NoError(t, err)
+
+	// A delayed result from the *first* cycle finally arrives, correlated
+	// to firstReq's EventID rather than the currently outstanding
+	// secondReq's EventID.
+	staleResult, err := NewCancelResult(CancelResult{
+		OrderID:  o.Request.OrderID,
+		Status:   StatusCanceled,
+		Metadata: id.Metadata{CausationID: firstReq.Metadata.EventID},
+	})
+	require.NoError(t, err)
+	_, err = ApplyCancelResult(o, staleResult)
+	assert.ErrorIs(t, err, ErrStaleResult)
+}
+
+// Regression coverage for the race Copilot flagged: once ApplyFill has
+// already overridden a pending cancel with a complete fill, a late or
+// duplicate CancelResult confirming that same terminal status must be a
+// safe no-op, not an error.
+func TestApplyCancelResultIsIdempotentAfterFillOverridesPendingCancel(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID, Metadata: mustCommandMetadata(t)})
+	require.NoError(t, err)
+	o, err = ApplyCancelRequest(o, req)
+	require.NoError(t, err)
+
+	o, err = ApplyFill(o, mustFillFor(t, o, "1000"))
+	require.NoError(t, err)
+	require.Equal(t, StatusFilled, o.Status)
+	require.True(t, o.PendingCommandID.IsZero())
+
+	lateResult, err := NewCancelResult(CancelResult{OrderID: o.Request.OrderID, Status: StatusFilled})
+	require.NoError(t, err)
+	unchanged, err := ApplyCancelResult(o, lateResult)
+	require.NoError(t, err)
+	assert.Equal(t, o, unchanged)
+
+	// But a late result claiming something inconsistent with the actual
+	// resulting state must still be rejected.
+	wrongResult, err := NewCancelResult(CancelResult{OrderID: o.Request.OrderID, Status: StatusCanceled})
+	require.NoError(t, err)
+	_, err = ApplyCancelResult(o, wrongResult)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
 // --- ApplyReplaceRequest / ApplyReplaceResult ---
 
 func TestApplyReplaceRequestValid(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyReplaceRequest(o, req)
 	require.NoError(t, err)
 	assert.Equal(t, StatusPendingReplace, o.Status)
+	assert.Equal(t, req.Metadata.EventID, o.PendingCommandID)
 }
 
 func TestApplyReplaceRequestRejectsMismatchedOrderID(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewReplaceRequest(ReplaceRequest{OrderID: mustOrderID(t), NewQuantity: qty(t, "2000")})
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: mustOrderID(t), NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	_, err = ApplyReplaceRequest(o, req)
 	assert.ErrorIs(t, err, ErrOrderMismatch)
 }
 
+func TestApplyReplaceRequestRejectsZeroEventID(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+	_, err = ApplyReplaceRequest(o, req)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
 func TestApplyReplaceRequestRejectsWrongSourceStatus(t *testing.T) {
 	o := mustPendingSubmitOrder(t)
-	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	_, err = ApplyReplaceRequest(o, req)
 	assert.ErrorIs(t, err, ErrIllegalTransition)
@@ -326,12 +418,13 @@ func TestApplyReplaceResultSuccessAppliesNewLimitAndStopPrice(t *testing.T) {
 		OrderID:       o.Request.OrderID,
 		NewLimitPrice: price(t, "1.10500"),
 		NewStopPrice:  price(t, "1.10000"),
+		Metadata:      mustCommandMetadata(t),
 	})
 	require.NoError(t, err)
 	o, err = ApplyReplaceRequest(o, req)
 	require.NoError(t, err)
 
-	result, err := NewReplaceResult(ReplaceResult{OrderID: o.Request.OrderID, Status: StatusWorking})
+	result, err := NewReplaceResult(ReplaceResult{OrderID: o.Request.OrderID, Status: StatusWorking, Metadata: resultMetadataFor(o)})
 	require.NoError(t, err)
 	o, err = ApplyReplaceResult(o, req, result)
 	require.NoError(t, err)
@@ -343,7 +436,7 @@ func TestApplyReplaceResultSuccessAppliesNewLimitAndStopPrice(t *testing.T) {
 
 func TestApplyReplaceResultRejectsIllegalResultStatus(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyReplaceRequest(o, req)
 	require.NoError(t, err)
@@ -353,6 +446,7 @@ func TestApplyReplaceResultRejectsIllegalResultStatus(t *testing.T) {
 		OrderID:   o.Request.OrderID,
 		Status:    StatusRejected,
 		Rejection: &Rejection{Reason: ReasonUnknown},
+		Metadata:  resultMetadataFor(o),
 	})
 	require.NoError(t, err)
 	_, err = ApplyReplaceResult(o, req, result)
@@ -361,23 +455,24 @@ func TestApplyReplaceResultRejectsIllegalResultStatus(t *testing.T) {
 
 func TestApplyReplaceResultSuccessAppliesNewQuantity(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyReplaceRequest(o, req)
 	require.NoError(t, err)
 
-	result, err := NewReplaceResult(ReplaceResult{OrderID: o.Request.OrderID, Status: StatusWorking})
+	result, err := NewReplaceResult(ReplaceResult{OrderID: o.Request.OrderID, Status: StatusWorking, Metadata: resultMetadataFor(o)})
 	require.NoError(t, err)
 	o, err = ApplyReplaceResult(o, req, result)
 	require.NoError(t, err)
 	assert.Equal(t, StatusWorking, o.Status)
 	require.NotNil(t, o.AcceptedQuantity)
 	assert.True(t, o.AcceptedQuantity.Equal(num.MustParseQuantity("2000")), "in-place amendment: same OrderID, updated accepted quantity")
+	assert.True(t, o.PendingCommandID.IsZero())
 }
 
 func TestApplyReplaceResultDeclinedLeavesAcceptedValuesUnchanged(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyReplaceRequest(o, req)
 	require.NoError(t, err)
@@ -386,6 +481,7 @@ func TestApplyReplaceResultDeclinedLeavesAcceptedValuesUnchanged(t *testing.T) {
 		OrderID:   o.Request.OrderID,
 		Status:    StatusWorking,
 		Rejection: &Rejection{Reason: ReasonUnsupportedCapability},
+		Metadata:  resultMetadataFor(o),
 	})
 	require.NoError(t, err)
 	o, err = ApplyReplaceResult(o, req, result)
@@ -394,15 +490,34 @@ func TestApplyReplaceResultDeclinedLeavesAcceptedValuesUnchanged(t *testing.T) {
 	assert.True(t, o.AcceptedQuantity.Equal(num.MustParseQuantity("1000")), "declined replace must not change accepted quantity")
 }
 
+// A non-rejected replace result whose Status is StatusCanceled must not
+// apply the new accepted terms first: "the replacement took effect" is
+// only true for a result that leaves the order live.
+func TestApplyReplaceResultCanceledDoesNotApplyNewValues(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, req)
+	require.NoError(t, err)
+
+	result, err := NewReplaceResult(ReplaceResult{OrderID: o.Request.OrderID, Status: StatusCanceled, Metadata: resultMetadataFor(o)})
+	require.NoError(t, err)
+	o, err = ApplyReplaceResult(o, req, result)
+	require.NoError(t, err)
+	assert.Equal(t, StatusCanceled, o.Status)
+	require.NotNil(t, o.AcceptedQuantity)
+	assert.True(t, o.AcceptedQuantity.Equal(num.MustParseQuantity("1000")), "a Canceled result must not apply the new accepted quantity")
+}
+
 func TestApplyReplaceResultRejectsRequestOrderIDNotMatchingOrder(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	realReq, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	realReq, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyReplaceRequest(o, realReq)
 	require.NoError(t, err)
 
 	otherOrderID := mustOrderID(t)
-	unrelatedReq, err := NewReplaceRequest(ReplaceRequest{OrderID: otherOrderID, NewQuantity: qty(t, "2000")})
+	unrelatedReq, err := NewReplaceRequest(ReplaceRequest{OrderID: otherOrderID, NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	unrelatedResult, err := NewReplaceResult(ReplaceResult{OrderID: otherOrderID, Status: StatusWorking})
 	require.NoError(t, err)
@@ -413,7 +528,7 @@ func TestApplyReplaceResultRejectsRequestOrderIDNotMatchingOrder(t *testing.T) {
 
 func TestApplyReplaceResultRejectsMismatchedRequestResultOrderIDs(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyReplaceRequest(o, req)
 	require.NoError(t, err)
@@ -426,12 +541,73 @@ func TestApplyReplaceResultRejectsMismatchedRequestResultOrderIDs(t *testing.T) 
 
 func TestApplyReplaceResultRejectsWithoutPendingReplace(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
-	result, err := NewReplaceResult(ReplaceResult{OrderID: o.Request.OrderID, Status: StatusWorking})
+	// result.Status is not idempotent-equal to o.Status (Working) and
+	// is not reachable directly from Working without having gone
+	// through PendingReplace first.
+	result, err := NewReplaceResult(ReplaceResult{OrderID: o.Request.OrderID, Status: StatusCanceled})
 	require.NoError(t, err)
 	_, err = ApplyReplaceResult(o, req, result)
 	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+// Regression coverage for the delayed-result race a design review
+// flagged: a stale ReplaceResult from an earlier replace cycle on the
+// same order must not be applied during a later replace cycle.
+func TestApplyReplaceResultRejectsStaleResultFromEarlierCycle(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+
+	firstReq, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "1500"), Metadata: mustCommandMetadata(t)})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, firstReq)
+	require.NoError(t, err)
+	firstResult, err := NewReplaceResult(ReplaceResult{
+		OrderID:   o.Request.OrderID,
+		Status:    StatusWorking,
+		Rejection: &Rejection{Reason: ReasonUnknown},
+		Metadata:  resultMetadataFor(o),
+	})
+	require.NoError(t, err)
+	o, err = ApplyReplaceResult(o, firstReq, firstResult)
+	require.NoError(t, err)
+
+	secondReq, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "3000"), Metadata: mustCommandMetadata(t)})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, secondReq)
+	require.NoError(t, err)
+
+	staleResult, err := NewReplaceResult(ReplaceResult{
+		OrderID:  o.Request.OrderID,
+		Status:   StatusWorking,
+		Metadata: id.Metadata{CausationID: firstReq.Metadata.EventID},
+	})
+	require.NoError(t, err)
+	_, err = ApplyReplaceResult(o, firstReq, staleResult)
+	assert.ErrorIs(t, err, ErrStaleResult)
+}
+
+// Regression coverage for the race Copilot flagged: once ApplyFill has
+// already overridden a pending replace with a complete fill, a late or
+// duplicate ReplaceResult confirming that same terminal status must be a
+// safe no-op, not an error.
+func TestApplyReplaceResultIsIdempotentAfterFillOverridesPendingReplace(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000"), Metadata: mustCommandMetadata(t)})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, req)
+	require.NoError(t, err)
+
+	o, err = ApplyFill(o, mustFillFor(t, o, "1000"))
+	require.NoError(t, err)
+	require.Equal(t, StatusFilled, o.Status)
+	require.True(t, o.PendingCommandID.IsZero())
+
+	lateResult, err := NewReplaceResult(ReplaceResult{OrderID: o.Request.OrderID, Status: StatusFilled})
+	require.NoError(t, err)
+	unchanged, err := ApplyReplaceResult(o, req, lateResult)
+	require.NoError(t, err)
+	assert.Equal(t, o, unchanged)
 }
 
 // --- ApplyFill ---
@@ -590,7 +766,7 @@ func TestApplyFillDetectsDuplicateByBrokerFillIDEvenWithNewFillID(t *testing.T) 
 
 func TestApplyFillPreservesPendingCancelOnPartialFill(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID, Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyCancelRequest(o, req)
 	require.NoError(t, err)
@@ -599,11 +775,12 @@ func TestApplyFillPreservesPendingCancelOnPartialFill(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, StatusPendingCancel, o.Status, "a partial fill must not discard the pending cancel")
 	assert.True(t, o.FilledQuantity.Equal(num.MustParseQuantity("400")))
+	assert.False(t, o.PendingCommandID.IsZero(), "the outstanding cancel command is still outstanding")
 }
 
 func TestApplyFillOverridesPendingCancelOnCompleteFill(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID, Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyCancelRequest(o, req)
 	require.NoError(t, err)
@@ -611,11 +788,12 @@ func TestApplyFillOverridesPendingCancelOnCompleteFill(t *testing.T) {
 	o, err = ApplyFill(o, mustFillFor(t, o, "1000"))
 	require.NoError(t, err)
 	assert.Equal(t, StatusFilled, o.Status, "a complete fill leaves nothing left to cancel")
+	assert.True(t, o.PendingCommandID.IsZero(), "no command is outstanding once fully filled")
 }
 
 func TestApplyFillPreservesPendingReplaceOnPartialFill(t *testing.T) {
 	o := mustWorkingOrder(t, "1000")
-	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "1500")})
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "1500"), Metadata: mustCommandMetadata(t)})
 	require.NoError(t, err)
 	o, err = ApplyReplaceRequest(o, req)
 	require.NoError(t, err)
@@ -623,4 +801,5 @@ func TestApplyFillPreservesPendingReplaceOnPartialFill(t *testing.T) {
 	o, err = ApplyFill(o, mustFillFor(t, o, "400"))
 	require.NoError(t, err)
 	assert.Equal(t, StatusPendingReplace, o.Status, "a partial fill must not discard the pending replace")
+	assert.False(t, o.PendingCommandID.IsZero(), "the outstanding replace command is still outstanding")
 }

--- a/order/transition_test.go
+++ b/order/transition_test.go
@@ -1,0 +1,626 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func allStatuses() []Status {
+	return []Status{
+		StatusUnknown, StatusPendingSubmit, StatusWorking, StatusPartiallyFilled,
+		StatusFilled, StatusPendingCancel, StatusCanceled, StatusPendingReplace,
+		StatusRejected, StatusExpired,
+	}
+}
+
+func TestCanTransitionToSameStatusIsIdempotentForKnownStatuses(t *testing.T) {
+	for _, s := range allStatuses() {
+		if s == StatusUnknown {
+			continue
+		}
+		assert.True(t, s.CanTransitionTo(s), "%s -> %s should be idempotent", s, s)
+	}
+}
+
+func TestCanTransitionToUnknownIsNeverLegal(t *testing.T) {
+	for _, from := range allStatuses() {
+		assert.False(t, from.CanTransitionTo(StatusUnknown), "%s -> Unknown should never be legal", from)
+	}
+	assert.False(t, StatusUnknown.CanTransitionTo(StatusUnknown), "Unknown -> Unknown should not be legal despite the same-status rule")
+}
+
+func TestCanTransitionToRejectsInvalidStatusValues(t *testing.T) {
+	assert.False(t, Status(200).CanTransitionTo(StatusWorking))
+	assert.False(t, StatusWorking.CanTransitionTo(Status(200)))
+}
+
+func TestCanTransitionToTerminalStatesRejectEverythingElse(t *testing.T) {
+	for _, terminal := range []Status{StatusFilled, StatusCanceled, StatusRejected, StatusExpired} {
+		for _, to := range allStatuses() {
+			if to == terminal || to == StatusUnknown {
+				continue
+			}
+			assert.False(t, terminal.CanTransitionTo(to), "%s -> %s should be illegal: terminal", terminal, to)
+		}
+	}
+}
+
+func TestCanTransitionToKnownGraph(t *testing.T) {
+	cases := []struct {
+		from, to Status
+		want     bool
+	}{
+		{StatusPendingSubmit, StatusWorking, true},
+		{StatusPendingSubmit, StatusRejected, true},
+		{StatusPendingSubmit, StatusFilled, false},
+		{StatusWorking, StatusPartiallyFilled, true},
+		{StatusWorking, StatusFilled, true},
+		{StatusWorking, StatusPendingCancel, true},
+		{StatusWorking, StatusPendingReplace, true},
+		{StatusWorking, StatusExpired, true},
+		{StatusWorking, StatusCanceled, false},
+		{StatusWorking, StatusRejected, false},
+		{StatusPartiallyFilled, StatusFilled, true},
+		{StatusPartiallyFilled, StatusPendingCancel, true},
+		{StatusPartiallyFilled, StatusExpired, true},
+		{StatusPartiallyFilled, StatusCanceled, false},
+		{StatusPendingCancel, StatusCanceled, true},
+		{StatusPendingCancel, StatusWorking, true},
+		{StatusPendingCancel, StatusPartiallyFilled, true},
+		{StatusPendingCancel, StatusFilled, true},
+		{StatusPendingCancel, StatusRejected, false},
+		{StatusPendingReplace, StatusWorking, true},
+		{StatusPendingReplace, StatusPartiallyFilled, true},
+		{StatusPendingReplace, StatusFilled, true},
+		{StatusPendingReplace, StatusCanceled, true},
+		{StatusPendingReplace, StatusRejected, false},
+	}
+	for _, tc := range cases {
+		got := tc.from.CanTransitionTo(tc.to)
+		assert.Equal(t, tc.want, got, "%s -> %s", tc.from, tc.to)
+	}
+}
+
+func TestStatusTerminal(t *testing.T) {
+	terminal := map[Status]bool{
+		StatusUnknown:         false,
+		StatusPendingSubmit:   false,
+		StatusWorking:         false,
+		StatusPartiallyFilled: false,
+		StatusFilled:          true,
+		StatusPendingCancel:   false,
+		StatusCanceled:        true,
+		StatusPendingReplace:  false,
+		StatusRejected:        true,
+		StatusExpired:         true,
+	}
+	for s, want := range terminal {
+		assert.Equal(t, want, s.Terminal(), "%s", s)
+	}
+}
+
+// --- ApplyAcceptance ---
+
+func TestApplyAcceptanceValid(t *testing.T) {
+	o := mustPendingSubmitOrder(t)
+	accepted := num.MustParseQuantity("1000")
+	o, err := ApplyAcceptance(o, "broker-1", accepted, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, StatusWorking, o.Status)
+	assert.Equal(t, "broker-1", o.BrokerOrderID)
+	require.NotNil(t, o.AcceptedQuantity)
+	assert.True(t, o.AcceptedQuantity.Equal(accepted))
+}
+
+func TestApplyAcceptanceRejectsWrongSourceStatus(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	_, err := ApplyAcceptance(o, "broker-1", num.MustParseQuantity("1000"), nil, nil)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+// --- ApplyRejection ---
+
+func TestApplyRejectionValid(t *testing.T) {
+	o := mustPendingSubmitOrder(t)
+	o, err := ApplyRejection(o, Rejection{Reason: ReasonMarketClosed})
+	require.NoError(t, err)
+	assert.Equal(t, StatusRejected, o.Status)
+	require.NotNil(t, o.Rejection)
+	assert.Equal(t, ReasonMarketClosed, o.Rejection.Reason)
+}
+
+func TestApplyRejectionRejectsWrongSourceStatus(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	_, err := ApplyRejection(o, Rejection{Reason: ReasonMarketClosed})
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+// --- ApplyExpiration ---
+
+func TestApplyExpirationValid(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	o, err := ApplyExpiration(o)
+	require.NoError(t, err)
+	assert.Equal(t, StatusExpired, o.Status)
+}
+
+func TestApplyExpirationRejectsPendingSubmit(t *testing.T) {
+	o := mustPendingSubmitOrder(t)
+	_, err := ApplyExpiration(o)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+func TestApplyExpirationIsTerminal(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	o, err := ApplyExpiration(o)
+	require.NoError(t, err)
+	_, err = ApplyExpiration(o)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+// --- ApplyCancelRequest / ApplyCancelResult ---
+
+func TestApplyCancelRequestValid(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	require.NoError(t, err)
+	o, err = ApplyCancelRequest(o, req)
+	require.NoError(t, err)
+	assert.Equal(t, StatusPendingCancel, o.Status)
+}
+
+func TestApplyCancelRequestRejectsMismatchedOrderID(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewCancelRequest(CancelRequest{OrderID: mustOrderID(t)})
+	require.NoError(t, err)
+	_, err = ApplyCancelRequest(o, req)
+	assert.ErrorIs(t, err, ErrOrderMismatch)
+}
+
+func TestApplyCancelRequestRejectsWrongSourceStatus(t *testing.T) {
+	o := mustPendingSubmitOrder(t)
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	require.NoError(t, err)
+	_, err = ApplyCancelRequest(o, req)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+func TestApplyCancelResultSuccess(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	require.NoError(t, err)
+	o, err = ApplyCancelRequest(o, req)
+	require.NoError(t, err)
+
+	result, err := NewCancelResult(CancelResult{OrderID: o.Request.OrderID, Status: StatusCanceled})
+	require.NoError(t, err)
+	o, err = ApplyCancelResult(o, result)
+	require.NoError(t, err)
+	assert.Equal(t, StatusCanceled, o.Status)
+	assert.Nil(t, o.Rejection, "a declined cancel must never set Order.Rejection")
+}
+
+func TestApplyCancelResultDeclinedDoesNotSetOrderRejection(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	require.NoError(t, err)
+	o, err = ApplyCancelRequest(o, req)
+	require.NoError(t, err)
+
+	// The cancel was declined because the order was already fully
+	// filled by the time the broker processed it.
+	result, err := NewCancelResult(CancelResult{
+		OrderID:   o.Request.OrderID,
+		Status:    StatusFilled,
+		Rejection: &Rejection{Reason: ReasonUnknown, Detail: "already filled"},
+	})
+	require.NoError(t, err)
+
+	// The order is not actually fully filled in this fixture, so
+	// completing the transition also requires FilledQuantity to match;
+	// use a fresh order where FilledQuantity already equals accepted.
+	accepted := num.MustParseQuantity("1000")
+	o.AcceptedQuantity = &accepted
+	o.FilledQuantity = accepted
+
+	o, err = ApplyCancelResult(o, result)
+	require.NoError(t, err)
+	assert.Equal(t, StatusFilled, o.Status)
+	assert.Nil(t, o.Rejection, "CancelResult.Rejection must not leak into Order.Rejection")
+}
+
+func TestApplyCancelResultRejectsMismatchedOrderID(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	require.NoError(t, err)
+	o, err = ApplyCancelRequest(o, req)
+	require.NoError(t, err)
+
+	result, err := NewCancelResult(CancelResult{OrderID: mustOrderID(t), Status: StatusCanceled})
+	require.NoError(t, err)
+	_, err = ApplyCancelResult(o, result)
+	assert.ErrorIs(t, err, ErrOrderMismatch)
+}
+
+func TestApplyCancelResultRejectsIllegalResultStatus(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	require.NoError(t, err)
+	o, err = ApplyCancelRequest(o, req)
+	require.NoError(t, err)
+
+	// StatusRejected is not reachable from StatusPendingCancel.
+	result, err := NewCancelResult(CancelResult{
+		OrderID:   o.Request.OrderID,
+		Status:    StatusRejected,
+		Rejection: &Rejection{Reason: ReasonUnknown},
+	})
+	require.NoError(t, err)
+	_, err = ApplyCancelResult(o, result)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+func TestApplyCancelResultRejectsWithoutPendingCancel(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	result, err := NewCancelResult(CancelResult{OrderID: o.Request.OrderID, Status: StatusCanceled})
+	require.NoError(t, err)
+	_, err = ApplyCancelResult(o, result)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+// --- ApplyReplaceRequest / ApplyReplaceResult ---
+
+func TestApplyReplaceRequestValid(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, req)
+	require.NoError(t, err)
+	assert.Equal(t, StatusPendingReplace, o.Status)
+}
+
+func TestApplyReplaceRequestRejectsMismatchedOrderID(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: mustOrderID(t), NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+	_, err = ApplyReplaceRequest(o, req)
+	assert.ErrorIs(t, err, ErrOrderMismatch)
+}
+
+func TestApplyReplaceRequestRejectsWrongSourceStatus(t *testing.T) {
+	o := mustPendingSubmitOrder(t)
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+	_, err = ApplyReplaceRequest(o, req)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+func TestApplyReplaceResultSuccessAppliesNewLimitAndStopPrice(t *testing.T) {
+	proposal, err := NewProposal(Proposal{
+		Listing:     mustEurUsdListing(t),
+		AccountID:   mustAccountID(t),
+		Side:        Buy,
+		Type:        StopLimit,
+		TimeInForce: GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		LimitPrice:  price(t, "1.10000"),
+		StopPrice:   price(t, "1.09500"),
+	})
+	require.NoError(t, err)
+	request, err := NewRequest(proposal, mustOrderID(t))
+	require.NoError(t, err)
+	accepted := num.MustParseQuantity("1000")
+	o, err := NewOrder(Order{
+		Request:            request,
+		AcceptedQuantity:   &accepted,
+		AcceptedLimitPrice: price(t, "1.10000"),
+		AcceptedStopPrice:  price(t, "1.09500"),
+		Status:             StatusWorking,
+	})
+	require.NoError(t, err)
+
+	req, err := NewReplaceRequest(ReplaceRequest{
+		OrderID:       o.Request.OrderID,
+		NewLimitPrice: price(t, "1.10500"),
+		NewStopPrice:  price(t, "1.10000"),
+	})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, req)
+	require.NoError(t, err)
+
+	result, err := NewReplaceResult(ReplaceResult{OrderID: o.Request.OrderID, Status: StatusWorking})
+	require.NoError(t, err)
+	o, err = ApplyReplaceResult(o, req, result)
+	require.NoError(t, err)
+	require.NotNil(t, o.AcceptedLimitPrice)
+	require.NotNil(t, o.AcceptedStopPrice)
+	assert.True(t, o.AcceptedLimitPrice.Equal(num.MustParsePrice("1.10500")))
+	assert.True(t, o.AcceptedStopPrice.Equal(num.MustParsePrice("1.10000")))
+}
+
+func TestApplyReplaceResultRejectsIllegalResultStatus(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, req)
+	require.NoError(t, err)
+
+	// StatusRejected is not reachable from StatusPendingReplace.
+	result, err := NewReplaceResult(ReplaceResult{
+		OrderID:   o.Request.OrderID,
+		Status:    StatusRejected,
+		Rejection: &Rejection{Reason: ReasonUnknown},
+	})
+	require.NoError(t, err)
+	_, err = ApplyReplaceResult(o, req, result)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+func TestApplyReplaceResultSuccessAppliesNewQuantity(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, req)
+	require.NoError(t, err)
+
+	result, err := NewReplaceResult(ReplaceResult{OrderID: o.Request.OrderID, Status: StatusWorking})
+	require.NoError(t, err)
+	o, err = ApplyReplaceResult(o, req, result)
+	require.NoError(t, err)
+	assert.Equal(t, StatusWorking, o.Status)
+	require.NotNil(t, o.AcceptedQuantity)
+	assert.True(t, o.AcceptedQuantity.Equal(num.MustParseQuantity("2000")), "in-place amendment: same OrderID, updated accepted quantity")
+}
+
+func TestApplyReplaceResultDeclinedLeavesAcceptedValuesUnchanged(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, req)
+	require.NoError(t, err)
+
+	result, err := NewReplaceResult(ReplaceResult{
+		OrderID:   o.Request.OrderID,
+		Status:    StatusWorking,
+		Rejection: &Rejection{Reason: ReasonUnsupportedCapability},
+	})
+	require.NoError(t, err)
+	o, err = ApplyReplaceResult(o, req, result)
+	require.NoError(t, err)
+	require.NotNil(t, o.AcceptedQuantity)
+	assert.True(t, o.AcceptedQuantity.Equal(num.MustParseQuantity("1000")), "declined replace must not change accepted quantity")
+}
+
+func TestApplyReplaceResultRejectsRequestOrderIDNotMatchingOrder(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	realReq, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, realReq)
+	require.NoError(t, err)
+
+	otherOrderID := mustOrderID(t)
+	unrelatedReq, err := NewReplaceRequest(ReplaceRequest{OrderID: otherOrderID, NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+	unrelatedResult, err := NewReplaceResult(ReplaceResult{OrderID: otherOrderID, Status: StatusWorking})
+	require.NoError(t, err)
+
+	_, err = ApplyReplaceResult(o, unrelatedReq, unrelatedResult)
+	assert.ErrorIs(t, err, ErrOrderMismatch)
+}
+
+func TestApplyReplaceResultRejectsMismatchedRequestResultOrderIDs(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, req)
+	require.NoError(t, err)
+
+	result, err := NewReplaceResult(ReplaceResult{OrderID: mustOrderID(t), Status: StatusWorking})
+	require.NoError(t, err)
+	_, err = ApplyReplaceResult(o, req, result)
+	assert.ErrorIs(t, err, ErrOrderMismatch)
+}
+
+func TestApplyReplaceResultRejectsWithoutPendingReplace(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "2000")})
+	require.NoError(t, err)
+	result, err := NewReplaceResult(ReplaceResult{OrderID: o.Request.OrderID, Status: StatusWorking})
+	require.NoError(t, err)
+	_, err = ApplyReplaceResult(o, req, result)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+// --- ApplyFill ---
+
+func TestApplyFillPartialThenFull(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+
+	o, err := ApplyFill(o, mustFillFor(t, o, "400"))
+	require.NoError(t, err)
+	assert.Equal(t, StatusPartiallyFilled, o.Status)
+	assert.True(t, o.FilledQuantity.Equal(num.MustParseQuantity("400")))
+
+	o, err = ApplyFill(o, mustFillFor(t, o, "600"))
+	require.NoError(t, err)
+	assert.Equal(t, StatusFilled, o.Status)
+	assert.True(t, o.FilledQuantity.Equal(num.MustParseQuantity("1000")))
+}
+
+func TestApplyFillClearsAvgFillPrice(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	stale := num.MustParsePrice("1.00000")
+	o.AvgFillPrice = &stale
+	o, err := ApplyFill(o, mustFillFor(t, o, "400"))
+	require.NoError(t, err)
+	assert.Nil(t, o.AvgFillPrice, "AvgFillPrice must be cleared, never left stale")
+}
+
+func TestApplyFillRejectsOverfill(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	o, err := ApplyFill(o, mustFillFor(t, o, "600"))
+	require.NoError(t, err)
+	_, err = ApplyFill(o, mustFillFor(t, o, "500"))
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestApplyFillRejectsOrderWithNoAcceptedQuantity(t *testing.T) {
+	// A malformed Order built as a bare struct literal, bypassing
+	// NewOrder's invariant that a "live" Status requires a non-nil
+	// AcceptedQuantity.
+	o := mustWorkingOrder(t, "1000")
+	o.AcceptedQuantity = nil
+	_, err := ApplyFill(o, mustFillFor(t, o, "100"))
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+func TestApplyFillRejectsAddOverflow(t *testing.T) {
+	o := mustWorkingOrder(t, "90000000000")
+	o.FilledQuantity = num.MustParseQuantity("50000000000")
+	fill := mustFillFor(t, o, "50000000000")
+	_, err := ApplyFill(o, fill)
+	assert.ErrorIs(t, err, ErrInvalidOrder)
+}
+
+func TestApplyFillRejectsWrongSourceStatus(t *testing.T) {
+	o := mustPendingSubmitOrder(t)
+	fill, err := NewFill(Fill{
+		FillID:    mustFillID(t),
+		OrderID:   o.Request.OrderID,
+		AccountID: o.Request.AccountID,
+		Listing:   o.Request.Listing,
+		Side:      o.Request.Side,
+		Price:     num.MustParsePrice("1.10000"),
+		Quantity:  num.MustParseQuantity("100"),
+	})
+	require.NoError(t, err)
+	_, err = ApplyFill(o, fill)
+	assert.ErrorIs(t, err, ErrIllegalTransition)
+}
+
+func TestApplyFillRejectsMismatchedOrderID(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	fill := mustFillFor(t, o, "100")
+	fill.OrderID = mustOrderID(t)
+	_, err := ApplyFill(o, fill)
+	assert.ErrorIs(t, err, ErrOrderMismatch)
+}
+
+func TestApplyFillRejectsMismatchedAccountID(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	fill := mustFillFor(t, o, "100")
+	fill.AccountID = mustAccountID(t)
+	_, err := ApplyFill(o, fill)
+	assert.ErrorIs(t, err, ErrOrderMismatch)
+}
+
+func TestApplyFillRejectsMismatchedListing(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	fill := mustFillFor(t, o, "100")
+	apple, err := instrumentEquityListing(t)
+	require.NoError(t, err)
+	fill.Listing = apple
+	_, err = ApplyFill(o, fill)
+	assert.ErrorIs(t, err, ErrOrderMismatch)
+}
+
+func TestApplyFillRejectsMismatchedSide(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	fill := mustFillFor(t, o, "100")
+	fill.Side = Sell
+	require.NotEqual(t, o.Request.Side, fill.Side)
+	_, err := ApplyFill(o, fill)
+	assert.ErrorIs(t, err, ErrOrderMismatch)
+}
+
+func TestApplyFillRejectsMismatchedBrokerOrderID(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	fill := mustFillFor(t, o, "100")
+	fill.BrokerOrderID = "some-other-broker-order"
+	_, err := ApplyFill(o, fill)
+	assert.ErrorIs(t, err, ErrOrderMismatch)
+}
+
+func TestApplyFillAllowsEmptyBrokerOrderIDOnEitherSide(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	o.BrokerOrderID = ""
+	fill := mustFillFor(t, o, "100")
+	fill.BrokerOrderID = "some-broker-order"
+	_, err := ApplyFill(o, fill)
+	assert.NoError(t, err, "an order with no recorded BrokerOrderID yet should not reject a fill that has one")
+}
+
+func TestApplyFillDetectsDuplicateByFillID(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	fill := mustFillFor(t, o, "400")
+
+	o, err := ApplyFill(o, fill)
+	require.NoError(t, err)
+
+	unchanged, err := ApplyFill(o, fill)
+	assert.ErrorIs(t, err, ErrDuplicateFill)
+	assert.Equal(t, o, unchanged, "a duplicate fill must return the order unchanged")
+}
+
+func TestApplyFillDetectsDuplicateByBrokerFillIDEvenWithNewFillID(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	first := mustFillFor(t, o, "400")
+	first.BrokerFillID = "broker-exec-1"
+	first, err := NewFill(first)
+	require.NoError(t, err)
+
+	o, err = ApplyFill(o, first)
+	require.NoError(t, err)
+
+	// A redelivery of the same broker execution, but the adapter minted
+	// a fresh Trader FillID for it.
+	redelivered := mustFillFor(t, o, "400")
+	redelivered.BrokerFillID = "broker-exec-1"
+	redelivered, err = NewFill(redelivered)
+	require.NoError(t, err)
+	require.NotEqual(t, first.FillID, redelivered.FillID)
+
+	unchanged, err := ApplyFill(o, redelivered)
+	assert.ErrorIs(t, err, ErrDuplicateFill)
+	assert.Equal(t, o, unchanged)
+}
+
+func TestApplyFillPreservesPendingCancelOnPartialFill(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	require.NoError(t, err)
+	o, err = ApplyCancelRequest(o, req)
+	require.NoError(t, err)
+
+	o, err = ApplyFill(o, mustFillFor(t, o, "400"))
+	require.NoError(t, err)
+	assert.Equal(t, StatusPendingCancel, o.Status, "a partial fill must not discard the pending cancel")
+	assert.True(t, o.FilledQuantity.Equal(num.MustParseQuantity("400")))
+}
+
+func TestApplyFillOverridesPendingCancelOnCompleteFill(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewCancelRequest(CancelRequest{OrderID: o.Request.OrderID})
+	require.NoError(t, err)
+	o, err = ApplyCancelRequest(o, req)
+	require.NoError(t, err)
+
+	o, err = ApplyFill(o, mustFillFor(t, o, "1000"))
+	require.NoError(t, err)
+	assert.Equal(t, StatusFilled, o.Status, "a complete fill leaves nothing left to cancel")
+}
+
+func TestApplyFillPreservesPendingReplaceOnPartialFill(t *testing.T) {
+	o := mustWorkingOrder(t, "1000")
+	req, err := NewReplaceRequest(ReplaceRequest{OrderID: o.Request.OrderID, NewQuantity: qty(t, "1500")})
+	require.NoError(t, err)
+	o, err = ApplyReplaceRequest(o, req)
+	require.NoError(t, err)
+
+	o, err = ApplyFill(o, mustFillFor(t, o, "400"))
+	require.NoError(t, err)
+	assert.Equal(t, StatusPendingReplace, o.Status, "a partial fill must not discard the pending replace")
+}


### PR DESCRIPTION
## Summary
- Adds `order.Status.CanTransitionTo`/`Terminal()` and the named lifecycle functions `ApplyAcceptance`, `ApplyRejection`, `ApplyFill`, `ApplyCancelRequest`/`ApplyCancelResult`, `ApplyReplaceRequest`/`ApplyReplaceResult`, `ApplyExpiration` in a new `order/transition.go`.
- Incorporates the design-review feedback posted on issue #29 before implementation began: event/order identity verification (new `ErrOrderMismatch`) on every `Apply*` that takes an external event; duplicate-fill detection keyed on `BrokerFillID` first (new `Order.AppliedBrokerFillIDs`/`AppliedFillIDs` fields, new `ErrDuplicateFill`); replace explicitly decided and documented as in-place amendment (not a `Superseded`/new-order model); `AvgFillPrice` cleared rather than left stale after a fill (`num` has no Price×Quantity arithmetic yet); and the same-status-idempotent rule fixed so `StatusUnknown -> StatusUnknown` is never legal.
- A partial fill while a cancel/replace is pending now preserves that pending status instead of silently discarding it; only a complete fill overrides to `Filled`.
- Adds ADR-018 (Accepted) and extends the `order` README section.

## Why
Closes #29 (M1-11). Plan and design review were posted and resolved on the issue before implementation began.

## How tested
- `make check` (fmt, vet, `go test -race ./...`) passes.
- `go test ./order/... -race -cover`: 100% coverage.
- `go doc`-style `Example` functions, including `Example_lifecycle` walking submission → acceptance → two partial fills → `Filled`, verified by `go test`.

## Documentation changed
- `docs/arch/adr-decisions.org` (new ADR-018, Accepted)
- `README.md` (`order` section extended)
- `order/doc.go` (new "Lifecycle transitions" section)

https://claude.ai/code/session_01FsfxQH4YBP5DA1LpAafWyt