### PR TITLE
M1-12: account and portfolio snapshot models

### DIFF
--- a/account/doc.go
+++ b/account/doc.go
@@ -1,0 +1,41 @@
+// Package account models one broker account's authoritative observed
+// snapshot (issue #30, M1-12, ADR-019): an immutable value describing
+// what a broker reported about one account at one point in time. It
+// does not query brokers, reconcile local state against broker truth,
+// or mutate anything after construction — see ADR-007 and the live
+// package (not yet built) for those responsibilities. Deposit and
+// withdrawal history (account.CashLedgerEntry in the architecture
+// document) is also out of scope here; it is additive future work.
+//
+// # Snapshot, not a live handle
+//
+// Snapshot is deliberately distinct from a broker-scoped action handle
+// (ADR-007's broker.Account): Snapshot is a value describing observed
+// state, with no methods that perform I/O. Constructing one does not
+// imply the data is current; AsOf is the only claim this package makes
+// about freshness.
+//
+// # Construction validates, ingestion clones
+//
+// NewSnapshot takes a SnapshotParams value rather than a Snapshot,
+// because Snapshot's collection-typed fields are unexported so nothing
+// outside this package can mutate them after construction. Every
+// balance field denominated in the account's home Currency is checked
+// against it; CashBalances may span several currencies (a real FX
+// account routinely holds more than one) and must not repeat a
+// currency. Every Position must belong to this account and name a
+// distinct (instrument, provider, venue) listing; every OpenOrder must
+// belong to this account, must not already be in a terminal status (see
+// order.Status.Terminal), and must not repeat an OrderID. Positions and
+// orders are revalidated through order.NewPosition/order.NewOrder rather
+// than trusted by provenance, for the same reason order's own
+// constructors revalidate nested stages: exported struct fields let a
+// caller build an invalid value as a bare literal.
+//
+// Positions, OpenOrders, and CashBalances are deep-copied on the way in
+// and every time an accessor returns them: order.Order and
+// order.Position both carry pointer and slice fields (AcceptedQuantity,
+// Rejection, AppliedFillIDs, AvgPrice, and so on) that a shallow copy
+// would still share with the caller, defeating immutability. See
+// cloneOrder and clonePosition.
+package account

--- a/account/doc.go
+++ b/account/doc.go
@@ -23,14 +23,19 @@
 // balance field denominated in the account's home Currency is checked
 // against it; CashBalances may span several currencies (a real FX
 // account routinely holds more than one) and must not repeat a
-// currency. Every Position must belong to this account and name a
+// currency. Every Position must belong to this account, must be listed
+// through this account's own Broker (Listing.Provider must
+// case-insensitively equal SnapshotParams.Broker — a snapshot is one
+// broker account's observation, so a contained listing from a different
+// provider would misrepresent whose position it is), and must name a
 // distinct (instrument, provider, venue) listing; every OpenOrder must
-// belong to this account, must not already be in a terminal status (see
-// order.Status.Terminal), and must not repeat an OrderID. Positions and
-// orders are revalidated through order.NewPosition/order.NewOrder rather
-// than trusted by provenance, for the same reason order's own
-// constructors revalidate nested stages: exported struct fields let a
-// caller build an invalid value as a bare literal.
+// belong to this account and this Broker, must not already be in a
+// terminal status (see order.Status.Terminal), and must not repeat an
+// OrderID. Positions and orders are revalidated through
+// order.NewPosition/order.NewOrder rather than trusted by provenance,
+// for the same reason order's own constructors revalidate nested
+// stages: exported struct fields let a caller build an invalid value as
+// a bare literal.
 //
 // Positions, OpenOrders, and CashBalances are deep-copied on the way in
 // and every time an accessor returns them: order.Order and

--- a/account/errors.go
+++ b/account/errors.go
@@ -1,0 +1,7 @@
+package account
+
+import "errors"
+
+// ErrInvalidSnapshot reports a SnapshotParams value that fails
+// NewSnapshot's validation.
+var ErrInvalidSnapshot = errors.New("account: invalid snapshot")

--- a/account/example_test.go
+++ b/account/example_test.go
@@ -1,0 +1,45 @@
+package account_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/clock"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+)
+
+// Example_newSnapshot builds a minimal, valid account.Snapshot: an
+// account holding only its home currency, with no open positions or
+// orders.
+func Example_newSnapshot() {
+	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(1, 2))
+	accountID, err := id.GenerateAccountID(g)
+	if err != nil {
+		panic(err)
+	}
+
+	usd := num.MustParseCurrency("USD")
+	snapshot, err := account.NewSnapshot(account.SnapshotParams{
+		AccountID:       accountID,
+		Broker:          "OANDA",
+		Currency:        usd,
+		AsOf:            time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC),
+		CashBalances:    []num.Money{num.MustParseMoney("10000", usd)},
+		Equity:          num.MustParseMoney("10000", usd),
+		BuyingPower:     num.MustParseMoney("10000", usd),
+		MarginUsed:      num.MustParseMoney("0", usd),
+		MarginAvailable: num.MustParseMoney("10000", usd),
+		RealizedPnL:     num.MustParseMoney("0", usd),
+		UnrealizedPnL:   num.MustParseMoney("0", usd),
+		Fees:            num.MustParseMoney("0", usd),
+		Financing:       num.MustParseMoney("0", usd),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(snapshot.Broker(), snapshot.Equity())
+	// Output: OANDA 10000 USD
+}

--- a/account/helpers_test.go
+++ b/account/helpers_test.go
@@ -1,0 +1,210 @@
+package account
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rustyeddy/trader/clock"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+	"github.com/stretchr/testify/require"
+)
+
+var sharedTestGenerator = id.NewGenerator(clock.NewSimulated(time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)), id.NewDeterministic(1, 2))
+
+func testGenerator() *id.Generator {
+	return sharedTestGenerator
+}
+
+func mustAccountID(t *testing.T) id.AccountID {
+	t.Helper()
+	aid, err := id.GenerateAccountID(testGenerator())
+	require.NoError(t, err)
+	return aid
+}
+
+func mustOrderID(t *testing.T) id.OrderID {
+	t.Helper()
+	oid, err := id.GenerateOrderID(testGenerator())
+	require.NoError(t, err)
+	return oid
+}
+
+func mustEventID(t *testing.T) id.EventID {
+	t.Helper()
+	eid, err := id.GenerateEventID(testGenerator())
+	require.NoError(t, err)
+	return eid
+}
+
+func mustEurUsdListing(t *testing.T) instrument.Listing {
+	t.Helper()
+	inst, err := instrument.NewCurrencyPair(num.MustParseCurrency("EUR"), num.MustParseCurrency("USD"))
+	require.NoError(t, err)
+	spec, err := instrument.NewSpec(
+		num.MustParsePrice("0.00001"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		num.MustParseCurrency("USD"),
+	)
+	require.NoError(t, err)
+	listing, err := instrument.NewListing(instrument.ListingParams{
+		Instrument: inst,
+		Provider:   "OANDA",
+		Symbol:     "EUR_USD",
+		Spec:       spec,
+		Tradable:   true,
+	})
+	require.NoError(t, err)
+	return listing
+}
+
+func mustGbpUsdListing(t *testing.T) instrument.Listing {
+	t.Helper()
+	inst, err := instrument.NewCurrencyPair(num.MustParseCurrency("GBP"), num.MustParseCurrency("USD"))
+	require.NoError(t, err)
+	spec, err := instrument.NewSpec(
+		num.MustParsePrice("0.00001"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		num.MustParseCurrency("USD"),
+	)
+	require.NoError(t, err)
+	listing, err := instrument.NewListing(instrument.ListingParams{
+		Instrument: inst,
+		Provider:   "OANDA",
+		Symbol:     "GBP_USD",
+		Spec:       spec,
+		Tradable:   true,
+	})
+	require.NoError(t, err)
+	return listing
+}
+
+func mustPosition(t *testing.T, accountID id.AccountID, listing instrument.Listing) order.Position {
+	t.Helper()
+	price := num.MustParsePrice("1.10000")
+	p, err := order.NewPosition(order.Position{
+		AccountID: accountID,
+		Listing:   listing,
+		Side:      order.Long,
+		Quantity:  num.MustParseQuantity("1000"),
+		AvgPrice:  &price,
+	})
+	require.NoError(t, err)
+	return p
+}
+
+func mustWorkingOrder(t *testing.T, accountID id.AccountID, listing instrument.Listing) order.Order {
+	t.Helper()
+	proposal, err := order.NewProposal(order.Proposal{
+		Listing:     listing,
+		AccountID:   accountID,
+		Side:        order.Buy,
+		Type:        order.Market,
+		TimeInForce: order.GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		Metadata:    id.Metadata{EventID: mustEventID(t)},
+	})
+	require.NoError(t, err)
+	request, err := order.NewRequest(proposal, mustOrderID(t))
+	require.NoError(t, err)
+	accepted := num.MustParseQuantity("1000")
+	o, err := order.NewOrder(order.Order{
+		Request:          request,
+		BrokerOrderID:    "broker-order-1",
+		AcceptedQuantity: &accepted,
+		Status:           order.StatusWorking,
+	})
+	require.NoError(t, err)
+	return o
+}
+
+// mustPartiallyFilledLimitOrder builds a StopLimit order (so both
+// LimitPrice and StopPrice are populated) that has received one partial
+// fill: it exercises every pointer/slice field cloneOrder must copy
+// (Request.LimitPrice, Request.StopPrice, AcceptedLimitPrice,
+// AcceptedStopPrice, AppliedFillIDs, AppliedBrokerFillIDs) except
+// Rejection and AvgFillPrice, which only ever coexist with StatusRejected
+// or a fill respectively — see mustRejectedOrder for Rejection.
+func mustPartiallyFilledLimitOrder(t *testing.T, accountID id.AccountID, listing instrument.Listing) order.Order {
+	t.Helper()
+	limitPrice := num.MustParsePrice("1.09000")
+	stopPrice := num.MustParsePrice("1.08000")
+	proposal, err := order.NewProposal(order.Proposal{
+		Listing:     listing,
+		AccountID:   accountID,
+		Side:        order.Buy,
+		Type:        order.StopLimit,
+		TimeInForce: order.GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+		LimitPrice:  &limitPrice,
+		StopPrice:   &stopPrice,
+		Metadata:    id.Metadata{EventID: mustEventID(t)},
+	})
+	require.NoError(t, err)
+	request, err := order.NewRequest(proposal, mustOrderID(t))
+	require.NoError(t, err)
+
+	accepted := num.MustParseQuantity("1000")
+	acceptedLimit := num.MustParsePrice("1.09000")
+	acceptedStop := num.MustParsePrice("1.08000")
+	o, err := order.NewOrder(order.Order{
+		Request:            request,
+		BrokerOrderID:      "broker-order-2",
+		AcceptedQuantity:   &accepted,
+		AcceptedLimitPrice: &acceptedLimit,
+		AcceptedStopPrice:  &acceptedStop,
+		Status:             order.StatusWorking,
+	})
+	require.NoError(t, err)
+
+	fillID, err := id.GenerateFillID(testGenerator())
+	require.NoError(t, err)
+	fill, err := order.NewFill(order.Fill{
+		FillID:        fillID,
+		OrderID:       o.Request.OrderID,
+		BrokerOrderID: o.BrokerOrderID,
+		BrokerFillID:  "broker-fill-1",
+		AccountID:     o.Request.AccountID,
+		Listing:       o.Request.Listing,
+		Side:          o.Request.Side,
+		Price:         num.MustParsePrice("1.09000"),
+		Quantity:      num.MustParseQuantity("400"),
+	})
+	require.NoError(t, err)
+	partial, err := order.ApplyFill(o, fill)
+	require.NoError(t, err)
+	return partial
+}
+
+func mustFilledOrder(t *testing.T, accountID id.AccountID, listing instrument.Listing) order.Order {
+	t.Helper()
+	o := mustWorkingOrder(t, accountID, listing)
+	fillID, err := id.GenerateFillID(testGenerator())
+	require.NoError(t, err)
+	fill, err := order.NewFill(order.Fill{
+		FillID:        fillID,
+		OrderID:       o.Request.OrderID,
+		BrokerOrderID: o.BrokerOrderID,
+		AccountID:     o.Request.AccountID,
+		Listing:       o.Request.Listing,
+		Side:          o.Request.Side,
+		Price:         num.MustParsePrice("1.10000"),
+		Quantity:      *o.AcceptedQuantity,
+	})
+	require.NoError(t, err)
+	filled, err := order.ApplyFill(o, fill)
+	require.NoError(t, err)
+	return filled
+}
+
+func usd(s string) num.Money {
+	return num.MustParseMoney(s, num.MustParseCurrency("USD"))
+}
+
+func eur(s string) num.Money {
+	return num.MustParseMoney(s, num.MustParseCurrency("EUR"))
+}

--- a/account/helpers_test.go
+++ b/account/helpers_test.go
@@ -41,41 +41,32 @@ func mustEventID(t *testing.T) id.EventID {
 
 func mustEurUsdListing(t *testing.T) instrument.Listing {
 	t.Helper()
-	inst, err := instrument.NewCurrencyPair(num.MustParseCurrency("EUR"), num.MustParseCurrency("USD"))
-	require.NoError(t, err)
-	spec, err := instrument.NewSpec(
-		num.MustParsePrice("0.00001"),
-		num.MustParseQuantity("1"),
-		num.MustParseRate("1"),
-		num.MustParseCurrency("USD"),
-	)
-	require.NoError(t, err)
-	listing, err := instrument.NewListing(instrument.ListingParams{
-		Instrument: inst,
-		Provider:   "OANDA",
-		Symbol:     "EUR_USD",
-		Spec:       spec,
-		Tradable:   true,
-	})
-	require.NoError(t, err)
-	return listing
+	return mustListing(t, "EUR", "USD", "OANDA", "EUR_USD")
 }
 
 func mustGbpUsdListing(t *testing.T) instrument.Listing {
 	t.Helper()
-	inst, err := instrument.NewCurrencyPair(num.MustParseCurrency("GBP"), num.MustParseCurrency("USD"))
+	return mustListing(t, "GBP", "USD", "OANDA", "GBP_USD")
+}
+
+// mustListing builds a currency-pair Listing under the given provider,
+// so tests can exercise cross-provider mismatches against a Snapshot's
+// Broker.
+func mustListing(t *testing.T, base, quote, provider, symbol string) instrument.Listing {
+	t.Helper()
+	inst, err := instrument.NewCurrencyPair(num.MustParseCurrency(base), num.MustParseCurrency(quote))
 	require.NoError(t, err)
 	spec, err := instrument.NewSpec(
 		num.MustParsePrice("0.00001"),
 		num.MustParseQuantity("1"),
 		num.MustParseRate("1"),
-		num.MustParseCurrency("USD"),
+		num.MustParseCurrency(quote),
 	)
 	require.NoError(t, err)
 	listing, err := instrument.NewListing(instrument.ListingParams{
 		Instrument: inst,
-		Provider:   "OANDA",
-		Symbol:     "GBP_USD",
+		Provider:   provider,
+		Symbol:     symbol,
 		Spec:       spec,
 		Tradable:   true,
 	})

--- a/account/snapshot.go
+++ b/account/snapshot.go
@@ -1,0 +1,361 @@
+package account
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+)
+
+// Snapshot is one broker account's authoritative observed state at one
+// point in time. It is immutable: every field is either a plain value
+// or reachable only through an accessor that returns a defensive copy,
+// so nothing a caller does with a returned value can change what
+// Snapshot itself holds. Construct one with NewSnapshot.
+type Snapshot struct {
+	accountID id.AccountID
+	broker    string
+	currency  num.Currency
+	asOf      time.Time
+	cursor    string
+
+	cashBalances []num.Money
+
+	equity          num.Money
+	buyingPower     num.Money
+	marginUsed      num.Money
+	marginAvailable num.Money
+	realizedPnL     num.Money
+	unrealizedPnL   num.Money
+	fees            num.Money
+	financing       num.Money
+
+	positions  []order.Position
+	openOrders []order.Order
+}
+
+// SnapshotParams supplies NewSnapshot's input. Its fields mirror
+// Snapshot's, but are exported and mutable since SnapshotParams is a
+// plain, short-lived construction argument, not the immutable value
+// itself.
+type SnapshotParams struct {
+	// AccountID identifies the Trader-managed account this snapshot
+	// describes. Must be non-zero.
+	AccountID id.AccountID
+	// Broker names the broker or provider that reported this snapshot,
+	// for example "OANDA". Must be non-empty.
+	Broker string
+	// Currency is the account's home/settlement currency. Equity,
+	// BuyingPower, MarginUsed, MarginAvailable, RealizedPnL,
+	// UnrealizedPnL, Fees, and Financing must all be denominated in it.
+	Currency num.Currency
+	// AsOf is when the broker observed this state. Must be non-zero.
+	AsOf time.Time
+	// Cursor is an opaque broker-supplied version or cursor token,
+	// carried but not interpreted by this package.
+	Cursor string
+
+	// CashBalances is the raw cash ledger balance per currency. An FX
+	// account may legitimately hold several; no currency may repeat.
+	CashBalances []num.Money
+
+	// Equity is the broker-reported net liquidation value.
+	Equity num.Money
+	// BuyingPower is funds available to open new positions.
+	BuyingPower num.Money
+	// MarginUsed is margin currently committed to open positions.
+	MarginUsed num.Money
+	// MarginAvailable is margin available for new positions.
+	MarginAvailable num.Money
+	// RealizedPnL is cumulative realized profit and loss.
+	RealizedPnL num.Money
+	// UnrealizedPnL is current unrealized profit and loss on open
+	// positions.
+	UnrealizedPnL num.Money
+	// Fees is cumulative fees observed as of AsOf.
+	Fees num.Money
+	// Financing is cumulative financing/carry cost or credit observed
+	// as of AsOf.
+	Financing num.Money
+
+	// Positions is this account's open positions. Every entry's
+	// AccountID must equal AccountID, and no two entries may name the
+	// same (instrument, provider, venue) listing.
+	Positions []order.Position
+	// OpenOrders is this account's outstanding orders. Every entry's
+	// Request.AccountID must equal AccountID, no entry may already be
+	// in a terminal Status, and no two entries may share an OrderID.
+	OpenOrders []order.Order
+}
+
+// NewSnapshot validates params and returns an immutable Snapshot.
+func NewSnapshot(params SnapshotParams) (Snapshot, error) {
+	if params.AccountID.IsZero() {
+		return Snapshot{}, fmt.Errorf("%w: account id must be set", ErrInvalidSnapshot)
+	}
+	if params.Broker == "" {
+		return Snapshot{}, fmt.Errorf("%w: broker must be set", ErrInvalidSnapshot)
+	}
+	if !params.Currency.IsValid() {
+		return Snapshot{}, fmt.Errorf("%w: currency must be valid", ErrInvalidSnapshot)
+	}
+	if params.AsOf.IsZero() {
+		return Snapshot{}, fmt.Errorf("%w: as-of time must be set", ErrInvalidSnapshot)
+	}
+
+	cashBalances, err := checkCashBalances(params.CashBalances)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("%w: cash balances: %v", ErrInvalidSnapshot, err)
+	}
+
+	homeFields := map[string]num.Money{
+		"equity":           params.Equity,
+		"buying power":     params.BuyingPower,
+		"margin used":      params.MarginUsed,
+		"margin available": params.MarginAvailable,
+		"realized pnl":     params.RealizedPnL,
+		"unrealized pnl":   params.UnrealizedPnL,
+		"fees":             params.Fees,
+		"financing":        params.Financing,
+	}
+	for name, m := range homeFields {
+		if !m.IsValid() {
+			return Snapshot{}, fmt.Errorf("%w: %s must be valid money", ErrInvalidSnapshot, name)
+		}
+		if !m.Currency().Equal(params.Currency) {
+			return Snapshot{}, fmt.Errorf("%w: %s currency %s does not match account currency %s",
+				ErrInvalidSnapshot, name, m.Currency(), params.Currency)
+		}
+	}
+
+	positions, err := checkPositions(params.AccountID, params.Positions)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("%w: positions: %v", ErrInvalidSnapshot, err)
+	}
+
+	openOrders, err := checkOpenOrders(params.AccountID, params.OpenOrders)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("%w: open orders: %v", ErrInvalidSnapshot, err)
+	}
+
+	return Snapshot{
+		accountID:       params.AccountID,
+		broker:          params.Broker,
+		currency:        params.Currency,
+		asOf:            params.AsOf,
+		cursor:          params.Cursor,
+		cashBalances:    cashBalances,
+		equity:          params.Equity,
+		buyingPower:     params.BuyingPower,
+		marginUsed:      params.MarginUsed,
+		marginAvailable: params.MarginAvailable,
+		realizedPnL:     params.RealizedPnL,
+		unrealizedPnL:   params.UnrealizedPnL,
+		fees:            params.Fees,
+		financing:       params.Financing,
+		positions:       positions,
+		openOrders:      openOrders,
+	}, nil
+}
+
+func checkCashBalances(balances []num.Money) ([]num.Money, error) {
+	seen := make(map[string]struct{}, len(balances))
+	cloned := make([]num.Money, len(balances))
+	for i, m := range balances {
+		if !m.IsValid() {
+			return nil, fmt.Errorf("entry %d is not valid money", i)
+		}
+		code := m.Currency().String()
+		if _, ok := seen[code]; ok {
+			return nil, fmt.Errorf("duplicate currency %s", code)
+		}
+		seen[code] = struct{}{}
+		cloned[i] = m
+	}
+	return cloned, nil
+}
+
+type listingKey struct {
+	instrumentID instrument.ID
+	provider     string
+	venue        string
+}
+
+func keyFor(l instrument.Listing) listingKey {
+	return listingKey{instrumentID: l.InstrumentID(), provider: l.Provider(), venue: l.Venue()}
+}
+
+func checkPositions(accountID id.AccountID, positions []order.Position) ([]order.Position, error) {
+	seen := make(map[listingKey]struct{}, len(positions))
+	cloned := make([]order.Position, len(positions))
+	for i, p := range positions {
+		validated, err := order.NewPosition(p)
+		if err != nil {
+			return nil, fmt.Errorf("entry %d: %w", i, err)
+		}
+		if validated.AccountID != accountID {
+			return nil, fmt.Errorf("entry %d: account id %s does not match snapshot account id %s",
+				i, validated.AccountID, accountID)
+		}
+		key := keyFor(validated.Listing)
+		if _, ok := seen[key]; ok {
+			return nil, fmt.Errorf("entry %d: duplicate listing %s/%s/%s",
+				i, key.instrumentID, key.provider, key.venue)
+		}
+		seen[key] = struct{}{}
+		cloned[i] = clonePosition(validated)
+	}
+	return cloned, nil
+}
+
+func checkOpenOrders(accountID id.AccountID, orders []order.Order) ([]order.Order, error) {
+	seen := make(map[id.OrderID]struct{}, len(orders))
+	cloned := make([]order.Order, len(orders))
+	for i, o := range orders {
+		validated, err := order.NewOrder(o)
+		if err != nil {
+			return nil, fmt.Errorf("entry %d: %w", i, err)
+		}
+		if validated.Request.AccountID != accountID {
+			return nil, fmt.Errorf("entry %d: account id %s does not match snapshot account id %s",
+				i, validated.Request.AccountID, accountID)
+		}
+		if validated.Status.Terminal() {
+			return nil, fmt.Errorf("entry %d: order %s is in terminal status %s and is not open",
+				i, validated.Request.OrderID, validated.Status)
+		}
+		orderID := validated.Request.OrderID
+		if _, ok := seen[orderID]; ok {
+			return nil, fmt.Errorf("entry %d: duplicate order id %s", i, orderID)
+		}
+		seen[orderID] = struct{}{}
+		cloned[i] = cloneOrder(validated)
+	}
+	return cloned, nil
+}
+
+// clonePosition returns a copy of p that shares no pointer state with
+// it, so a caller holding the returned value cannot mutate p through
+// AvgPrice.
+func clonePosition(p order.Position) order.Position {
+	cloned := p
+	if p.AvgPrice != nil {
+		v := *p.AvgPrice
+		cloned.AvgPrice = &v
+	}
+	return cloned
+}
+
+// cloneOrder returns a copy of o that shares no pointer or slice state
+// with it: every *num.Price/*num.Quantity field, Rejection, and the
+// AppliedFillIDs/AppliedBrokerFillIDs slices are independently
+// allocated.
+func cloneOrder(o order.Order) order.Order {
+	cloned := o
+	if o.Request.LimitPrice != nil {
+		v := *o.Request.LimitPrice
+		cloned.Request.LimitPrice = &v
+	}
+	if o.Request.StopPrice != nil {
+		v := *o.Request.StopPrice
+		cloned.Request.StopPrice = &v
+	}
+	if o.AcceptedQuantity != nil {
+		v := *o.AcceptedQuantity
+		cloned.AcceptedQuantity = &v
+	}
+	if o.AcceptedLimitPrice != nil {
+		v := *o.AcceptedLimitPrice
+		cloned.AcceptedLimitPrice = &v
+	}
+	if o.AcceptedStopPrice != nil {
+		v := *o.AcceptedStopPrice
+		cloned.AcceptedStopPrice = &v
+	}
+	if o.AvgFillPrice != nil {
+		v := *o.AvgFillPrice
+		cloned.AvgFillPrice = &v
+	}
+	if o.Rejection != nil {
+		v := *o.Rejection
+		cloned.Rejection = &v
+	}
+	if o.AppliedFillIDs != nil {
+		cloned.AppliedFillIDs = append([]id.FillID(nil), o.AppliedFillIDs...)
+	}
+	if o.AppliedBrokerFillIDs != nil {
+		cloned.AppliedBrokerFillIDs = append([]string(nil), o.AppliedBrokerFillIDs...)
+	}
+	return cloned
+}
+
+// AccountID identifies the account this snapshot describes.
+func (s Snapshot) AccountID() id.AccountID { return s.accountID }
+
+// Broker names the broker or provider that reported this snapshot.
+func (s Snapshot) Broker() string { return s.broker }
+
+// Currency is the account's home/settlement currency.
+func (s Snapshot) Currency() num.Currency { return s.currency }
+
+// AsOf is when the broker observed this state.
+func (s Snapshot) AsOf() time.Time { return s.asOf }
+
+// Cursor is an opaque broker-supplied version or cursor token.
+func (s Snapshot) Cursor() string { return s.cursor }
+
+// CashBalances returns a copy of the account's raw cash ledger balances
+// by currency. Mutating the returned slice does not affect s.
+func (s Snapshot) CashBalances() []num.Money {
+	return append([]num.Money(nil), s.cashBalances...)
+}
+
+// Equity is the broker-reported net liquidation value.
+func (s Snapshot) Equity() num.Money { return s.equity }
+
+// BuyingPower is funds available to open new positions.
+func (s Snapshot) BuyingPower() num.Money { return s.buyingPower }
+
+// MarginUsed is margin currently committed to open positions.
+func (s Snapshot) MarginUsed() num.Money { return s.marginUsed }
+
+// MarginAvailable is margin available for new positions.
+func (s Snapshot) MarginAvailable() num.Money { return s.marginAvailable }
+
+// RealizedPnL is cumulative realized profit and loss.
+func (s Snapshot) RealizedPnL() num.Money { return s.realizedPnL }
+
+// UnrealizedPnL is current unrealized profit and loss on open positions.
+func (s Snapshot) UnrealizedPnL() num.Money { return s.unrealizedPnL }
+
+// Fees is cumulative fees observed as of AsOf.
+func (s Snapshot) Fees() num.Money { return s.fees }
+
+// Financing is cumulative financing/carry cost or credit observed as of
+// AsOf.
+func (s Snapshot) Financing() num.Money { return s.financing }
+
+// Positions returns a deep copy of the account's open positions.
+// Mutating the returned slice, or any *num.Price it reaches through
+// AvgPrice, does not affect s.
+func (s Snapshot) Positions() []order.Position {
+	cloned := make([]order.Position, len(s.positions))
+	for i, p := range s.positions {
+		cloned[i] = clonePosition(p)
+	}
+	return cloned
+}
+
+// OpenOrders returns a deep copy of the account's outstanding orders.
+// Mutating the returned slice, or any pointer/slice field it reaches,
+// does not affect s.
+func (s Snapshot) OpenOrders() []order.Order {
+	cloned := make([]order.Order, len(s.openOrders))
+	for i, o := range s.openOrders {
+		cloned[i] = cloneOrder(o)
+	}
+	return cloned
+}

--- a/account/snapshot.go
+++ b/account/snapshot.go
@@ -2,6 +2,7 @@ package account
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rustyeddy/trader/id"
@@ -82,12 +83,15 @@ type SnapshotParams struct {
 	Financing num.Money
 
 	// Positions is this account's open positions. Every entry's
-	// AccountID must equal AccountID, and no two entries may name the
-	// same (instrument, provider, venue) listing.
+	// AccountID must equal AccountID, every entry's Listing.Provider
+	// must case-insensitively equal Broker, and no two entries may name
+	// the same (instrument, provider, venue) listing.
 	Positions []order.Position
 	// OpenOrders is this account's outstanding orders. Every entry's
-	// Request.AccountID must equal AccountID, no entry may already be
-	// in a terminal Status, and no two entries may share an OrderID.
+	// Request.AccountID must equal AccountID, every entry's
+	// Request.Listing.Provider must case-insensitively equal Broker, no
+	// entry may already be in a terminal Status, and no two entries may
+	// share an OrderID.
 	OpenOrders []order.Order
 }
 
@@ -131,12 +135,12 @@ func NewSnapshot(params SnapshotParams) (Snapshot, error) {
 		}
 	}
 
-	positions, err := checkPositions(params.AccountID, params.Positions)
+	positions, err := checkPositions(params.AccountID, params.Broker, params.Positions)
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("%w: positions: %v", ErrInvalidSnapshot, err)
 	}
 
-	openOrders, err := checkOpenOrders(params.AccountID, params.OpenOrders)
+	openOrders, err := checkOpenOrders(params.AccountID, params.Broker, params.OpenOrders)
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("%w: open orders: %v", ErrInvalidSnapshot, err)
 	}
@@ -188,7 +192,7 @@ func keyFor(l instrument.Listing) listingKey {
 	return listingKey{instrumentID: l.InstrumentID(), provider: l.Provider(), venue: l.Venue()}
 }
 
-func checkPositions(accountID id.AccountID, positions []order.Position) ([]order.Position, error) {
+func checkPositions(accountID id.AccountID, broker string, positions []order.Position) ([]order.Position, error) {
 	seen := make(map[listingKey]struct{}, len(positions))
 	cloned := make([]order.Position, len(positions))
 	for i, p := range positions {
@@ -199,6 +203,10 @@ func checkPositions(accountID id.AccountID, positions []order.Position) ([]order
 		if validated.AccountID != accountID {
 			return nil, fmt.Errorf("entry %d: account id %s does not match snapshot account id %s",
 				i, validated.AccountID, accountID)
+		}
+		if !strings.EqualFold(validated.Listing.Provider(), broker) {
+			return nil, fmt.Errorf("entry %d: listing provider %s does not match snapshot broker %s",
+				i, validated.Listing.Provider(), broker)
 		}
 		key := keyFor(validated.Listing)
 		if _, ok := seen[key]; ok {
@@ -211,7 +219,7 @@ func checkPositions(accountID id.AccountID, positions []order.Position) ([]order
 	return cloned, nil
 }
 
-func checkOpenOrders(accountID id.AccountID, orders []order.Order) ([]order.Order, error) {
+func checkOpenOrders(accountID id.AccountID, broker string, orders []order.Order) ([]order.Order, error) {
 	seen := make(map[id.OrderID]struct{}, len(orders))
 	cloned := make([]order.Order, len(orders))
 	for i, o := range orders {
@@ -222,6 +230,10 @@ func checkOpenOrders(accountID id.AccountID, orders []order.Order) ([]order.Orde
 		if validated.Request.AccountID != accountID {
 			return nil, fmt.Errorf("entry %d: account id %s does not match snapshot account id %s",
 				i, validated.Request.AccountID, accountID)
+		}
+		if !strings.EqualFold(validated.Request.Listing.Provider(), broker) {
+			return nil, fmt.Errorf("entry %d: listing provider %s does not match snapshot broker %s",
+				i, validated.Request.Listing.Provider(), broker)
 		}
 		if validated.Status.Terminal() {
 			return nil, fmt.Errorf("entry %d: order %s is in terminal status %s and is not open",

--- a/account/snapshot_test.go
+++ b/account/snapshot_test.go
@@ -1,0 +1,334 @@
+package account
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validParams(t *testing.T) SnapshotParams {
+	t.Helper()
+	accountID := mustAccountID(t)
+	listing := mustEurUsdListing(t)
+	return SnapshotParams{
+		AccountID:       accountID,
+		Broker:          "OANDA",
+		Currency:        num.MustParseCurrency("USD"),
+		AsOf:            time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC),
+		Cursor:          "cursor-1",
+		CashBalances:    []num.Money{usd("10000"), eur("500")},
+		Equity:          usd("10500"),
+		BuyingPower:     usd("9000"),
+		MarginUsed:      usd("1500"),
+		MarginAvailable: usd("8500"),
+		RealizedPnL:     usd("250"),
+		UnrealizedPnL:   usd("-50"),
+		Fees:            usd("12.34"),
+		Financing:       usd("1.10"),
+		Positions:       []order.Position{mustPosition(t, accountID, listing)},
+		OpenOrders:      []order.Order{mustWorkingOrder(t, accountID, listing)},
+	}
+}
+
+func TestNewSnapshotValid(t *testing.T) {
+	p := validParams(t)
+	s, err := NewSnapshot(p)
+	require.NoError(t, err)
+
+	assert.Equal(t, p.AccountID, s.AccountID())
+	assert.Equal(t, "OANDA", s.Broker())
+	assert.Equal(t, "USD", s.Currency().String())
+	assert.True(t, p.AsOf.Equal(s.AsOf()))
+	assert.Equal(t, "cursor-1", s.Cursor())
+	assert.Equal(t, p.Equity, s.Equity())
+	assert.Equal(t, p.BuyingPower, s.BuyingPower())
+	assert.Equal(t, p.MarginUsed, s.MarginUsed())
+	assert.Equal(t, p.MarginAvailable, s.MarginAvailable())
+	assert.Equal(t, p.RealizedPnL, s.RealizedPnL())
+	assert.Equal(t, p.UnrealizedPnL, s.UnrealizedPnL())
+	assert.Equal(t, p.Fees, s.Fees())
+	assert.Equal(t, p.Financing, s.Financing())
+	assert.Len(t, s.CashBalances(), 2)
+	assert.Len(t, s.Positions(), 1)
+	assert.Len(t, s.OpenOrders(), 1)
+}
+
+// TestSnapshotClonesEveryOrderPointerField exercises cloneOrder against
+// an order carrying every pointer/slice field it must independently
+// clone (Request.LimitPrice/StopPrice, AcceptedLimitPrice/
+// AcceptedStopPrice, AppliedFillIDs, AppliedBrokerFillIDs), by mutating
+// the returned copy through each pointer and slice and confirming a
+// fresh accessor call is unaffected.
+func TestSnapshotClonesEveryOrderPointerField(t *testing.T) {
+	p := validParams(t)
+	listing := mustEurUsdListing(t)
+	o := mustPartiallyFilledLimitOrder(t, p.AccountID, listing)
+	p.OpenOrders = []order.Order{o}
+	// A partial fill leaves the order carrying an accepted quantity
+	// larger than its filled quantity, so it remains open/non-terminal.
+	p.Positions = []order.Position{mustPosition(t, p.AccountID, listing)}
+
+	s, err := NewSnapshot(p)
+	require.NoError(t, err)
+
+	got := s.OpenOrders()
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].Request.LimitPrice)
+	require.NotNil(t, got[0].Request.StopPrice)
+	require.NotNil(t, got[0].AcceptedLimitPrice)
+	require.NotNil(t, got[0].AcceptedStopPrice)
+	require.NotEmpty(t, got[0].AppliedFillIDs)
+	require.NotEmpty(t, got[0].AppliedBrokerFillIDs)
+
+	origLimit := *got[0].Request.LimitPrice
+	origStop := *got[0].Request.StopPrice
+	origAcceptedLimit := *got[0].AcceptedLimitPrice
+	origAcceptedStop := *got[0].AcceptedStopPrice
+	origFillIDCount := len(got[0].AppliedFillIDs)
+	origBrokerFillIDCount := len(got[0].AppliedBrokerFillIDs)
+
+	mutated := num.MustParsePrice("0.00001")
+	*got[0].Request.LimitPrice = mutated
+	*got[0].Request.StopPrice = mutated
+	*got[0].AcceptedLimitPrice = mutated
+	*got[0].AcceptedStopPrice = mutated
+	got[0].AppliedFillIDs = append(got[0].AppliedFillIDs, id.FillID{})
+	got[0].AppliedBrokerFillIDs = append(got[0].AppliedBrokerFillIDs, "tampered")
+
+	again := s.OpenOrders()
+	require.Len(t, again, 1)
+	assert.Equal(t, origLimit, *again[0].Request.LimitPrice)
+	assert.Equal(t, origStop, *again[0].Request.StopPrice)
+	assert.Equal(t, origAcceptedLimit, *again[0].AcceptedLimitPrice)
+	assert.Equal(t, origAcceptedStop, *again[0].AcceptedStopPrice)
+	assert.Len(t, again[0].AppliedFillIDs, origFillIDCount)
+	assert.Len(t, again[0].AppliedBrokerFillIDs, origBrokerFillIDCount)
+}
+
+func TestNewSnapshotRejectsZeroAccountID(t *testing.T) {
+	p := validParams(t)
+	p.AccountID = id.AccountID{}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsMissingBroker(t *testing.T) {
+	p := validParams(t)
+	p.Broker = ""
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsInvalidCurrency(t *testing.T) {
+	p := validParams(t)
+	p.Currency = num.Currency{}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsZeroAsOf(t *testing.T) {
+	p := validParams(t)
+	p.AsOf = time.Time{}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsDuplicateCashBalanceCurrency(t *testing.T) {
+	p := validParams(t)
+	p.CashBalances = []num.Money{usd("100"), usd("200")}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsInvalidCashBalance(t *testing.T) {
+	p := validParams(t)
+	p.CashBalances = []num.Money{{}}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsHomeCurrencyMismatch(t *testing.T) {
+	tests := []struct {
+		name  string
+		apply func(*SnapshotParams)
+	}{
+		{"equity", func(p *SnapshotParams) { p.Equity = eur("1") }},
+		{"buying power", func(p *SnapshotParams) { p.BuyingPower = eur("1") }},
+		{"margin used", func(p *SnapshotParams) { p.MarginUsed = eur("1") }},
+		{"margin available", func(p *SnapshotParams) { p.MarginAvailable = eur("1") }},
+		{"realized pnl", func(p *SnapshotParams) { p.RealizedPnL = eur("1") }},
+		{"unrealized pnl", func(p *SnapshotParams) { p.UnrealizedPnL = eur("1") }},
+		{"fees", func(p *SnapshotParams) { p.Fees = eur("1") }},
+		{"financing", func(p *SnapshotParams) { p.Financing = eur("1") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := validParams(t)
+			tt.apply(&p)
+			_, err := NewSnapshot(p)
+			require.ErrorIs(t, err, ErrInvalidSnapshot)
+		})
+	}
+}
+
+func TestNewSnapshotRejectsInvalidHomeCurrencyField(t *testing.T) {
+	p := validParams(t)
+	p.Equity = num.Money{}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsPositionAccountMismatch(t *testing.T) {
+	p := validParams(t)
+	other := mustAccountID(t)
+	p.Positions = []order.Position{mustPosition(t, other, mustEurUsdListing(t))}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsInvalidPosition(t *testing.T) {
+	p := validParams(t)
+	p.Positions = []order.Position{{AccountID: p.AccountID}}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsDuplicateListingPosition(t *testing.T) {
+	p := validParams(t)
+	listing := mustEurUsdListing(t)
+	p.Positions = []order.Position{
+		mustPosition(t, p.AccountID, listing),
+		mustPosition(t, p.AccountID, listing),
+	}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotAllowsMultipleDistinctPositions(t *testing.T) {
+	p := validParams(t)
+	listing := mustEurUsdListing(t)
+	other := mustGbpUsdListing(t)
+	p.Positions = []order.Position{
+		mustPosition(t, p.AccountID, listing),
+		mustPosition(t, p.AccountID, other),
+	}
+	s, err := NewSnapshot(p)
+	require.NoError(t, err)
+	assert.Len(t, s.Positions(), 2)
+}
+
+func TestNewSnapshotRejectsOpenOrderAccountMismatch(t *testing.T) {
+	p := validParams(t)
+	other := mustAccountID(t)
+	p.OpenOrders = []order.Order{mustWorkingOrder(t, other, mustEurUsdListing(t))}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsInvalidOpenOrder(t *testing.T) {
+	p := validParams(t)
+	p.OpenOrders = []order.Order{{}}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsTerminalOpenOrder(t *testing.T) {
+	p := validParams(t)
+	filled := mustFilledOrder(t, p.AccountID, mustEurUsdListing(t))
+	p.OpenOrders = []order.Order{filled}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsDuplicateOrderID(t *testing.T) {
+	p := validParams(t)
+	o := mustWorkingOrder(t, p.AccountID, mustEurUsdListing(t))
+	p.OpenOrders = []order.Order{o, o}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+// TestCloneOrderClonesRejectionAndAvgFillPrice exercises cloneOrder's
+// Rejection and AvgFillPrice branches directly. Neither field can occur
+// on a Snapshot's OpenOrders in practice — Rejection only coexists with
+// a Terminal Status (order.NewOrder), which checkOpenOrders excludes,
+// and order/transition.go's ApplyFill always clears AvgFillPrice — but
+// cloneOrder is a general Order-copying helper and must not silently
+// alias either pointer if some future caller populates them.
+func TestCloneOrderClonesRejectionAndAvgFillPrice(t *testing.T) {
+	avgFillPrice := num.MustParsePrice("1.10000")
+	o := order.Order{
+		AvgFillPrice: &avgFillPrice,
+		Rejection: &order.Rejection{
+			Reason:     order.ReasonInsufficientMargin,
+			BrokerCode: "INSUFFICIENT_MARGIN",
+		},
+	}
+
+	cloned := cloneOrder(o)
+	require.NotNil(t, cloned.AvgFillPrice)
+	require.NotNil(t, cloned.Rejection)
+	assert.Equal(t, *o.AvgFillPrice, *cloned.AvgFillPrice)
+	assert.Equal(t, *o.Rejection, *cloned.Rejection)
+
+	*cloned.AvgFillPrice = num.MustParsePrice("999")
+	cloned.Rejection.Detail = "tampered"
+
+	assert.Equal(t, avgFillPrice, *o.AvgFillPrice)
+	assert.Equal(t, "", o.Rejection.Detail)
+}
+
+func TestSnapshotCashBalancesIsDefensiveCopy(t *testing.T) {
+	s, err := NewSnapshot(validParams(t))
+	require.NoError(t, err)
+
+	got := s.CashBalances()
+	got[0] = num.Money{}
+
+	again := s.CashBalances()
+	assert.NotEqual(t, num.Money{}, again[0])
+}
+
+func TestSnapshotPositionsIsDeepDefensiveCopy(t *testing.T) {
+	s, err := NewSnapshot(validParams(t))
+	require.NoError(t, err)
+
+	got := s.Positions()
+	require.Len(t, got, 1)
+	original := *got[0].AvgPrice
+
+	// Mutate the pointed-to value in place, not merely the local
+	// pointer, and mutate a plain field for good measure.
+	*got[0].AvgPrice = num.MustParsePrice("999")
+	got[0].Side = order.Short
+
+	again := s.Positions()
+	require.Len(t, again, 1)
+	assert.Equal(t, order.Long, again[0].Side)
+	assert.Equal(t, original, *again[0].AvgPrice)
+}
+
+func TestSnapshotOpenOrdersIsDeepDefensiveCopy(t *testing.T) {
+	s, err := NewSnapshot(validParams(t))
+	require.NoError(t, err)
+
+	got := s.OpenOrders()
+	require.Len(t, got, 1)
+	originalAccepted := *got[0].AcceptedQuantity
+
+	mutatedQty := num.MustParseQuantity("1")
+	*got[0].AcceptedQuantity = mutatedQty
+	got[0].AppliedFillIDs = append(got[0].AppliedFillIDs, id.FillID{})
+	got[0].BrokerOrderID = "tampered"
+
+	again := s.OpenOrders()
+	require.Len(t, again, 1)
+	assert.Equal(t, originalAccepted, *again[0].AcceptedQuantity)
+	assert.Empty(t, again[0].AppliedFillIDs)
+	assert.Equal(t, "broker-order-1", again[0].BrokerOrderID)
+}

--- a/account/snapshot_test.go
+++ b/account/snapshot_test.go
@@ -198,6 +198,15 @@ func TestNewSnapshotRejectsInvalidPosition(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidSnapshot)
 }
 
+func TestNewSnapshotRejectsPositionProviderMismatch(t *testing.T) {
+	p := validParams(t)
+	require.Equal(t, "OANDA", p.Broker)
+	otherProviderListing := mustListing(t, "EUR", "USD", "IBKR", "EURUSD")
+	p.Positions = []order.Position{mustPosition(t, p.AccountID, otherProviderListing)}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
 func TestNewSnapshotRejectsDuplicateListingPosition(t *testing.T) {
 	p := validParams(t)
 	listing := mustEurUsdListing(t)
@@ -207,6 +216,15 @@ func TestNewSnapshotRejectsDuplicateListingPosition(t *testing.T) {
 	}
 	_, err := NewSnapshot(p)
 	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotAllowsCaseInsensitiveProviderMatch(t *testing.T) {
+	p := validParams(t)
+	p.Broker = "oanda"
+	listing := mustEurUsdListing(t) // Provider "OANDA"
+	p.Positions = []order.Position{mustPosition(t, p.AccountID, listing)}
+	_, err := NewSnapshot(p)
+	require.NoError(t, err)
 }
 
 func TestNewSnapshotAllowsMultipleDistinctPositions(t *testing.T) {
@@ -226,6 +244,15 @@ func TestNewSnapshotRejectsOpenOrderAccountMismatch(t *testing.T) {
 	p := validParams(t)
 	other := mustAccountID(t)
 	p.OpenOrders = []order.Order{mustWorkingOrder(t, other, mustEurUsdListing(t))}
+	_, err := NewSnapshot(p)
+	require.ErrorIs(t, err, ErrInvalidSnapshot)
+}
+
+func TestNewSnapshotRejectsOpenOrderProviderMismatch(t *testing.T) {
+	p := validParams(t)
+	require.Equal(t, "OANDA", p.Broker)
+	otherProviderListing := mustListing(t, "EUR", "USD", "IBKR", "EURUSD")
+	p.OpenOrders = []order.Order{mustWorkingOrder(t, p.AccountID, otherProviderListing)}
 	_, err := NewSnapshot(p)
 	require.ErrorIs(t, err, ErrInvalidSnapshot)
 }

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -284,9 +284,9 @@ and =Currency=, backed by a signed scaled int64 at a common 1e8 scale
 accounting boundaries.  =Money= carries a mandatory =Currency= and
 rejects cross-currency arithmetic and comparison outright; the one
 sanctioned currency-conversion operation is =Money.Convert=, added by
-ADR-019 for =portfolio='s cross-account aggregation, which requires an
-explicit target currency and an explicit rate and performs only the
-arithmetic — rate provenance is the caller's responsibility.
+ADR-019 for the =portfolio= package's cross-account aggregation; it
+requires an explicit target currency and an explicit rate and performs
+only the arithmetic — rate provenance is the caller's responsibility.
 
 ** Consequences
 

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -1336,9 +1336,13 @@ this account with no two positions naming the same
 "the venue's listing for an instrument"), and every open order
 revalidated through =order.NewOrder=, belonging to this account, not
 already =Terminal= (=order.Status.Terminal=), and not repeating an
-=OrderID=.  =account.CashLedgerEntry= (deposit/withdrawal history,
-named in the architecture document) is not part of this decision;
-it is additive future work.
+=OrderID=.  Every =Position=/open order's =Listing.Provider= must
+also case-insensitively equal =SnapshotParams.Broker=: a =Snapshot=
+represents one broker account's observation, so a contained listing
+from a different provider would misrepresent whose position or order
+it actually is.  =account.CashLedgerEntry= (deposit/withdrawal
+history, named in the architecture document) is not part of this
+decision; it is additive future work.
 
 =Positions=, =OpenOrders=, and =CashBalances= are deep-copied on
 ingestion and again by every accessor call: =order.Order= and
@@ -1355,8 +1359,11 @@ grow a public cloning API it does not otherwise need.
 values into a =BaseCurrency=-denominated view, constructed via
 =NewPortfolio(PortfolioParams)= the same
 params-struct-in/immutable-value-out way.  Because =num= deliberately
-implements no currency conversion (see =num.Money='s doc comment),
-this decision adds the one sanctioned conversion primitive,
+implements no /implicit/ currency conversion (see =num.Money='s doc
+comment) — =Convert= performs only exact arithmetic for an explicit
+target currency and rate, with no policy about when conversion is
+appropriate or where a rate comes from — this decision adds the one
+sanctioned conversion primitive,
 =Money.Convert(to Currency, rate Rate) (Money, error)=: same
 arithmetic and rounding contract as =MulRate=/=DivRate=, but
 re-denominating into an explicit target currency.  =Convert= performs
@@ -1365,9 +1372,13 @@ only the exact arithmetic; rate provenance is a caller concern.
 =ConversionRate{From, To, Rate, AsOf, Source}=, not a bare
 =map[Currency]Rate=: every supplied rate's =To= must equal
 =BaseCurrency=, its =From= must not already equal =BaseCurrency=, its
-=Rate= must be strictly positive, and its =AsOf= must be set, so a
+=Rate= must be strictly positive, its =AsOf= must be set, and its
+=AsOf= must not be after the =Portfolio='s own =AsOf=, so a
 =Portfolio= can later report exactly which rates, from where and as
-of when, produced its total.
+of when, produced its total, and a historical =Portfolio= can never be
+built from a rate that could not actually have been known as of its
+own observation time — look-ahead a backtest replaying a historical
+=Portfolio.AsOf= must not be able to see.
 
 An account already denominated in =BaseCurrency= needs no rate; an
 account in any other currency needs a matching =ConversionRate= or its
@@ -1424,6 +1435,17 @@ fully immutable, so there is no mutable state an element could expose.
   contract multipliers) or mark-to-market valuation must build that
   themselves from =Exposure.Contributors= today; this package does not
   yet provide it.
+- A =Snapshot= cannot silently accumulate another broker's listings
+  under this account's identity: a caller building one from data that
+  actually spans providers must construct separate =Snapshot= values,
+  one per provider, and let =Portfolio= do the cross-broker
+  aggregation — which is exactly the role =Portfolio.Exposures=
+  exists to fill.
+- A historical =Portfolio= cannot be built, even accidentally, from a
+  conversion rate observed after its own =AsOf=; a caller that only
+  has a same-day or later rate must either accept
+  =ConversionIncomplete= or supply a rate actually available as of
+  that =AsOf=.
 
 ** Alternatives Considered
 
@@ -1460,6 +1482,20 @@ fully immutable, so there is no mutable state an element could expose.
   =Money= is exactly the implicit workaround that comment warns
   against. =Money.Convert= is the explicit, minimal primitive =num=
   was already documented as willing to add for a real consumer.
+- *Validating only =AccountID= consistency for =Positions=/=OpenOrders=,
+  leaving listing provider unchecked.* Rejected on design review: a
+  =Snapshot= with =Broker="OANDA"= could otherwise validly contain a
+  =Listing= whose =Provider()= is =IBKR=, silently misrepresenting
+  which broker a position or order actually came from. Every entry's
+  =Listing.Provider= must now case-insensitively equal
+  =SnapshotParams.Broker=.
+- *Leaving =ConversionRate.AsOf= unconstrained relative to
+  =Portfolio.AsOf=.* Rejected on design review: an unconstrained rate
+  timestamp lets a historical =Portfolio= report =ConversionComplete=
+  using a rate that could not actually have been known as of its own
+  observation time — look-ahead risk that matters most for backtests
+  replaying a historical =Portfolio.AsOf=. =NewPortfolio= now rejects
+  any =ConversionRate= whose =AsOf= is after the =Portfolio='s own.
 
 * ADR Template                                                       :noexport:
 

--- a/docs/arch/adr-decisions.org
+++ b/docs/arch/adr-decisions.org
@@ -70,7 +70,7 @@ believed at that time.
 | 001 | Modular monolith before service decomposition                     | Accepted   |
 | 002 | Ports and adapters dependency direction                           | Accepted   |
 | 003 | Instrument versus listing identity                                | Accepted   |
-| 004 | Exact numeric representation                                      | Proposed   |
+| 004 | Exact numeric representation                                      | Accepted   |
 | 005 | Strategy emits intents, not broker orders                         | Accepted   |
 | 006 | Execution and risk are separate stages                            | Accepted   |
 | 007 | Broker account handle versus account snapshot                     | Accepted   |
@@ -84,6 +84,7 @@ believed at that time.
 | 016 | Symbol and listing resolution                                     | Accepted   |
 | 017 | Broker-neutral order and execution vocabulary                     | Accepted   |
 | 018 | Order lifecycle transition rules                                  | Accepted   |
+| 019 | Account and portfolio snapshot models                             | Accepted   |
 
 * ADR-001: Modular monolith before service decomposition
 
@@ -264,7 +265,7 @@ decision.
 
 ** Status
 
-Proposed
+Accepted
 
 ** Context
 
@@ -277,9 +278,15 @@ yet chosen.
 ** Decision
 
 Introduce distinct exact types for =Price=, =Quantity=, =Money=, =Rate=,
-and =Currency=.  Analytical code may use =float64= internally and convert
-to exact values only at order or accounting boundaries.  The concrete
-backing representation will be selected by a later ADR.
+and =Currency=, backed by a signed scaled int64 at a common 1e8 scale
+(package =num=, =num/internal/fixed=).  Analytical code may use
+=float64= internally and convert to exact values only at order or
+accounting boundaries.  =Money= carries a mandatory =Currency= and
+rejects cross-currency arithmetic and comparison outright; the one
+sanctioned currency-conversion operation is =Money.Convert=, added by
+ADR-019 for =portfolio='s cross-account aggregation, which requires an
+explicit target currency and an explicit rate and performs only the
+arithmetic — rate provenance is the caller's responsibility.
 
 ** Consequences
 
@@ -288,6 +295,9 @@ backing representation will be selected by a later ADR.
 - Requires validation against tick size and quantity increment at
   boundaries.
 - Increases API surface but improves correctness at the accounting edge.
+- Currency conversion is opt-in and explicit rather than an implicit
+  side effect of ordinary arithmetic, which keeps every other =Money=
+  operation safe from silently crossing currencies.
 
 ** Alternatives Considered
 
@@ -1280,6 +1290,176 @@ terms first would misrepresent what actually happened.
   more state than the correlation check needs; a single
   =id.EventID= is sufficient to detect a stale result and imposes no
   obligation to keep a full, possibly-stale copy of the request around.
+
+* ADR-019: Account and portfolio snapshot models
+
+** Status
+
+Accepted
+
+** Context
+
+Issue #30 (M1-12) required broker-neutral, currency-safe value models
+for one broker account's observed state and for a Trader-level view
+spanning several accounts, without implementing broker queries,
+reconciliation, or mutable projections — those remain =live=/future
+=broker= package concerns.  It depends on M1-04 (=num=), M1-07
+(=instrument=), and M1-10 (=order=), all already accepted.  A design
+review on the issue's initial plan identified several gaps before
+implementation: constructing =Snapshot= directly from itself was
+incompatible with keeping its collection fields unexported; a
+shallow slice copy does not protect =order.Order=/=order.Position=,
+both of which carry pointer and slice fields a caller could still
+mutate through a copied element; =map[num.Currency]num.Rate= discards
+exactly the provenance (source, observation time) a report needs to
+explain a converted total; and summing position quantities across
+=Listing= values for the same instrument is not safe in general,
+since =Spec.Multiplier= is not guaranteed identical across venues.
+
+** Decision
+
+=account.Snapshot= is one broker account's authoritative *observed*
+state — not a reconciled or broker-queried one; reconciliation is
+explicitly out of scope and belongs to the future =live= package.  It
+is constructed from a plain =SnapshotParams= value via =NewSnapshot=,
+not from a =Snapshot= itself, since =Snapshot='s own fields are
+unexported so nothing outside =account= can mutate them after
+construction.  =NewSnapshot= validates: non-zero =AccountID=,
+non-empty =Broker=, a valid home =Currency=, a non-zero =AsOf=, no
+duplicate currency among =CashBalances=, every home-currency
+=num.Money= field (=Equity=, =BuyingPower=, =MarginUsed=,
+=MarginAvailable=, =RealizedPnL=, =UnrealizedPnL=, =Fees=,
+=Financing=) valid and denominated in that =Currency=, every
+=Position= revalidated through =order.NewPosition= and belonging to
+this account with no two positions naming the same
+(=instrument.ID=, provider, venue) listing (ADR-016's identity for
+"the venue's listing for an instrument"), and every open order
+revalidated through =order.NewOrder=, belonging to this account, not
+already =Terminal= (=order.Status.Terminal=), and not repeating an
+=OrderID=.  =account.CashLedgerEntry= (deposit/withdrawal history,
+named in the architecture document) is not part of this decision;
+it is additive future work.
+
+=Positions=, =OpenOrders=, and =CashBalances= are deep-copied on
+ingestion and again by every accessor call: =order.Order= and
+=order.Position= both carry pointer fields (=AcceptedQuantity=,
+=AcceptedLimitPrice=, =AcceptedStopPrice=, =AvgFillPrice=,
+=Rejection=, =AvgPrice=) and slice fields
+(=AppliedFillIDs=/=AppliedBrokerFillIDs=) that a shallow =append=
+copy of the outer slice would still share with whatever the snapshot
+holds internally.  =account= owns unexported =cloneOrder=/
+=clonePosition= helpers for this rather than requiring =order= to
+grow a public cloning API it does not otherwise need.
+
+=portfolio.Portfolio= aggregates one or more =account.Snapshot=
+values into a =BaseCurrency=-denominated view, constructed via
+=NewPortfolio(PortfolioParams)= the same
+params-struct-in/immutable-value-out way.  Because =num= deliberately
+implements no currency conversion (see =num.Money='s doc comment),
+this decision adds the one sanctioned conversion primitive,
+=Money.Convert(to Currency, rate Rate) (Money, error)=: same
+arithmetic and rounding contract as =MulRate=/=DivRate=, but
+re-denominating into an explicit target currency.  =Convert= performs
+only the exact arithmetic; rate provenance is a caller concern.
+=portfolio= supplies that provenance itself via
+=ConversionRate{From, To, Rate, AsOf, Source}=, not a bare
+=map[Currency]Rate=: every supplied rate's =To= must equal
+=BaseCurrency=, its =From= must not already equal =BaseCurrency=, its
+=Rate= must be strictly positive, and its =AsOf= must be set, so a
+=Portfolio= can later report exactly which rates, from where and as
+of when, produced its total.
+
+An account already denominated in =BaseCurrency= needs no rate; an
+account in any other currency needs a matching =ConversionRate= or its
+currency is recorded in =MissingCurrencies=.  If every account
+resolves, =ConversionStatus= is =ConversionComplete= and =Equity=
+returns the summed, converted total and =true=; if any account's
+currency has no matching rate, =ConversionStatus= is
+=ConversionIncomplete= and =Equity= returns the zero =Money= and
+=false= — never a partial sum silently presented as complete.
+
+=Portfolio.Exposures= groups every contributing account's =Position=
+by =instrument.ID= — the cross-venue, cross-broker economic
+instrument, and the reason this aggregation lives in =portfolio=
+rather than =account= — but does not sum position quantities into one
+number.  Two =Listing= values for the same instrument are not
+guaranteed to express one =Quantity= unit identically, and no live or
+historical price is available to =portfolio= to convert to a common
+notional value.  Each =Exposure= instead preserves every contributing
+=AccountPosition{AccountID, Position}= unmodified, so a caller with
+the additional data an aggregate would require (multipliers, marks,
+conversion rates) can compute one itself rather than being handed a
+number this package cannot vouch for.
+
+=Portfolio.AsOf= is documented as when the caller assembled the view,
+not a claim that every contributing account was observed
+simultaneously; each account's own =AsOf= survives unchanged through
+=Portfolio.Accounts=, and =Portfolio.AccountAsOfRange= reports the
+oldest and newest of them for a caller that wants to see how stale
+the least current account is. =Portfolio.Accounts= returns a plain
+slice copy rather than a deep clone: =account.Snapshot= is already
+fully immutable, so there is no mutable state an element could expose.
+
+** Consequences
+
+- =account= and =portfolio= gain no dependency on broker I/O,
+  reconciliation, or =live=-session behavior; both packages depend
+  only on =instrument=, =id=, =num=, and (for =portfolio=) =account=,
+  matching =docs/arch/package-boundaries.org='s preliminary map.
+- =Snapshot.Positions()=/=Snapshot.OpenOrders()=/
+  =Portfolio.Exposures()[].Contributors()= are safe to hand to
+  arbitrary calling code: mutating a returned element, including
+  through its pointer fields, cannot affect the snapshot or portfolio
+  it came from.
+- A =Portfolio='s =Equity= is trustworthy by construction: it is
+  either a complete, fully-converted total, or explicitly marked
+  incomplete with the exact missing currencies named — never a
+  quietly wrong partial sum.
+- =Money.Convert= is now part of =num='s public API, exercised first
+  by a real consumer (=portfolio=) rather than spec'd speculatively;
+  ADR-004 is promoted from Proposed to Accepted alongside this
+  decision, since the scaled-int64 backing it describes was already
+  shipped and =Convert= is now built directly on it.
+- Callers wanting summed cross-listing exposure (accounting for
+  contract multipliers) or mark-to-market valuation must build that
+  themselves from =Exposure.Contributors= today; this package does not
+  yet provide it.
+
+** Alternatives Considered
+
+- *=NewSnapshot(Snapshot)=, mirroring =order.NewOrder(Order)=.*
+  Rejected: unlike =order='s types, =Snapshot='s collection fields are
+  unexported precisely so nothing outside =account= can mutate them
+  post-construction, which makes a caller-populated =Snapshot= literal
+  impossible to accept as constructor input in the first place.
+- *Shallow slice-copy accessors (=append([]T(nil), s.field...)=)
+  without deep-cloning pointer fields.* Rejected on design review:
+  demonstrably insufficient, since a caller could still mutate a
+  position's =AvgPrice= or an order's =AcceptedQuantity= through the
+  returned slice's elements while believing the snapshot was
+  immutable.
+- *=map[num.Currency]num.Rate= for portfolio conversion input.*
+  Rejected on design review: it preserves the numeric rate but
+  discards its provenance, and a rate's source/observation time is
+  exactly what a report explaining a converted total needs.
+- *Summing position quantities per instrument across accounts in
+  =Exposures=.* Rejected on design review: blindly summing
+  =Quantity= across =Listing= values is misleading unless their
+  contract multipliers are known to agree, which this package has no
+  way to verify; preserving contributors unmodified keeps the
+  aggregation honest about what it does and does not know.
+- *Requiring every account snapshot in a =Portfolio= to share the same
+  =AsOf=.* Rejected: a portfolio spanning multiple brokers routinely
+  combines observations from slightly different times, and forcing
+  identical timestamps would either be false or would require
+  discarding real accounts from the view.
+- *Deriving currency conversion from =Money.MulRate= directly, or by
+  parsing =Money.String()= to extract a raw amount.* Rejected:
+  =MulRate= deliberately preserves currency and is not conversion by
+  its own doc comment, and string-parsing an amount back out of
+  =Money= is exactly the implicit workaround that comment warns
+  against. =Money.Convert= is the explicit, minimal primitive =num=
+  was already documented as willing to add for a real consumer.
 
 * ADR Template                                                       :noexport:
 

--- a/docs/arch/package-boundaries.org
+++ b/docs/arch/package-boundaries.org
@@ -4,16 +4,17 @@
 
 * Purpose
 
-This document records the package boundary rules for Trader.  It states
-which packages may depend on which, what belongs in a public package
-versus =internal/=, and which behaviors are prohibited inside domain
-code.
+This document records the package boundary rules for Trader.  It
+states which packages may depend on which, what belongs in a public
+package versus =internal/=, and which behaviors are prohibited inside
+domain code.
 
-It is a companion to, not a replacement for, the canonical architecture
-document =docs/arch/trader-framework-architecture.org= and the decision
-registry =docs/arch/adr-decisions.org=.  Where this document and the
-canonical architecture appear to disagree, the canonical architecture
-governs and the disagreement is a defect in this document.
+It is a companion to, not a replacement for, the canonical
+architecture document =docs/arch/trader-framework-architecture.org=
+and the decision registry =docs/arch/adr-decisions.org=.  Where this
+document and the canonical architecture appear to disagree, the
+canonical architecture governs and the disagreement is a defect in
+this document.
 
 This document deliberately does *not* create package directories.  Rules
 are recorded before code exists so that the first implementation lands

--- a/docs/prompts/num-implementation.md
+++ b/docs/prompts/num-implementation.md
@@ -1,0 +1,360 @@
+You are working in the `rustyeddy/trader` repository.
+
+Create and switch to a new branch named:
+
+```text
+num
+```
+
+Before writing code, read the following completely:
+
+1. `docs/arch/adr-004-exact-numeric-representation.org`
+2. GitHub issue `#22` — `M1-04 Implement exact foundational value types`
+
+ADR-004 is the authoritative design contract. Do not reopen or reinterpret its settled decisions unless the document contains a genuine contradiction that prevents implementation. If you encounter such a contradiction, stop and describe it clearly before proceeding.
+
+## Objective
+
+Implement the exact foundational numeric types described by ADR-004 and issue #22 as a clean-room implementation.
+
+Do not copy production numeric code wholesale from `trader-first-try`. The legacy repository may be consulted only for test scenarios, edge cases, golden vectors, or algorithmic lessons. It must not become a dependency.
+
+## Package architecture
+
+Use this package structure:
+
+```text
+num/
+    doc.go
+
+    price.go
+    price_test.go
+
+    quantity.go
+    quantity_test.go
+
+    rate.go
+    rate_test.go
+
+    currency.go
+    currency_test.go
+
+    money.go
+    money_test.go
+
+    encoding.go
+    encoding_test.go
+
+    internal/
+        fixed/
+            scale.go
+            errors.go
+            checked.go
+            wide.go
+            rounding.go
+            decimal.go
+            decimal_test.go
+```
+
+Minor file-name adjustments are acceptable if they improve cohesion, but preserve the package boundaries:
+
+```text
+github.com/rustyeddy/trader/num
+github.com/rustyeddy/trader/num/internal/fixed
+```
+
+Do not create a `pkg/` directory.
+
+## Architectural boundary
+
+The public `num` package contains semantic Trader values:
+
+```go
+num.Price
+num.Quantity
+num.Rate
+num.Currency
+num.Money
+```
+
+The private package:
+
+```text
+num/internal/fixed
+```
+
+contains only exact scaled-integer representation mechanics, including:
+
+* the common scale;
+* checked `int64` arithmetic;
+* signed widened multiplication and division;
+* scale restoration;
+* rounding;
+* exact decimal parsing;
+* canonical decimal formatting;
+* representation-level errors.
+
+Packages outside `num` must never import or access `num/internal/fixed`.
+
+Accounts, brokers, strategies, indicators, risk, portfolio, persistence, and other Trader packages must use the semantic types exported by `num`. They must not know the raw scale, manipulate raw scaled integers, or call generic fixed-point primitives directly.
+
+The architectural rule is:
+
+> Code outside `num` expresses financial intent. Code inside `num/internal/fixed` implements exact representation mechanics.
+
+Do not expose a generic public decimal or fixed-point type.
+
+## Context-dependent arithmetic
+
+Do not place every financial calculation in `num`.
+
+Universally valid semantic operations belong in `num`, for example:
+
+```go
+Price.MulRate(Rate) (Price, error)
+Money.MulRate(Rate) (Money, error)
+Quantity.MulRate(Rate) (Quantity, error)
+
+Money.Add(Money) (Money, error)
+Money.Sub(Money) (Money, error)
+```
+
+Context-dependent calculations belong in their eventual domain packages.
+
+For example:
+
+```text
+Price × Quantity -> Money
+```
+
+may require quotation currency, instrument metadata, contract multipliers, lot conventions, or broker rules. The widened arithmetic primitive belongs in `num/internal/fixed`, but do not invent a context-free public `num` operation when the domain meaning is incomplete.
+
+## Implementation sequence
+
+Implement the work incrementally in reviewable commits.
+
+Recommended order:
+
+1. Add the private fixed-point kernel.
+2. Implement `Rate`.
+3. Implement `Price`.
+4. Implement `Quantity`.
+5. Implement `Currency`.
+6. Implement `Money`.
+7. Implement text and JSON encoding.
+8. Add architecture enforcement and comprehensive tests.
+
+The branch may contain the complete implementation, but each commit should be coherent, focused, and leave the test suite passing.
+
+## Fixed-point kernel requirements
+
+Implement the behavior required by ADR-004, including:
+
+* signed `int64` authoritative representation;
+* common scale `1e8`;
+* checked addition and subtraction;
+* checked negation and absolute value;
+* explicit rejection of invalid `math.MinInt64` operations;
+* widened signed intermediate arithmetic for scaled multiplication and division;
+* no `float64` overflow escape path;
+* default rounding to nearest, ties to even;
+* explicit alternative rounding policies where ADR-004 requires them;
+* division-by-zero detection;
+* overflow and underflow errors;
+* exact decimal parsing without `float64`;
+* full signed `int64` parsing support, including `math.MinInt64`;
+* canonical decimal formatting without `float64`;
+* no scientific notation;
+* no thousands separators;
+* no unnecessary trailing zeros;
+* no trailing decimal point;
+* normalization of negative zero to `0`;
+* exact parse/format round trips.
+
+Normal public operations must return errors. Panic-based `Must...` helpers, if any, are limited to programmer-controlled constants, fixtures, and tests.
+
+Do not silently wrap, clamp, saturate, truncate, or round unless an operation explicitly selects a documented rounding policy.
+
+## Semantic type requirements
+
+Follow ADR-004 exactly.
+
+### Price
+
+* Backed by scaled signed `int64`.
+* Scale `1e8`.
+* Public valid values are normally non-negative.
+* Tick size and display precision are not part of `Price`; they belong to instrument or listing rules.
+* Zero is representable, with validity determined by context.
+
+### Quantity
+
+* Backed by scaled signed `int64`.
+* Scale `1e8`.
+* Public values are non-negative.
+* Direction is represented by order side, never quantity sign.
+* Zero is representable, but order construction will eventually require quantity greater than zero.
+* Increment, minimum, maximum, and integral-only rules belong outside the representation type.
+
+### Rate
+
+* Backed by scaled signed `int64`.
+* Scale `1e8`.
+* Signed.
+* It is the foundational exact dimensionless representation.
+* Domain-specific constraints should eventually use semantic wrappers rather than weakening the base representation.
+
+### Currency
+
+* Validate supported currency identifiers according to the repository’s existing conventions and ADR-004.
+* Do not silently accept malformed or unspecified currencies.
+* Keep the implementation suitable for currencies beyond FX-only assumptions.
+
+### Money
+
+Conceptually:
+
+```go
+type Money struct {
+    amount   int64
+    currency Currency
+}
+```
+
+Requirements:
+
+* Signed amount at scale `1e8`.
+* Currency is mandatory.
+* The Go zero value of `Money` is invalid or unspecified because it has no currency.
+* Valid zero money must be constructed explicitly with a currency.
+* Same-currency addition and subtraction are allowed with checked overflow.
+* Cross-currency arithmetic must return an error.
+* Currency conversion is not implicit.
+* Any future conversion operation must require target currency, rate, and provenance.
+* Do not expose a lower-level currency-free amount as the public domain value.
+
+## Public boundaries
+
+External callers should construct semantic values through exact decimal text or safe semantic constructors.
+
+Raw scaled `int64` construction must be narrowly scoped and clearly identified as already scaled. It is intended only for trusted internal code, persistence reconstruction, representation tests, or similarly controlled use.
+
+Do not expose raw scaled integers as the ordinary public API.
+
+Do not provide implicit `float64` conversion.
+
+Any unavoidable future float conversion belongs in provider adapters, must be explicitly named as rounded or lossy, and must validate NaN, infinity, range, rounding, and semantic invariants.
+
+## Serialization
+
+Implement ADR-004 serialization behavior:
+
+* `Price`, `Quantity`, and `Rate` serialize publicly as canonical decimal strings.
+* `Money` serializes as a structured value containing:
+
+  * canonical decimal amount;
+  * explicit currency.
+* Text and JSON round trips must be exact.
+* Public serialization must not expose raw scaled integers.
+* Writers emit canonical forms.
+* Readers may accept exact equivalent decimal forms when ADR-004 permits them.
+* Do not use `float64` during encoding or decoding.
+
+Persistence-specific database adapters may be deferred if issue #22 does not require a database package yet, but the public types must support exact reconstruction suitable for scaled `BIGINT` plus explicit currency storage.
+
+## Determinism and float containment
+
+Authoritative calculations must be deterministic and exact.
+
+Binary floating point is prohibited from:
+
+* `num`;
+* domain values;
+* brokerage;
+* accounting;
+* risk;
+* orders;
+* positions;
+* portfolio;
+* persistence;
+* authoritative public APIs.
+
+Do not add `float64` fields, parameters, return values, or internal arithmetic to the public `num` implementation.
+
+Indicators may eventually use approved sealed floating-point implementations, but that is outside this package. Such code must accept and return semantic `num` values and quantize before an authoritative decision boundary.
+
+Add an automated check if practical to prevent accidental floating-point use in `num` and `num/internal/fixed`.
+
+## Testing requirements
+
+Implement thorough tests with the code, not afterward.
+
+Include:
+
+* zero, positive, and negative cases where semantically valid;
+* all eight decimal places;
+* trailing-zero acceptance;
+* canonical trailing-zero removal;
+* malformed input;
+* excess precision;
+* out-of-range input;
+* full `math.MinInt64` parsing for signed types;
+* rejection of negative `Price` and `Quantity`;
+* invalid or missing currency;
+* same-currency arithmetic;
+* cross-currency arithmetic rejection;
+* checked overflow and underflow;
+* negation and absolute-value failure at `math.MinInt64`;
+* widened realistic `Price × Rate`;
+* widened realistic `Quantity × Rate`;
+* midpoint rounding for positive and negative values;
+* nearest-even tie behavior;
+* division by zero;
+* exact text round trips;
+* exact JSON round trips;
+* negative-zero normalization;
+* absence of silent wrapping;
+* absence of `float64` in exact parsing, formatting, and arithmetic.
+
+Use table-driven tests where appropriate.
+
+Add fuzz tests or property tests for high-value invariants, especially:
+
+```text
+Parse(Format(x)) == x
+```
+
+and checked arithmetic boundary behavior.
+
+Reuse useful scenarios from `trader-first-try` only after translating them to ADR-004 semantics. Do not preserve obsolete assumptions such as:
+
+* `Price` backed by `int32`;
+* scales of `1e5` or `1e6`;
+* float-based formatting;
+* panic-first external constructors;
+* FX-only precision;
+* currency-free `Money`.
+
+## Quality gates
+
+Before finishing:
+
+1. Run the full repository tests.
+2. Run `make check` if available.
+3. Run formatting and static analysis used by the repository.
+4. Confirm no package outside `num` imports `num/internal/fixed`.
+5. Confirm the implementation does not expose raw scale details unnecessarily.
+6. Confirm the exported API contains only semantically valid operations.
+7. Update issue #22’s implementation notes or prepare a concise PR description mapping the implementation to its acceptance criteria.
+
+Do not merge the branch.
+
+At completion, report:
+
+* commits created;
+* files added or changed;
+* exported API summary;
+* tests added;
+* commands run and results;
+* any intentionally deferred portions of issue #22;
+* any ADR ambiguity encountered.

--- a/num/money.go
+++ b/num/money.go
@@ -12,10 +12,12 @@ import "github.com/rustyeddy/trader/num/internal/fixed"
 // Same-currency amounts may be compared, added, and subtracted with checked
 // arithmetic. Cross-currency arithmetic and comparison are rejected outright:
 // currency is never silently assumed, dropped, or coerced. Currency
-// conversion is not implicit; it is not implemented by this type at all. Any
-// future conversion operation must require an explicit target currency, an
-// explicit rate, and provenance for that rate — Money.MulRate deliberately
-// keeps the existing currency rather than serving as a disguised conversion.
+// conversion is not implicit. Money.MulRate deliberately keeps the existing
+// currency rather than serving as a disguised conversion; Convert is the one
+// method that changes currency, and it requires an explicit target currency
+// and an explicit rate. Convert performs only the arithmetic — rate
+// provenance (source, observation time) is a caller concern, most notably
+// the portfolio package's cross-account aggregation.
 type Money struct {
 	amount   int64
 	currency Currency
@@ -191,6 +193,30 @@ func (m Money) MulRate(r Rate) (Money, error) {
 		return Money{}, wrapFixedErr(err)
 	}
 	return Money{amount: raw, currency: m.currency, valid: true}, nil
+}
+
+// Convert returns m's amount multiplied by rate and re-denominated in to,
+// rounding to nearest with ties to even.
+//
+// Convert is the one sanctioned currency-conversion primitive in num; see
+// the package-level Money doc comment for why MulRate deliberately does
+// not serve this purpose. Convert performs only the exact arithmetic:
+// it has no concept of market data, so callers are responsible for the
+// rate's provenance (source currency pair, observation time, source) and
+// for deciding whether a stale or missing rate is acceptable.
+//
+// Convert reports ErrMissingCurrency if m is invalid or to is not a
+// structurally valid Currency. Converting to m's own currency is
+// permitted and is equivalent to MulRate(rate).
+func (m Money) Convert(to Currency, rate Rate) (Money, error) {
+	if !m.IsValid() || !to.IsValid() {
+		return Money{}, ErrMissingCurrency
+	}
+	raw, err := fixed.MulScaled(m.amount, rate.raw, fixed.RoundHalfEven)
+	if err != nil {
+		return Money{}, wrapFixedErr(err)
+	}
+	return Money{amount: raw, currency: to, valid: true}, nil
 }
 
 // DivRate returns m/r, preserving currency and rounding to nearest with ties

--- a/num/money_test.go
+++ b/num/money_test.go
@@ -205,6 +205,65 @@ func TestMoneyMulRate(t *testing.T) {
 	assert.Equal(t, "USD", got.Currency().String())
 }
 
+func TestMoneyConvert(t *testing.T) {
+	m := usd("100.00")
+	rate := MustParseRate("0.85")
+
+	got, err := m.Convert(MustParseCurrency("EUR"), rate)
+	require.NoError(t, err)
+	assert.Equal(t, "85 EUR", got.String())
+	assert.Equal(t, "EUR", got.Currency().String())
+	assert.Equal(t, "100 USD", m.String(), "Convert must not mutate the receiver")
+}
+
+func TestMoneyConvertToSameCurrency(t *testing.T) {
+	m := usd("100.00")
+
+	got, err := m.Convert(MustParseCurrency("USD"), MustParseRate("1.05"))
+	require.NoError(t, err)
+	assert.Equal(t, "105 USD", got.String())
+}
+
+func TestMoneyConvertRoundsHalfToEven(t *testing.T) {
+	// Mirrors MulRate's rounding contract; Convert differs only in the
+	// resulting currency.
+	m := usd("0.00000005")
+	rate := MustParseRate("1")
+
+	got, err := m.Convert(MustParseCurrency("EUR"), rate)
+	require.NoError(t, err)
+	want, err := m.MulRate(rate)
+	require.NoError(t, err)
+	assert.Equal(t, want.String(), "0.00000005 USD")
+	assert.Equal(t, got.String(), "0.00000005 EUR")
+}
+
+func TestMoneyConvertRejectsInvalidMoney(t *testing.T) {
+	_, err := Money{}.Convert(MustParseCurrency("EUR"), MustParseRate("1"))
+	require.ErrorIs(t, err, ErrMissingCurrency)
+}
+
+func TestMoneyConvertRejectsInvalidTargetCurrency(t *testing.T) {
+	m := usd("100.00")
+	_, err := m.Convert(Currency{}, MustParseRate("1"))
+	require.ErrorIs(t, err, ErrMissingCurrency)
+}
+
+func TestMoneyConvertZeroRate(t *testing.T) {
+	m := usd("100.00")
+	got, err := m.Convert(MustParseCurrency("EUR"), Rate{})
+	require.NoError(t, err)
+	assert.True(t, got.IsZero())
+	assert.Equal(t, "EUR", got.Currency().String())
+}
+
+func TestMoneyConvertNegativeRate(t *testing.T) {
+	m := usd("100.00")
+	got, err := m.Convert(MustParseCurrency("EUR"), MustParseRate("-1"))
+	require.NoError(t, err)
+	assert.Equal(t, "-100 EUR", got.String())
+}
+
 func TestMoneyDivRate(t *testing.T) {
 	m := usd("105.00")
 	rate := MustParseRate("1.05")

--- a/portfolio/conversion.go
+++ b/portfolio/conversion.go
@@ -25,7 +25,11 @@ type ConversionRate struct {
 	// amountInFrom * Rate. Must be strictly positive; a real exchange
 	// rate is never zero or negative.
 	Rate num.Rate
-	// AsOf is when this rate was observed.
+	// AsOf is when this rate was observed. Must not be after the
+	// Portfolio's own AsOf: a rate observed later than the portfolio
+	// being assembled is look-ahead information, most dangerous in a
+	// backtest replaying a historical Portfolio.AsOf against a rate
+	// that could not actually have been known yet.
 	AsOf time.Time
 	// Source names where this rate came from, for example
 	// "oanda.rates" or "ecb.reference". May be empty.
@@ -33,8 +37,8 @@ type ConversionRate struct {
 }
 
 // checkConversionRate validates r against base, the Portfolio's
-// BaseCurrency.
-func checkConversionRate(r ConversionRate, base num.Currency) error {
+// BaseCurrency, and portfolioAsOf, the Portfolio's own AsOf.
+func checkConversionRate(r ConversionRate, base num.Currency, portfolioAsOf time.Time) error {
 	if !r.From.IsValid() {
 		return fmt.Errorf("conversion rate: from currency must be valid")
 	}
@@ -52,6 +56,9 @@ func checkConversionRate(r ConversionRate, base num.Currency) error {
 	}
 	if r.AsOf.IsZero() {
 		return fmt.Errorf("conversion rate: as-of time must be set")
+	}
+	if r.AsOf.After(portfolioAsOf) {
+		return fmt.Errorf("conversion rate: as-of %s is after portfolio as-of %s", r.AsOf, portfolioAsOf)
 	}
 	return nil
 }

--- a/portfolio/conversion.go
+++ b/portfolio/conversion.go
@@ -1,0 +1,57 @@
+package portfolio
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/num"
+)
+
+// ConversionRate is one exchange rate, with provenance, that
+// NewPortfolio may use to convert an account's Equity into a
+// Portfolio's BaseCurrency. num.Rate alone cannot answer "where did
+// this rate come from and when was it observed," which a report
+// explaining a converted total needs.
+type ConversionRate struct {
+	// From is the currency this rate converts out of.
+	From num.Currency
+	// To is the currency this rate converts into. NewPortfolio rejects
+	// any ConversionRate whose To does not equal the Portfolio's
+	// BaseCurrency: a rate targeting some other currency cannot be used
+	// here, and accepting it silently would invite confusing a
+	// same-shaped but wrongly directed rate for a usable one.
+	To num.Currency
+	// Rate converts one unit of From into To: amountInTo =
+	// amountInFrom * Rate. Must be strictly positive; a real exchange
+	// rate is never zero or negative.
+	Rate num.Rate
+	// AsOf is when this rate was observed.
+	AsOf time.Time
+	// Source names where this rate came from, for example
+	// "oanda.rates" or "ecb.reference". May be empty.
+	Source string
+}
+
+// checkConversionRate validates r against base, the Portfolio's
+// BaseCurrency.
+func checkConversionRate(r ConversionRate, base num.Currency) error {
+	if !r.From.IsValid() {
+		return fmt.Errorf("conversion rate: from currency must be valid")
+	}
+	if !r.To.IsValid() {
+		return fmt.Errorf("conversion rate: to currency must be valid")
+	}
+	if !r.To.Equal(base) {
+		return fmt.Errorf("conversion rate: to currency %s does not match base currency %s", r.To, base)
+	}
+	if r.From.Equal(base) {
+		return fmt.Errorf("conversion rate: from currency %s must not equal base currency", r.From)
+	}
+	if r.Rate.Sign() <= 0 {
+		return fmt.Errorf("conversion rate: rate must be strictly positive")
+	}
+	if r.AsOf.IsZero() {
+		return fmt.Errorf("conversion rate: as-of time must be set")
+	}
+	return nil
+}

--- a/portfolio/doc.go
+++ b/portfolio/doc.go
@@ -5,9 +5,12 @@
 //
 // # Currency-safe aggregation
 //
-// num deliberately implements no currency conversion (see the num.Money
-// doc comment and num.Money.Convert); portfolio is the layer that needs
-// it, so it is the layer that owns conversion policy. NewPortfolio takes
+// num deliberately implements no implicit currency conversion (see the
+// num.Money doc comment): Money.Convert performs only the exact
+// arithmetic for an explicit target currency and rate, with no policy
+// about when conversion is appropriate or where a rate comes from.
+// portfolio is the layer that needs that policy, so it is the layer
+// that owns it. NewPortfolio takes
 // a BaseCurrency and a set of ConversionRate values supplied by the
 // caller — portfolio never fetches rates itself. An account already
 // denominated in BaseCurrency needs no rate. An account in any other

--- a/portfolio/doc.go
+++ b/portfolio/doc.go
@@ -1,0 +1,48 @@
+// Package portfolio models a Trader-level view spanning one or more
+// account.Snapshot values (issue #30, M1-12, ADR-019): Portfolio, an
+// immutable aggregate that preserves each contributing account's
+// provenance rather than collapsing accounts into an opaque total.
+//
+// # Currency-safe aggregation
+//
+// num deliberately implements no currency conversion (see the num.Money
+// doc comment and num.Money.Convert); portfolio is the layer that needs
+// it, so it is the layer that owns conversion policy. NewPortfolio takes
+// a BaseCurrency and a set of ConversionRate values supplied by the
+// caller — portfolio never fetches rates itself. An account already
+// denominated in BaseCurrency needs no rate. An account in any other
+// currency needs a matching ConversionRate or its currency is recorded
+// as missing.
+//
+// If every account resolved, ConversionStatus is ConversionComplete and
+// Equity returns the summed, converted total. If any account's currency
+// had no matching rate, ConversionStatus is ConversionIncomplete and
+// Equity's second return value is false rather than a partial or
+// misleading sum — see MissingCurrencies for exactly which currencies
+// blocked it. ConversionRates returns only the rates actually used,
+// preserving the provenance (source, observation time) the caller
+// supplied, so a report can show what produced the total.
+//
+// # Exposure is a grouping, not a valuation
+//
+// Exposures groups positions across every account by instrument.ID —
+// the cross-venue, cross-broker economic instrument, which is why this
+// aggregation belongs in portfolio rather than account. It deliberately
+// does not sum position quantities into a single number: two Listings
+// for the same instrument are not guaranteed to express one Quantity
+// unit identically (Spec.Multiplier can differ), and no live or
+// historical price is available here to convert to a common notional
+// value. Exposure instead preserves every contributing account's own
+// Position unmodified, so a caller with the additional data required
+// (multipliers, marks, conversion rates) can compute a defensible
+// aggregate itself, rather than being handed a number whose units this
+// package cannot vouch for.
+//
+// # Portfolio.AsOf is an observation time, not a claim of simultaneity
+//
+// Portfolio.AsOf is when the caller assembled this view — it does not
+// imply every contributing account.Snapshot was observed at the same
+// instant. Each account's own AsOf is preserved through Accounts;
+// AccountAsOfRange reports the oldest and newest of them for a caller
+// that wants to see how stale the least current account is.
+package portfolio

--- a/portfolio/doc.go
+++ b/portfolio/doc.go
@@ -22,9 +22,20 @@
 // had no matching rate, ConversionStatus is ConversionIncomplete and
 // Equity's second return value is false rather than a partial or
 // misleading sum — see MissingCurrencies for exactly which currencies
-// blocked it. ConversionRates returns only the rates actually used,
-// preserving the provenance (source, observation time) the caller
-// supplied, so a report can show what produced the total.
+// blocked it. In that case ConversionRates is also empty, even for
+// currencies that did resolve before the missing one was found: there
+// is no settled total for a partial rate list to explain. When
+// ConversionStatus is ConversionComplete, ConversionRates returns only
+// the rates actually used, preserving the provenance (source,
+// observation time) the caller supplied, so a report can show what
+// produced the total.
+//
+// Every ConversionRate's AsOf must not be after the Portfolio's own
+// AsOf — NewPortfolio rejects one that is. A rate observed later than
+// the portfolio being assembled is look-ahead information a caller
+// could not actually have had at the time; this matters most for a
+// backtest replaying a historical Portfolio.AsOf, which must not be
+// allowed to see a rate from its own future.
 //
 // # Exposure is a grouping, not a valuation
 //

--- a/portfolio/errors.go
+++ b/portfolio/errors.go
@@ -1,0 +1,7 @@
+package portfolio
+
+import "errors"
+
+// ErrInvalidPortfolio reports a PortfolioParams value that fails
+// NewPortfolio's validation.
+var ErrInvalidPortfolio = errors.New("portfolio: invalid portfolio")

--- a/portfolio/example_test.go
+++ b/portfolio/example_test.go
@@ -1,0 +1,84 @@
+package portfolio_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/clock"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/portfolio"
+)
+
+// Example_newPortfolio aggregates a USD account and a EUR account into
+// one USD-denominated Portfolio.
+func Example_newPortfolio() {
+	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(1, 2))
+	usdAccountID, err := id.GenerateAccountID(g)
+	if err != nil {
+		panic(err)
+	}
+	eurAccountID, err := id.GenerateAccountID(g)
+	if err != nil {
+		panic(err)
+	}
+
+	usd := num.MustParseCurrency("USD")
+	eur := num.MustParseCurrency("EUR")
+	asOf := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+
+	usdAccount, err := account.NewSnapshot(account.SnapshotParams{
+		AccountID:       usdAccountID,
+		Broker:          "OANDA",
+		Currency:        usd,
+		AsOf:            asOf,
+		CashBalances:    []num.Money{num.MustParseMoney("10000", usd)},
+		Equity:          num.MustParseMoney("10000", usd),
+		BuyingPower:     num.MustParseMoney("10000", usd),
+		MarginUsed:      num.MustParseMoney("0", usd),
+		MarginAvailable: num.MustParseMoney("10000", usd),
+		RealizedPnL:     num.MustParseMoney("0", usd),
+		UnrealizedPnL:   num.MustParseMoney("0", usd),
+		Fees:            num.MustParseMoney("0", usd),
+		Financing:       num.MustParseMoney("0", usd),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	eurAccount, err := account.NewSnapshot(account.SnapshotParams{
+		AccountID:       eurAccountID,
+		Broker:          "OANDA",
+		Currency:        eur,
+		AsOf:            asOf,
+		CashBalances:    []num.Money{num.MustParseMoney("1000", eur)},
+		Equity:          num.MustParseMoney("1000", eur),
+		BuyingPower:     num.MustParseMoney("1000", eur),
+		MarginUsed:      num.MustParseMoney("0", eur),
+		MarginAvailable: num.MustParseMoney("1000", eur),
+		RealizedPnL:     num.MustParseMoney("0", eur),
+		UnrealizedPnL:   num.MustParseMoney("0", eur),
+		Fees:            num.MustParseMoney("0", eur),
+		Financing:       num.MustParseMoney("0", eur),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	p, err := portfolio.NewPortfolio(portfolio.PortfolioParams{
+		BaseCurrency: usd,
+		AsOf:         asOf,
+		Accounts:     []account.Snapshot{usdAccount, eurAccount},
+		Rates: []portfolio.ConversionRate{
+			{From: eur, To: usd, Rate: num.MustParseRate("1.10"), AsOf: asOf, Source: "ecb.reference"},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	equity, ok := p.Equity()
+	fmt.Println(p.ConversionStatus(), ok, equity)
+	// Output: complete true 11100 USD
+}

--- a/portfolio/exposure.go
+++ b/portfolio/exposure.go
@@ -1,0 +1,78 @@
+package portfolio
+
+import (
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/order"
+)
+
+// AccountPosition pairs one account's Position with the account it
+// belongs to, preserving provenance inside an Exposure.
+type AccountPosition struct {
+	AccountID id.AccountID
+	Position  order.Position
+}
+
+// Exposure groups every account's Position in one economic instrument
+// (instrument.ID), across every venue and broker it is held through.
+// See the package doc comment for why this is a provenance-preserving
+// grouping, not a summed notional or quantity.
+type Exposure struct {
+	instrumentID instrument.ID
+	contributors []AccountPosition
+}
+
+// InstrumentID identifies the economic instrument this Exposure groups.
+func (e Exposure) InstrumentID() instrument.ID { return e.instrumentID }
+
+// Contributors returns a deep copy of the account positions grouped
+// under this Exposure. Mutating the returned slice, or any *num.Price a
+// Position reaches through AvgPrice, does not affect e.
+func (e Exposure) Contributors() []AccountPosition {
+	cloned := make([]AccountPosition, len(e.contributors))
+	for i, c := range e.contributors {
+		cloned[i] = AccountPosition{AccountID: c.AccountID, Position: clonePosition(c.Position)}
+	}
+	return cloned
+}
+
+// clonePosition returns a copy of p that shares no pointer state with
+// it, mirroring account's identically named, independently maintained
+// helper: portfolio has no reason to depend on account's unexported
+// implementation details for this.
+func clonePosition(p order.Position) order.Position {
+	cloned := p
+	if p.AvgPrice != nil {
+		v := *p.AvgPrice
+		cloned.AvgPrice = &v
+	}
+	return cloned
+}
+
+// buildExposures groups every position across accounts by
+// instrument.ID, preserving each account's Positions() order and the
+// order accounts were supplied in.
+func buildExposures(accounts []account.Snapshot) []Exposure {
+	instrumentOrder := make([]instrument.ID, 0)
+	byInstrument := make(map[instrument.ID][]AccountPosition)
+
+	for _, snapshot := range accounts {
+		for _, pos := range snapshot.Positions() {
+			iid := pos.Listing.InstrumentID()
+			if _, ok := byInstrument[iid]; !ok {
+				instrumentOrder = append(instrumentOrder, iid)
+			}
+			byInstrument[iid] = append(byInstrument[iid], AccountPosition{
+				AccountID: snapshot.AccountID(),
+				Position:  pos,
+			})
+		}
+	}
+
+	exposures := make([]Exposure, 0, len(instrumentOrder))
+	for _, iid := range instrumentOrder {
+		exposures = append(exposures, Exposure{instrumentID: iid, contributors: byInstrument[iid]})
+	}
+	return exposures
+}

--- a/portfolio/exposure_test.go
+++ b/portfolio/exposure_test.go
@@ -31,6 +31,7 @@ func TestPortfolioExposuresGroupsAcrossAccountsByInstrument(t *testing.T) {
 	require.NoError(t, err)
 
 	paramsB := snapshotParamsFor(t, accountB, "USD", "5000")
+	paramsB.Broker = "IBKR"
 	paramsB.Positions = []order.Position{posB}
 	snapB, err := account.NewSnapshot(paramsB)
 	require.NoError(t, err)

--- a/portfolio/exposure_test.go
+++ b/portfolio/exposure_test.go
@@ -1,0 +1,119 @@
+package portfolio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPortfolioExposuresGroupsAcrossAccountsByInstrument(t *testing.T) {
+	accountA := mustAccountID(t)
+	accountB := mustAccountID(t)
+
+	// Same economic instrument (EUR/USD), reached through two different
+	// venues/providers — exactly the cross-broker case portfolio exists
+	// for.
+	listingA := mustListing(t, "EUR", "USD", "OANDA", "EUR_USD")
+	listingB := mustListing(t, "EUR", "USD", "IBKR", "EURUSD")
+
+	posA := mustPosition(t, accountA, listingA)
+	posB := mustPosition(t, accountB, listingB)
+
+	paramsA := snapshotParamsFor(t, accountA, "USD", "10000")
+	paramsA.Positions = []order.Position{posA}
+	snapA, err := account.NewSnapshot(paramsA)
+	require.NoError(t, err)
+
+	paramsB := snapshotParamsFor(t, accountB, "USD", "5000")
+	paramsB.Positions = []order.Position{posB}
+	snapB, err := account.NewSnapshot(paramsB)
+	require.NoError(t, err)
+
+	p, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{snapA, snapB},
+	})
+	require.NoError(t, err)
+
+	exposures := p.Exposures()
+	require.Len(t, exposures, 1)
+	assert.Equal(t, listingA.InstrumentID(), exposures[0].InstrumentID())
+
+	contributors := exposures[0].Contributors()
+	require.Len(t, contributors, 2)
+	assert.Equal(t, accountA, contributors[0].AccountID)
+	assert.Equal(t, accountB, contributors[1].AccountID)
+}
+
+func TestPortfolioExposuresSeparatesDifferentInstruments(t *testing.T) {
+	acctID := mustAccountID(t)
+	eurUsd := mustListing(t, "EUR", "USD", "OANDA", "EUR_USD")
+	gbpUsd := mustListing(t, "GBP", "USD", "OANDA", "GBP_USD")
+
+	posEur := mustPosition(t, acctID, eurUsd)
+	posGbp := mustPosition(t, acctID, gbpUsd)
+
+	params := snapshotParamsFor(t, acctID, "USD", "10000")
+	params.Positions = []order.Position{posEur, posGbp}
+	snap, err := account.NewSnapshot(params)
+	require.NoError(t, err)
+
+	p, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{snap},
+	})
+	require.NoError(t, err)
+
+	exposures := p.Exposures()
+	require.Len(t, exposures, 2)
+}
+
+func TestPortfolioExposuresContributorsIsDeepDefensiveCopy(t *testing.T) {
+	acctID := mustAccountID(t)
+	listing := mustListing(t, "EUR", "USD", "OANDA", "EUR_USD")
+	pos := mustPosition(t, acctID, listing)
+
+	params := snapshotParamsFor(t, acctID, "USD", "10000")
+	params.Positions = []order.Position{pos}
+	snap, err := account.NewSnapshot(params)
+	require.NoError(t, err)
+
+	p, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{snap},
+	})
+	require.NoError(t, err)
+
+	got := p.Exposures()
+	require.Len(t, got, 1)
+	contributors := got[0].Contributors()
+	require.Len(t, contributors, 1)
+	original := *contributors[0].Position.AvgPrice
+
+	*contributors[0].Position.AvgPrice = num.MustParsePrice("999")
+	contributors[0].Position.Side = order.Short
+
+	again := p.Exposures()[0].Contributors()
+	require.Len(t, again, 1)
+	assert.Equal(t, order.Long, again[0].Position.Side)
+	assert.Equal(t, original, *again[0].Position.AvgPrice)
+}
+
+// snapshotParamsFor is like snapshotParams but with a caller-supplied
+// AccountID, so multiple related snapshots can be built for the same
+// portfolio test.
+func snapshotParamsFor(t *testing.T, accountID id.AccountID, currency, equity string) account.SnapshotParams {
+	t.Helper()
+	p := snapshotParams(t, currency, equity)
+	p.AccountID = accountID
+	return p
+}

--- a/portfolio/helpers_test.go
+++ b/portfolio/helpers_test.go
@@ -1,0 +1,99 @@
+package portfolio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/clock"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+	"github.com/stretchr/testify/require"
+)
+
+var sharedTestGenerator = id.NewGenerator(clock.NewSimulated(time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)), id.NewDeterministic(1, 2))
+
+func testGenerator() *id.Generator {
+	return sharedTestGenerator
+}
+
+func mustAccountID(t *testing.T) id.AccountID {
+	t.Helper()
+	aid, err := id.GenerateAccountID(testGenerator())
+	require.NoError(t, err)
+	return aid
+}
+
+func money(t *testing.T, amount, currency string) num.Money {
+	t.Helper()
+	return num.MustParseMoney(amount, num.MustParseCurrency(currency))
+}
+
+func mustListing(t *testing.T, base, quote, provider, symbol string) instrument.Listing {
+	t.Helper()
+	inst, err := instrument.NewCurrencyPair(num.MustParseCurrency(base), num.MustParseCurrency(quote))
+	require.NoError(t, err)
+	spec, err := instrument.NewSpec(
+		num.MustParsePrice("0.00001"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		num.MustParseCurrency(quote),
+	)
+	require.NoError(t, err)
+	listing, err := instrument.NewListing(instrument.ListingParams{
+		Instrument: inst,
+		Provider:   provider,
+		Symbol:     symbol,
+		Spec:       spec,
+		Tradable:   true,
+	})
+	require.NoError(t, err)
+	return listing
+}
+
+func mustPosition(t *testing.T, accountID id.AccountID, listing instrument.Listing) order.Position {
+	t.Helper()
+	price := num.MustParsePrice("1.10000")
+	p, err := order.NewPosition(order.Position{
+		AccountID: accountID,
+		Listing:   listing,
+		Side:      order.Long,
+		Quantity:  num.MustParseQuantity("1000"),
+		AvgPrice:  &price,
+	})
+	require.NoError(t, err)
+	return p
+}
+
+// snapshotParams returns a minimal, valid account.SnapshotParams in
+// currency, with no cash balances beyond the account's own currency and
+// no open orders.
+func snapshotParams(t *testing.T, currency string, equity string) account.SnapshotParams {
+	t.Helper()
+	cur := num.MustParseCurrency(currency)
+	zero := num.MustParseMoney("0", cur)
+	return account.SnapshotParams{
+		AccountID:       mustAccountID(t),
+		Broker:          "OANDA",
+		Currency:        cur,
+		AsOf:            time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC),
+		CashBalances:    []num.Money{num.MustParseMoney(equity, cur)},
+		Equity:          num.MustParseMoney(equity, cur),
+		BuyingPower:     num.MustParseMoney(equity, cur),
+		MarginUsed:      zero,
+		MarginAvailable: num.MustParseMoney(equity, cur),
+		RealizedPnL:     zero,
+		UnrealizedPnL:   zero,
+		Fees:            zero,
+		Financing:       zero,
+	}
+}
+
+func mustSnapshot(t *testing.T, currency, equity string) account.Snapshot {
+	t.Helper()
+	s, err := account.NewSnapshot(snapshotParams(t, currency, equity))
+	require.NoError(t, err)
+	return s
+}

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -1,0 +1,269 @@
+package portfolio
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+)
+
+// ConversionStatus reports whether a Portfolio's Equity could be
+// computed for every contributing account. Like order.Status, its zero
+// value, ConversionUnknown, is reserved for an unconstructed Portfolio
+// rather than silently meaning "complete" — NewPortfolio always sets it
+// to ConversionComplete or ConversionIncomplete and never leaves it
+// Unknown.
+type ConversionStatus uint8
+
+const (
+	// ConversionUnknown is ConversionStatus's zero value.
+	ConversionUnknown ConversionStatus = iota
+	// ConversionComplete means every account's Equity was resolved into
+	// the Portfolio's BaseCurrency.
+	ConversionComplete
+	// ConversionIncomplete means at least one account's currency had no
+	// matching ConversionRate; see MissingCurrencies.
+	ConversionIncomplete
+)
+
+// String returns a human-readable ConversionStatus name.
+func (s ConversionStatus) String() string {
+	switch s {
+	case ConversionComplete:
+		return "complete"
+	case ConversionIncomplete:
+		return "incomplete"
+	default:
+		return fmt.Sprintf("ConversionStatus(%d)", uint8(s))
+	}
+}
+
+// Portfolio is a Trader-level view spanning one or more account.Snapshot
+// values. It is immutable; construct one with NewPortfolio.
+type Portfolio struct {
+	baseCurrency num.Currency
+	asOf         time.Time
+
+	accounts []account.Snapshot
+
+	conversionStatus  ConversionStatus
+	conversionRates   []ConversionRate
+	missingCurrencies []num.Currency
+	equity            *num.Money
+
+	exposures []Exposure
+}
+
+// PortfolioParams supplies NewPortfolio's input.
+type PortfolioParams struct {
+	// BaseCurrency is the reporting currency Equity is expressed in.
+	BaseCurrency num.Currency
+	// AsOf is when the caller assembled this view; see the package doc
+	// comment for why this is distinct from any account's own AsOf.
+	AsOf time.Time
+	// Accounts is every account.Snapshot this Portfolio spans. Must be
+	// non-empty, and no two entries may share an AccountID.
+	Accounts []account.Snapshot
+	// Rates supplies whatever exchange rates the caller has for
+	// converting an account's currency into BaseCurrency. An account
+	// already denominated in BaseCurrency needs no entry. At most one
+	// entry per From currency is allowed.
+	Rates []ConversionRate
+}
+
+// NewPortfolio validates params and returns an immutable Portfolio.
+func NewPortfolio(params PortfolioParams) (Portfolio, error) {
+	if !params.BaseCurrency.IsValid() {
+		return Portfolio{}, fmt.Errorf("%w: base currency must be valid", ErrInvalidPortfolio)
+	}
+	if params.AsOf.IsZero() {
+		return Portfolio{}, fmt.Errorf("%w: as-of time must be set", ErrInvalidPortfolio)
+	}
+	if len(params.Accounts) == 0 {
+		return Portfolio{}, fmt.Errorf("%w: at least one account is required", ErrInvalidPortfolio)
+	}
+
+	accounts, err := checkAccounts(params.Accounts)
+	if err != nil {
+		return Portfolio{}, fmt.Errorf("%w: accounts: %v", ErrInvalidPortfolio, err)
+	}
+
+	rateByFrom, err := checkRates(params.Rates, params.BaseCurrency)
+	if err != nil {
+		return Portfolio{}, fmt.Errorf("%w: rates: %v", ErrInvalidPortfolio, err)
+	}
+
+	status, usedRates, missing, equity, err := aggregateEquity(accounts, params.BaseCurrency, rateByFrom)
+	if err != nil {
+		return Portfolio{}, fmt.Errorf("%w: %v", ErrInvalidPortfolio, err)
+	}
+
+	return Portfolio{
+		baseCurrency:      params.BaseCurrency,
+		asOf:              params.AsOf,
+		accounts:          accounts,
+		conversionStatus:  status,
+		conversionRates:   usedRates,
+		missingCurrencies: missing,
+		equity:            equity,
+		exposures:         buildExposures(accounts),
+	}, nil
+}
+
+func checkAccounts(accounts []account.Snapshot) ([]account.Snapshot, error) {
+	seen := make(map[id.AccountID]struct{}, len(accounts))
+	cloned := make([]account.Snapshot, len(accounts))
+	for i, a := range accounts {
+		if a.AccountID().IsZero() {
+			return nil, fmt.Errorf("entry %d: account snapshot must be constructed with NewSnapshot", i)
+		}
+		if _, ok := seen[a.AccountID()]; ok {
+			return nil, fmt.Errorf("entry %d: duplicate account id %s", i, a.AccountID())
+		}
+		seen[a.AccountID()] = struct{}{}
+		cloned[i] = a
+	}
+	return cloned, nil
+}
+
+func checkRates(rates []ConversionRate, base num.Currency) (map[num.Currency]ConversionRate, error) {
+	byFrom := make(map[num.Currency]ConversionRate, len(rates))
+	for i, r := range rates {
+		if err := checkConversionRate(r, base); err != nil {
+			return nil, fmt.Errorf("entry %d: %w", i, err)
+		}
+		if _, ok := byFrom[r.From]; ok {
+			return nil, fmt.Errorf("entry %d: duplicate rate for currency %s", i, r.From)
+		}
+		byFrom[r.From] = r
+	}
+	return byFrom, nil
+}
+
+// aggregateEquity converts and sums each account's Equity into base,
+// using rateByFrom for any account not already denominated in base.
+func aggregateEquity(accounts []account.Snapshot, base num.Currency, rateByFrom map[num.Currency]ConversionRate) (ConversionStatus, []ConversionRate, []num.Currency, *num.Money, error) {
+	var (
+		usedRates   []ConversionRate
+		usedFrom    = make(map[num.Currency]struct{})
+		missing     []num.Currency
+		missingSeen = make(map[num.Currency]struct{})
+		total       num.Money
+		haveTotal   bool
+	)
+
+	for _, a := range accounts {
+		cur := a.Currency()
+
+		var converted num.Money
+		switch {
+		case cur.Equal(base):
+			converted = a.Equity()
+		default:
+			rate, ok := rateByFrom[cur]
+			if !ok {
+				if _, seen := missingSeen[cur]; !seen {
+					missingSeen[cur] = struct{}{}
+					missing = append(missing, cur)
+				}
+				continue
+			}
+			var err error
+			converted, err = a.Equity().Convert(base, rate.Rate)
+			if err != nil {
+				return ConversionUnknown, nil, nil, nil, fmt.Errorf("account %s: converting equity: %w", a.AccountID(), err)
+			}
+			if _, ok := usedFrom[cur]; !ok {
+				usedFrom[cur] = struct{}{}
+				usedRates = append(usedRates, rate)
+			}
+		}
+
+		if !haveTotal {
+			total = converted
+			haveTotal = true
+			continue
+		}
+		var err error
+		total, err = total.Add(converted)
+		if err != nil {
+			return ConversionUnknown, nil, nil, nil, fmt.Errorf("summing equity: %w", err)
+		}
+	}
+
+	if len(missing) > 0 {
+		return ConversionIncomplete, usedRates, missing, nil, nil
+	}
+	return ConversionComplete, usedRates, nil, &total, nil
+}
+
+// BaseCurrency is the reporting currency Equity is expressed in.
+func (p Portfolio) BaseCurrency() num.Currency { return p.baseCurrency }
+
+// AsOf is when this Portfolio was assembled.
+func (p Portfolio) AsOf() time.Time { return p.asOf }
+
+// Accounts returns a copy of the account snapshots this Portfolio
+// spans, preserving each account's provenance. account.Snapshot is
+// itself immutable, so copying the slice is sufficient — there is no
+// mutable state a caller could reach through an element.
+func (p Portfolio) Accounts() []account.Snapshot {
+	return append([]account.Snapshot(nil), p.accounts...)
+}
+
+// AccountAsOfRange returns the oldest and newest AsOf among this
+// Portfolio's accounts.
+func (p Portfolio) AccountAsOfRange() (oldest, newest time.Time) {
+	for i, a := range p.accounts {
+		if i == 0 || a.AsOf().Before(oldest) {
+			oldest = a.AsOf()
+		}
+		if i == 0 || a.AsOf().After(newest) {
+			newest = a.AsOf()
+		}
+	}
+	return oldest, newest
+}
+
+// ConversionStatus reports whether Equity could be computed for every
+// account.
+func (p Portfolio) ConversionStatus() ConversionStatus { return p.conversionStatus }
+
+// MissingCurrencies names the currencies that blocked a complete
+// conversion, in the order first encountered. Empty when
+// ConversionStatus is ConversionComplete.
+func (p Portfolio) MissingCurrencies() []num.Currency {
+	return append([]num.Currency(nil), p.missingCurrencies...)
+}
+
+// ConversionRates returns a copy of the ConversionRate values actually
+// used to compute Equity, one per distinct currency converted. Empty if
+// every account was already in BaseCurrency, or if ConversionStatus is
+// ConversionIncomplete.
+func (p Portfolio) ConversionRates() []ConversionRate {
+	return append([]ConversionRate(nil), p.conversionRates...)
+}
+
+// Equity returns the sum of every account's Equity, converted into
+// BaseCurrency, and true — unless ConversionStatus is
+// ConversionIncomplete, in which case it returns the zero Money and
+// false rather than a partial or misleading total.
+func (p Portfolio) Equity() (num.Money, bool) {
+	if p.equity == nil {
+		return num.Money{}, false
+	}
+	return *p.equity, true
+}
+
+// Exposures returns a deep copy of this Portfolio's per-instrument
+// position groupings. See the package doc comment for why this is a
+// grouping, not a valuation.
+func (p Portfolio) Exposures() []Exposure {
+	cloned := make([]Exposure, len(p.exposures))
+	for i, e := range p.exposures {
+		cloned[i] = Exposure{instrumentID: e.instrumentID, contributors: e.Contributors()}
+	}
+	return cloned
+}

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -194,7 +194,12 @@ func aggregateEquity(accounts []account.Snapshot, base num.Currency, rateByFrom 
 	}
 
 	if len(missing) > 0 {
-		return ConversionIncomplete, usedRates, missing, nil, nil
+		// usedRates only reflects accounts processed before the loop
+		// found a missing currency, not a settled answer to "what was
+		// used to compute Equity" — there is no such total in the
+		// incomplete case, so ConversionRates must not return a
+		// partial, possibly-misleading subset alongside it.
+		return ConversionIncomplete, nil, missing, nil, nil
 	}
 	return ConversionComplete, usedRates, nil, &total, nil
 }

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -90,7 +90,7 @@ func NewPortfolio(params PortfolioParams) (Portfolio, error) {
 		return Portfolio{}, fmt.Errorf("%w: accounts: %v", ErrInvalidPortfolio, err)
 	}
 
-	rateByFrom, err := checkRates(params.Rates, params.BaseCurrency)
+	rateByFrom, err := checkRates(params.Rates, params.BaseCurrency, params.AsOf)
 	if err != nil {
 		return Portfolio{}, fmt.Errorf("%w: rates: %v", ErrInvalidPortfolio, err)
 	}
@@ -128,10 +128,10 @@ func checkAccounts(accounts []account.Snapshot) ([]account.Snapshot, error) {
 	return cloned, nil
 }
 
-func checkRates(rates []ConversionRate, base num.Currency) (map[num.Currency]ConversionRate, error) {
+func checkRates(rates []ConversionRate, base num.Currency, portfolioAsOf time.Time) (map[num.Currency]ConversionRate, error) {
 	byFrom := make(map[num.Currency]ConversionRate, len(rates))
 	for i, r := range rates {
-		if err := checkConversionRate(r, base); err != nil {
+		if err := checkConversionRate(r, base, portfolioAsOf); err != nil {
 			return nil, fmt.Errorf("entry %d: %w", i, err)
 		}
 		if _, ok := byFrom[r.From]; ok {

--- a/portfolio/portfolio_test.go
+++ b/portfolio/portfolio_test.go
@@ -1,0 +1,228 @@
+package portfolio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/num"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPortfolioSingleAccountSameCurrency(t *testing.T) {
+	acct := mustSnapshot(t, "USD", "10000")
+	p, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{acct},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ConversionComplete, p.ConversionStatus())
+	equity, ok := p.Equity()
+	require.True(t, ok)
+	assert.Equal(t, "10000 USD", equity.String())
+	assert.Empty(t, p.MissingCurrencies())
+	assert.Empty(t, p.ConversionRates())
+}
+
+func TestNewPortfolioMultiAccountSameCurrency(t *testing.T) {
+	a := mustSnapshot(t, "USD", "10000")
+	b := mustSnapshot(t, "USD", "5000")
+	p, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{a, b},
+	})
+	require.NoError(t, err)
+
+	equity, ok := p.Equity()
+	require.True(t, ok)
+	assert.Equal(t, "15000 USD", equity.String())
+}
+
+func TestNewPortfolioMultiCurrencyComplete(t *testing.T) {
+	usdAcct := mustSnapshot(t, "USD", "10000")
+	eurAcct := mustSnapshot(t, "EUR", "1000")
+
+	p, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{usdAcct, eurAcct},
+		Rates: []ConversionRate{
+			{
+				From:   num.MustParseCurrency("EUR"),
+				To:     num.MustParseCurrency("USD"),
+				Rate:   num.MustParseRate("1.10"),
+				AsOf:   time.Date(2026, 1, 2, 12, 30, 0, 0, time.UTC),
+				Source: "ecb.reference",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ConversionComplete, p.ConversionStatus())
+	equity, ok := p.Equity()
+	require.True(t, ok)
+	assert.Equal(t, "11100 USD", equity.String())
+
+	rates := p.ConversionRates()
+	require.Len(t, rates, 1)
+	assert.Equal(t, "ecb.reference", rates[0].Source)
+}
+
+func TestNewPortfolioMissingRateIsIncomplete(t *testing.T) {
+	usdAcct := mustSnapshot(t, "USD", "10000")
+	eurAcct := mustSnapshot(t, "EUR", "1000")
+	gbpAcct := mustSnapshot(t, "GBP", "500")
+
+	p, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{usdAcct, eurAcct, gbpAcct},
+		Rates: []ConversionRate{
+			{
+				From: num.MustParseCurrency("EUR"),
+				To:   num.MustParseCurrency("USD"),
+				Rate: num.MustParseRate("1.10"),
+				AsOf: time.Date(2026, 1, 2, 12, 30, 0, 0, time.UTC),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ConversionIncomplete, p.ConversionStatus())
+	_, ok := p.Equity()
+	assert.False(t, ok)
+
+	missing := p.MissingCurrencies()
+	require.Len(t, missing, 1)
+	assert.Equal(t, "GBP", missing[0].String())
+}
+
+func TestNewPortfolioRejectsInvalidBaseCurrency(t *testing.T) {
+	_, err := NewPortfolio(PortfolioParams{
+		AsOf:     time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts: []account.Snapshot{mustSnapshot(t, "USD", "1")},
+	})
+	require.ErrorIs(t, err, ErrInvalidPortfolio)
+}
+
+func TestNewPortfolioRejectsZeroAsOf(t *testing.T) {
+	_, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		Accounts:     []account.Snapshot{mustSnapshot(t, "USD", "1")},
+	})
+	require.ErrorIs(t, err, ErrInvalidPortfolio)
+}
+
+func TestNewPortfolioRejectsNoAccounts(t *testing.T) {
+	_, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+	})
+	require.ErrorIs(t, err, ErrInvalidPortfolio)
+}
+
+func TestNewPortfolioRejectsDuplicateAccountID(t *testing.T) {
+	acct := mustSnapshot(t, "USD", "1")
+	_, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{acct, acct},
+	})
+	require.ErrorIs(t, err, ErrInvalidPortfolio)
+}
+
+func TestNewPortfolioRejectsRateNotTargetingBase(t *testing.T) {
+	_, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{mustSnapshot(t, "EUR", "1")},
+		Rates: []ConversionRate{
+			{
+				From: num.MustParseCurrency("EUR"),
+				To:   num.MustParseCurrency("GBP"),
+				Rate: num.MustParseRate("1"),
+				AsOf: time.Date(2026, 1, 2, 12, 30, 0, 0, time.UTC),
+			},
+		},
+	})
+	require.ErrorIs(t, err, ErrInvalidPortfolio)
+}
+
+func TestNewPortfolioRejectsNonPositiveRate(t *testing.T) {
+	_, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{mustSnapshot(t, "EUR", "1")},
+		Rates: []ConversionRate{
+			{
+				From: num.MustParseCurrency("EUR"),
+				To:   num.MustParseCurrency("USD"),
+				Rate: num.MustParseRate("0"),
+				AsOf: time.Date(2026, 1, 2, 12, 30, 0, 0, time.UTC),
+			},
+		},
+	})
+	require.ErrorIs(t, err, ErrInvalidPortfolio)
+}
+
+func TestNewPortfolioRejectsDuplicateRateCurrency(t *testing.T) {
+	_, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{mustSnapshot(t, "EUR", "1")},
+		Rates: []ConversionRate{
+			{From: num.MustParseCurrency("EUR"), To: num.MustParseCurrency("USD"), Rate: num.MustParseRate("1.10"), AsOf: time.Date(2026, 1, 2, 12, 30, 0, 0, time.UTC)},
+			{From: num.MustParseCurrency("EUR"), To: num.MustParseCurrency("USD"), Rate: num.MustParseRate("1.11"), AsOf: time.Date(2026, 1, 2, 12, 30, 0, 0, time.UTC)},
+		},
+	})
+	require.ErrorIs(t, err, ErrInvalidPortfolio)
+}
+
+func TestNewPortfolioRejectsRateFromEqualsBase(t *testing.T) {
+	_, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{mustSnapshot(t, "USD", "1")},
+		Rates: []ConversionRate{
+			{From: num.MustParseCurrency("USD"), To: num.MustParseCurrency("USD"), Rate: num.MustParseRate("1"), AsOf: time.Date(2026, 1, 2, 12, 30, 0, 0, time.UTC)},
+		},
+	})
+	require.ErrorIs(t, err, ErrInvalidPortfolio)
+}
+
+func TestPortfolioAccountsPreservesProvenance(t *testing.T) {
+	a := mustSnapshot(t, "USD", "10000")
+	b := mustSnapshot(t, "EUR", "1000")
+	p, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{a, b},
+		Rates: []ConversionRate{
+			{From: num.MustParseCurrency("EUR"), To: num.MustParseCurrency("USD"), Rate: num.MustParseRate("1.1"), AsOf: time.Date(2026, 1, 2, 12, 30, 0, 0, time.UTC)},
+		},
+	})
+	require.NoError(t, err)
+
+	got := p.Accounts()
+	require.Len(t, got, 2)
+	assert.Equal(t, a.AccountID(), got[0].AccountID())
+	assert.Equal(t, b.AccountID(), got[1].AccountID())
+}
+
+func TestPortfolioAccountAsOfRange(t *testing.T) {
+	a := mustSnapshot(t, "USD", "10000")
+	p, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC),
+		Accounts:     []account.Snapshot{a},
+	})
+	require.NoError(t, err)
+
+	oldest, newest := p.AccountAsOfRange()
+	assert.Equal(t, a.AsOf(), oldest)
+	assert.Equal(t, a.AsOf(), newest)
+}

--- a/portfolio/portfolio_test.go
+++ b/portfolio/portfolio_test.go
@@ -99,6 +99,10 @@ func TestNewPortfolioMissingRateIsIncomplete(t *testing.T) {
 	missing := p.MissingCurrencies()
 	require.Len(t, missing, 1)
 	assert.Equal(t, "GBP", missing[0].String())
+
+	// ConversionRates must not report a partial, seemingly-usable subset
+	// when Equity itself could not be computed.
+	assert.Empty(t, p.ConversionRates())
 }
 
 func TestNewPortfolioRejectsInvalidBaseCurrency(t *testing.T) {

--- a/portfolio/portfolio_test.go
+++ b/portfolio/portfolio_test.go
@@ -173,6 +173,45 @@ func TestNewPortfolioRejectsNonPositiveRate(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidPortfolio)
 }
 
+func TestNewPortfolioRejectsFutureDatedRate(t *testing.T) {
+	portfolioAsOf := time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC)
+	_, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         portfolioAsOf,
+		Accounts:     []account.Snapshot{mustSnapshot(t, "EUR", "1")},
+		Rates: []ConversionRate{
+			{
+				From: num.MustParseCurrency("EUR"),
+				To:   num.MustParseCurrency("USD"),
+				Rate: num.MustParseRate("1.1"),
+				// One second after Portfolio.AsOf: look-ahead the
+				// portfolio could not actually have had.
+				AsOf: portfolioAsOf.Add(time.Second),
+			},
+		},
+	})
+	require.ErrorIs(t, err, ErrInvalidPortfolio)
+}
+
+func TestNewPortfolioAllowsRateAsOfExactlyPortfolioAsOf(t *testing.T) {
+	portfolioAsOf := time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC)
+	p, err := NewPortfolio(PortfolioParams{
+		BaseCurrency: num.MustParseCurrency("USD"),
+		AsOf:         portfolioAsOf,
+		Accounts:     []account.Snapshot{mustSnapshot(t, "EUR", "1000")},
+		Rates: []ConversionRate{
+			{
+				From: num.MustParseCurrency("EUR"),
+				To:   num.MustParseCurrency("USD"),
+				Rate: num.MustParseRate("1.1"),
+				AsOf: portfolioAsOf,
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ConversionComplete, p.ConversionStatus())
+}
+
 func TestNewPortfolioRejectsDuplicateRateCurrency(t *testing.T) {
 	_, err := NewPortfolio(PortfolioParams{
 		BaseCurrency: num.MustParseCurrency("USD"),


### PR DESCRIPTION
## Summary

Implements #30: broker-neutral, currency-safe value models for one
broker account's observed state, and a Trader-level view spanning
multiple accounts.

- `account.Snapshot` (`SnapshotParams` → `NewSnapshot`) models one
  account's balances, margin, PnL, fees/financing, positions, and open
  orders. Validates account/currency/provenance invariants (no
  duplicate cash-balance currency, every home-currency field matches
  the account's `Currency`, every position/order belongs to this
  account, no duplicate listing/order id, no terminal open orders) and
  deep-clones `Positions`/`OpenOrders`/`CashBalances` on ingestion and
  on every accessor call, so returned collections — including nested
  pointer fields like `AvgPrice`/`AcceptedQuantity`/`Rejection` — can
  never mutate stored snapshot state.
- `portfolio.Portfolio` (`PortfolioParams` → `NewPortfolio`) aggregates
  one or more `account.Snapshot` values into a `BaseCurrency` total,
  using explicit `ConversionRate{From, To, Rate, AsOf, Source}`
  provenance rather than a bare rate map. If any account's currency has
  no matching rate, `ConversionStatus` is `ConversionIncomplete` and
  `Equity()` returns `(zero, false)` instead of a misleading partial
  sum — never a false total. `Exposures()` groups positions across
  accounts by `instrument.ID` (the cross-broker economic instrument)
  but deliberately does not sum quantities across `Listing`s, since
  contract multipliers aren't guaranteed to agree; it preserves every
  contributing `AccountPosition` instead.
- `num.Money` gains `Convert(to, rate)`, the one sanctioned
  currency-conversion primitive its own doc comment already
  anticipated ("any future conversion operation must require an
  explicit target currency, an explicit rate, and provenance for that
  rate"); `MulRate` continues to deliberately not serve this purpose.
- ADR-019 records these decisions. ADR-004 (exact numeric
  representation) is promoted from Proposed to Accepted, since the
  scaled-int64 backing it describes was already shipped and `Convert`
  is now built directly on it.

This follows the plan and design-review comments left on #30: params-
struct construction (not `NewSnapshot(Snapshot)`, since `Snapshot`'s
collection fields are unexported), deep rather than shallow defensive
copying, first-class conversion-rate provenance, a provenance-only
(non-summed) `Exposure` model, `Status.Terminal()` enforcement on open
orders, and `Portfolio.AsOf` documented as an observation time rather
than a claim every account shares one instant (see
`AccountAsOfRange`).

## Test plan

- [x] `account`: table tests over every `NewSnapshot` invariant,
      deep-defensive-copy tests for `Positions`/`OpenOrders`/
      `CashBalances` (including direct pointer/slice mutation), a
      direct `cloneOrder` unit test covering `Rejection`/`AvgFillPrice`
      (unreachable through `NewSnapshot` today, since terminal orders
      are excluded from `OpenOrders`, but `cloneOrder` is a general
      helper that must not alias either pointer)
- [x] `portfolio`: single/multi-account same-currency, multi-currency
      complete conversion, missing-rate incomplete conversion,
      duplicate account/rate rejection, rate-direction/sign validation,
      cross-account exposure grouping with deep-copy verification
- [x] `num`: `Convert` valid/zero-rate/negative-rate/invalid-money/
      invalid-target-currency/rounding cases
- [x] `go test -race ./...` and `make check` (fmt, vet, test, race) —
      all green
- [x] Coverage: `account` 100%, `portfolio` 91%, `num` 93.2%

## Documentation

- New ADR-019 (account and portfolio snapshot models)
- ADR-004 promoted from Proposed to Accepted
- Decision index updated

https://claude.ai/code/session_01FsfxQH4YBP5DA1LpAafWyt