### PR TITLE
M1-13: public tradertest foundation (scoped per #31)

### DIFF
--- a/tradertest/account.go
+++ b/tradertest/account.go
@@ -1,0 +1,142 @@
+package tradertest
+
+import (
+	"time"
+
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+)
+
+// DefaultAsOf is a fixed reference time for builders in this package
+// that need one. It carries no significance beyond being deterministic
+// and reused, matching every M1 test fixture's habit of hard-coding one
+// literal date rather than calling time.Now.
+var DefaultAsOf = time.Date(2026, time.January, 2, 12, 0, 0, 0, time.UTC)
+
+// SnapshotParams builds an account.Snapshot. AccountID is required;
+// Broker, Currency, AsOf, and Equity default to "OANDA", "USD",
+// DefaultAsOf, and "10000". CashBalances defaults to a single entry
+// holding Equity in Currency. BuyingPower and MarginAvailable default
+// to Equity; MarginUsed, RealizedPnL, UnrealizedPnL, Fees, and
+// Financing default to zero — the common case of an account test only
+// cares about one or two of these fields and would otherwise have to
+// populate all nine by hand.
+type SnapshotParams struct {
+	AccountID       id.AccountID
+	Broker          string
+	Currency        string
+	AsOf            time.Time
+	Cursor          string
+	CashBalances    []num.Money
+	Equity          string
+	BuyingPower     string
+	MarginUsed      string
+	MarginAvailable string
+	RealizedPnL     string
+	UnrealizedPnL   string
+	Fees            string
+	Financing       string
+	Positions       []order.Position
+	OpenOrders      []order.Order
+}
+
+// NewSnapshot returns a valid account.Snapshot built from p, filling in
+// defaults for zero-valued fields.
+func NewSnapshot(p SnapshotParams) (account.Snapshot, error) {
+	if p.Broker == "" {
+		p.Broker = "OANDA"
+	}
+	if p.Currency == "" {
+		p.Currency = "USD"
+	}
+	if p.AsOf.IsZero() {
+		p.AsOf = DefaultAsOf
+	}
+	if p.Equity == "" {
+		p.Equity = "10000"
+	}
+	if p.BuyingPower == "" {
+		p.BuyingPower = p.Equity
+	}
+	if p.MarginAvailable == "" {
+		p.MarginAvailable = p.Equity
+	}
+	for _, s := range []*string{&p.MarginUsed, &p.RealizedPnL, &p.UnrealizedPnL, &p.Fees, &p.Financing} {
+		if *s == "" {
+			*s = "0"
+		}
+	}
+
+	currency, err := num.ParseCurrency(p.Currency)
+	if err != nil {
+		return account.Snapshot{}, err
+	}
+
+	equity, err := num.ParseMoney(p.Equity, currency)
+	if err != nil {
+		return account.Snapshot{}, err
+	}
+	buyingPower, err := num.ParseMoney(p.BuyingPower, currency)
+	if err != nil {
+		return account.Snapshot{}, err
+	}
+	marginUsed, err := num.ParseMoney(p.MarginUsed, currency)
+	if err != nil {
+		return account.Snapshot{}, err
+	}
+	marginAvailable, err := num.ParseMoney(p.MarginAvailable, currency)
+	if err != nil {
+		return account.Snapshot{}, err
+	}
+	realizedPnL, err := num.ParseMoney(p.RealizedPnL, currency)
+	if err != nil {
+		return account.Snapshot{}, err
+	}
+	unrealizedPnL, err := num.ParseMoney(p.UnrealizedPnL, currency)
+	if err != nil {
+		return account.Snapshot{}, err
+	}
+	fees, err := num.ParseMoney(p.Fees, currency)
+	if err != nil {
+		return account.Snapshot{}, err
+	}
+	financing, err := num.ParseMoney(p.Financing, currency)
+	if err != nil {
+		return account.Snapshot{}, err
+	}
+
+	cashBalances := p.CashBalances
+	if cashBalances == nil {
+		cashBalances = []num.Money{equity}
+	}
+
+	return account.NewSnapshot(account.SnapshotParams{
+		AccountID:       p.AccountID,
+		Broker:          p.Broker,
+		Currency:        currency,
+		AsOf:            p.AsOf,
+		Cursor:          p.Cursor,
+		CashBalances:    cashBalances,
+		Equity:          equity,
+		BuyingPower:     buyingPower,
+		MarginUsed:      marginUsed,
+		MarginAvailable: marginAvailable,
+		RealizedPnL:     realizedPnL,
+		UnrealizedPnL:   unrealizedPnL,
+		Fees:            fees,
+		Financing:       financing,
+		Positions:       p.Positions,
+		OpenOrders:      p.OpenOrders,
+	})
+}
+
+// MustNewSnapshot is like NewSnapshot but panics on error.
+func MustNewSnapshot(p SnapshotParams) account.Snapshot {
+	s, err := NewSnapshot(p)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}

--- a/tradertest/account.go
+++ b/tradertest/account.go
@@ -9,20 +9,32 @@ import (
 	"github.com/rustyeddy/trader/order"
 )
 
-// DefaultAsOf is a fixed reference time for builders in this package
-// that need one. It carries no significance beyond being deterministic
-// and reused, matching every M1 test fixture's habit of hard-coding one
-// literal date rather than calling time.Now.
-var DefaultAsOf = time.Date(2026, time.January, 2, 12, 0, 0, 0, time.UTC)
+// defaultAsOf is the fixed reference time DefaultAsOf returns. It
+// carries no significance beyond being deterministic and reused,
+// matching every M1 test fixture's habit of hard-coding one literal
+// date rather than calling time.Now. It is unexported and returned
+// only through a function, not an exported var: a mutable package-level
+// variable would let one test's assignment leak into every other test
+// sharing this default, which is exactly the kind of global mutable
+// state a determinism-focused package must not introduce.
+var defaultAsOf = time.Date(2026, time.January, 2, 12, 0, 0, 0, time.UTC)
+
+// DefaultAsOf returns the fixed reference time builders in this package
+// use when AsOf is left zero. Tests that need to compare against the
+// default explicitly (rather than just accepting whatever a builder
+// produced) can call this instead of hard-coding the literal date
+// themselves.
+func DefaultAsOf() time.Time { return defaultAsOf }
 
 // SnapshotParams builds an account.Snapshot. AccountID is required;
 // Broker, Currency, AsOf, and Equity default to "OANDA", "USD",
-// DefaultAsOf, and "10000". CashBalances defaults to a single entry
-// holding Equity in Currency. BuyingPower and MarginAvailable default
-// to Equity; MarginUsed, RealizedPnL, UnrealizedPnL, Fees, and
-// Financing default to zero — the common case of an account test only
-// cares about one or two of these fields and would otherwise have to
-// populate all nine by hand.
+// DefaultAsOf(), and "10000". CashBalances defaults, when nil, to a
+// single entry holding Equity in Currency; an explicitly empty
+// (non-nil) slice is preserved as-is rather than defaulted. BuyingPower
+// and MarginAvailable default to Equity; MarginUsed, RealizedPnL,
+// UnrealizedPnL, Fees, and Financing default to zero — the common case
+// of an account test only cares about one or two of these fields and
+// would otherwise have to populate all nine by hand.
 type SnapshotParams struct {
 	AccountID       id.AccountID
 	Broker          string
@@ -52,7 +64,7 @@ func NewSnapshot(p SnapshotParams) (account.Snapshot, error) {
 		p.Currency = "USD"
 	}
 	if p.AsOf.IsZero() {
-		p.AsOf = DefaultAsOf
+		p.AsOf = defaultAsOf
 	}
 	if p.Equity == "" {
 		p.Equity = "10000"

--- a/tradertest/account_test.go
+++ b/tradertest/account_test.go
@@ -19,7 +19,7 @@ func TestNewSnapshotDefaults(t *testing.T) {
 
 	assert.Equal(t, "OANDA", s.Broker())
 	assert.Equal(t, "USD", s.Currency().String())
-	assert.True(t, tradertest.DefaultAsOf.Equal(s.AsOf()))
+	assert.True(t, tradertest.DefaultAsOf().Equal(s.AsOf()))
 	assert.Empty(t, s.Positions())
 	assert.Empty(t, s.OpenOrders())
 	tradertest.AssertMoneyEqual(t, s.Equity(), s.BuyingPower())
@@ -62,6 +62,18 @@ func TestNewSnapshotExplicitCashBalances(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Len(t, s.CashBalances(), 2)
+}
+
+func TestNewSnapshotExplicitEmptyCashBalancesIsPreserved(t *testing.T) {
+	g := testGenerator()
+	s, err := tradertest.NewSnapshot(tradertest.SnapshotParams{
+		AccountID:    tradertest.MustAccountID(g),
+		CashBalances: []num.Money{},
+	})
+	require.NoError(t, err)
+	// A nil CashBalances would have defaulted to one entry holding
+	// Equity; an explicitly empty, non-nil slice must not be defaulted.
+	assert.Empty(t, s.CashBalances())
 }
 
 func TestNewSnapshotRejectsInvalidCurrency(t *testing.T) {

--- a/tradertest/account_test.go
+++ b/tradertest/account_test.go
@@ -1,0 +1,80 @@
+package tradertest_test
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+	"github.com/rustyeddy/trader/tradertest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSnapshotDefaults(t *testing.T) {
+	g := testGenerator()
+	s, err := tradertest.NewSnapshot(tradertest.SnapshotParams{
+		AccountID: tradertest.MustAccountID(g),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "OANDA", s.Broker())
+	assert.Equal(t, "USD", s.Currency().String())
+	assert.True(t, tradertest.DefaultAsOf.Equal(s.AsOf()))
+	assert.Empty(t, s.Positions())
+	assert.Empty(t, s.OpenOrders())
+	tradertest.AssertMoneyEqual(t, s.Equity(), s.BuyingPower())
+}
+
+func TestNewSnapshotWithPositionsAndOrders(t *testing.T) {
+	g := testGenerator()
+	accountID := tradertest.MustAccountID(g)
+	listing := tradertest.MustNewListing(tradertest.ListingParams{})
+
+	position := tradertest.MustNewPosition(tradertest.PositionParams{
+		AccountID: accountID,
+		Listing:   listing,
+	})
+	proposal := tradertest.MustNewProposal(tradertest.ProposalParams{
+		Listing:   listing,
+		AccountID: accountID,
+	})
+	request, err := order.NewRequest(proposal, tradertest.MustOrderID(g))
+	require.NoError(t, err)
+	workingOrder := tradertest.MustNewOrder(tradertest.OrderParams{Request: request})
+
+	s, err := tradertest.NewSnapshot(tradertest.SnapshotParams{
+		AccountID:  accountID,
+		Positions:  []order.Position{position},
+		OpenOrders: []order.Order{workingOrder},
+	})
+	require.NoError(t, err)
+	assert.Len(t, s.Positions(), 1)
+	assert.Len(t, s.OpenOrders(), 1)
+}
+
+func TestNewSnapshotExplicitCashBalances(t *testing.T) {
+	g := testGenerator()
+	usd := "USD"
+	s, err := tradertest.NewSnapshot(tradertest.SnapshotParams{
+		AccountID:    tradertest.MustAccountID(g),
+		Currency:     usd,
+		CashBalances: []num.Money{num.MustParseMoney("1", num.MustParseCurrency(usd)), num.MustParseMoney("2", num.MustParseCurrency("EUR"))},
+	})
+	require.NoError(t, err)
+	assert.Len(t, s.CashBalances(), 2)
+}
+
+func TestNewSnapshotRejectsInvalidCurrency(t *testing.T) {
+	g := testGenerator()
+	_, err := tradertest.NewSnapshot(tradertest.SnapshotParams{
+		AccountID: tradertest.MustAccountID(g),
+		Currency:  "not-a-currency",
+	})
+	require.Error(t, err)
+}
+
+func TestMustNewSnapshotPanicsOnError(t *testing.T) {
+	assert.Panics(t, func() {
+		tradertest.MustNewSnapshot(tradertest.SnapshotParams{})
+	})
+}

--- a/tradertest/assert.go
+++ b/tradertest/assert.go
@@ -1,0 +1,81 @@
+package tradertest
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertMoneyEqual asserts that want and got are the same amount in the
+// same currency, using num.Money.Equal rather than assert.Equal's
+// struct-reflection comparison: Money.Equal treats a currency mismatch
+// as simply unequal, not a comparison error, which is the semantics a
+// domain-aware assertion should report.
+func AssertMoneyEqual(t assert.TestingT, want, got num.Money, msgAndArgs ...any) bool {
+	helper(t)
+	if want.Equal(got) {
+		return true
+	}
+	return assert.Fail(t, fmt.Sprintf("Money not equal:\nwant: %s\ngot:  %s", want, got), msgAndArgs...)
+}
+
+// AssertPriceEqual asserts that want and got are the same exact price,
+// using num.Price.Equal.
+func AssertPriceEqual(t assert.TestingT, want, got num.Price, msgAndArgs ...any) bool {
+	helper(t)
+	if want.Equal(got) {
+		return true
+	}
+	return assert.Fail(t, fmt.Sprintf("Price not equal:\nwant: %s\ngot:  %s", want, got), msgAndArgs...)
+}
+
+// AssertQuantityEqual asserts that want and got are the same exact
+// quantity, using num.Quantity.Equal.
+func AssertQuantityEqual(t assert.TestingT, want, got num.Quantity, msgAndArgs ...any) bool {
+	helper(t)
+	if want.Equal(got) {
+		return true
+	}
+	return assert.Fail(t, fmt.Sprintf("Quantity not equal:\nwant: %s\ngot:  %s", want, got), msgAndArgs...)
+}
+
+// AssertRateEqual asserts that want and got are the same exact rate,
+// using num.Rate.Equal.
+func AssertRateEqual(t assert.TestingT, want, got num.Rate, msgAndArgs ...any) bool {
+	helper(t)
+	if want.Equal(got) {
+		return true
+	}
+	return assert.Fail(t, fmt.Sprintf("Rate not equal:\nwant: %s\ngot:  %s", want, got), msgAndArgs...)
+}
+
+// AssertStatus asserts that o's Status is want.
+func AssertStatus(t assert.TestingT, want order.Status, o order.Order, msgAndArgs ...any) bool {
+	helper(t)
+	if o.Status == want {
+		return true
+	}
+	return assert.Fail(t, fmt.Sprintf("Order status not equal:\nwant: %s\ngot:  %s", want, o.Status), msgAndArgs...)
+}
+
+// AssertTerminal asserts that o's Status is a terminal one (see
+// order.Status.Terminal): StatusFilled, StatusCanceled, StatusRejected,
+// or StatusExpired.
+func AssertTerminal(t assert.TestingT, o order.Order, msgAndArgs ...any) bool {
+	helper(t)
+	if o.Status.Terminal() {
+		return true
+	}
+	return assert.Fail(t, fmt.Sprintf("Order status %s is not terminal", o.Status), msgAndArgs...)
+}
+
+// helper marks the calling assertion as a test helper when t supports
+// it (as *testing.T and *testing.B do), so failure line numbers point
+// at the caller rather than into tradertest.
+func helper(t assert.TestingT) {
+	if h, ok := t.(interface{ Helper() }); ok {
+		h.Helper()
+	}
+}

--- a/tradertest/assert_test.go
+++ b/tradertest/assert_test.go
@@ -1,0 +1,96 @@
+package tradertest_test
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+	"github.com/rustyeddy/trader/tradertest"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockT records whether Errorf was called, without depending on
+// *testing.T's own pass/fail bookkeeping, so we can assert that a
+// tradertest assertion reports failure without actually failing this
+// test.
+type mockT struct {
+	failed bool
+}
+
+func (m *mockT) Errorf(format string, args ...any) { m.failed = true }
+
+func TestAssertMoneyEqual(t *testing.T) {
+	usd := num.MustParseCurrency("USD")
+	a := num.MustParseMoney("100", usd)
+	b := num.MustParseMoney("100", usd)
+	c := num.MustParseMoney("200", usd)
+
+	assert.True(t, tradertest.AssertMoneyEqual(t, a, b))
+
+	m := &mockT{}
+	tradertest.AssertMoneyEqual(m, a, c)
+	assert.True(t, m.failed)
+}
+
+func TestAssertPriceEqual(t *testing.T) {
+	a := num.MustParsePrice("1.10000")
+	b := num.MustParsePrice("1.10000")
+	c := num.MustParsePrice("1.20000")
+
+	assert.True(t, tradertest.AssertPriceEqual(t, a, b))
+
+	m := &mockT{}
+	tradertest.AssertPriceEqual(m, a, c)
+	assert.True(t, m.failed)
+}
+
+func TestAssertQuantityEqual(t *testing.T) {
+	a := num.MustParseQuantity("100")
+	b := num.MustParseQuantity("100")
+	c := num.MustParseQuantity("200")
+
+	assert.True(t, tradertest.AssertQuantityEqual(t, a, b))
+
+	m := &mockT{}
+	tradertest.AssertQuantityEqual(m, a, c)
+	assert.True(t, m.failed)
+}
+
+func TestAssertRateEqual(t *testing.T) {
+	a := num.MustParseRate("1.1")
+	b := num.MustParseRate("1.1")
+	c := num.MustParseRate("1.2")
+
+	assert.True(t, tradertest.AssertRateEqual(t, a, b))
+
+	m := &mockT{}
+	tradertest.AssertRateEqual(m, a, c)
+	assert.True(t, m.failed)
+}
+
+func TestAssertStatus(t *testing.T) {
+	o := mustWorkingOrder(t)
+
+	assert.True(t, tradertest.AssertStatus(t, order.StatusWorking, o))
+
+	m := &mockT{}
+	tradertest.AssertStatus(m, order.StatusFilled, o)
+	assert.True(t, m.failed)
+}
+
+func TestAssertTerminal(t *testing.T) {
+	g := testGenerator()
+	o := mustWorkingOrder(t)
+	f := tradertest.MustNewFillFor(tradertest.FillParams{
+		Order:  o,
+		FillID: tradertest.MustFillID(g),
+	})
+	filled, err := order.ApplyFill(o, f)
+	assert.NoError(t, err)
+
+	assert.True(t, tradertest.AssertTerminal(t, filled))
+
+	m := &mockT{}
+	tradertest.AssertTerminal(m, o)
+	assert.True(t, m.failed)
+}

--- a/tradertest/doc.go
+++ b/tradertest/doc.go
@@ -1,0 +1,56 @@
+// Package tradertest provides deterministic public builders and
+// assertions for testing code that consumes Trader's M1 domain packages
+// (issue #31, M1-13): instrument, order, account, and portfolio.
+//
+// # Why this package exists
+//
+// By M1-12, every one of instrument, order, account, and portfolio had
+// accumulated its own private, near-identical "build me a valid EUR/USD
+// listing" or "build me a working order" test helper. tradertest exists
+// to hold that boilerplate once, as public API, so an external consumer
+// writing tests against Trader does not have to reinvent it — not to be
+// a second, more convenient API layered on top of the real one.
+//
+// # What belongs here, and the rule for adding more
+//
+// A helper belongs in this package only if it is needed by an
+// external-consumer test or replaces boilerplate that already existed,
+// repeated, in M1's own tests. Concretely, that is:
+//
+//   - Instrument and listing builders (NewListing).
+//   - Proposal, order, fill, and position builders (NewProposal,
+//     NewOrder, NewFillFor, NewPosition).
+//   - Account and portfolio snapshot builders (NewSnapshot,
+//     NewPortfolio).
+//   - Currency-aware exact-value assertions and a couple of order-state
+//     assertions (AssertMoneyEqual and friends, AssertStatus,
+//     AssertTerminal).
+//
+// Every builder here takes a small params struct with sensible defaults
+// and returns the real domain type via the real domain constructor
+// (order.NewProposal, account.NewSnapshot, and so on) — never a
+// parallel object model, and never a value that bypasses the domain
+// package's own validation. A Must-prefixed variant of each builder
+// panics on error for terse test setup; the plain variant returns the
+// error so a caller can deliberately build an invalid fixture and
+// inspect what went wrong.
+//
+// # What does not belong here
+//
+// Deterministic time and identifiers are already public, already
+// correct, and already exactly what every M1 package's own tests use
+// directly: clock.NewSimulated for time, and
+// id.NewGenerator(clock, id.NewDeterministic(seed1, seed2)) plus
+// id.GenerateAccountID and friends for identifiers. tradertest does not
+// wrap or re-export either — most builders here that need an identifier
+// simply accept an *id.Generator, the same way the real constructors
+// accept whatever identity a caller already has.
+//
+// marketdata.Quote and marketdata.Bar do not exist yet (M2, not M1), so
+// there are no quote or bar fixtures here; adding them now would mean
+// pre-designing M2's types from inside an M1 issue. In-memory historical
+// sources, live feeds, simulated broker presets, strategy harnesses, and
+// golden journal/report helpers are later-milestone tradertest
+// responsibilities per the architecture document and do not belong in
+// this package until the packages they build on exist.
+package tradertest

--- a/tradertest/example_test.go
+++ b/tradertest/example_test.go
@@ -1,0 +1,98 @@
+package tradertest_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/clock"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/order"
+	"github.com/rustyeddy/trader/tradertest"
+)
+
+// Example_buildOrderLifecycle is the acceptance scenario for issue #31:
+// an external-package test builds an instrument, an order, a fill, and
+// an account snapshot with little boilerplate, using only tradertest
+// and the public M1 packages it builds on.
+func Example_buildOrderLifecycle() {
+	// Deterministic time and identifiers: tradertest does not wrap
+	// these, so build them the same way any Trader consumer would.
+	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(1, 2))
+	accountID := tradertest.MustAccountID(g)
+
+	listing := tradertest.MustNewListing(tradertest.ListingParams{})
+
+	proposal := tradertest.MustNewProposal(tradertest.ProposalParams{
+		Listing:   listing,
+		AccountID: accountID,
+	})
+	request, err := order.NewRequest(proposal, tradertest.MustOrderID(g))
+	if err != nil {
+		panic(err)
+	}
+	workingOrder := tradertest.MustNewOrder(tradertest.OrderParams{Request: request})
+
+	fill := tradertest.MustNewFillFor(tradertest.FillParams{
+		Order:  workingOrder,
+		FillID: tradertest.MustFillID(g),
+	})
+	filledOrder, err := order.ApplyFill(workingOrder, fill)
+	if err != nil {
+		panic(err)
+	}
+
+	position := tradertest.MustNewPosition(tradertest.PositionParams{
+		AccountID: accountID,
+		Listing:   listing,
+	})
+
+	snapshot := tradertest.MustNewSnapshot(tradertest.SnapshotParams{
+		AccountID:  accountID,
+		Positions:  []order.Position{position},
+		OpenOrders: []order.Order{},
+	})
+
+	fmt.Println(filledOrder.Status, len(snapshot.Positions()), snapshot.Broker())
+	// Output: filled 1 OANDA
+}
+
+// Example_newSnapshot shows a minimal account.Snapshot built with only
+// the fields a given test cares about — the rest default to zero or to
+// the snapshot's own Equity, rather than requiring all nine num.Money
+// fields to be populated by hand.
+func Example_newSnapshot() {
+	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(1, 2))
+
+	snapshot := tradertest.MustNewSnapshot(tradertest.SnapshotParams{
+		AccountID: tradertest.MustAccountID(g),
+		Equity:    "25000",
+	})
+
+	fmt.Println(snapshot.Broker(), snapshot.Equity())
+	// Output: OANDA 25000 USD
+}
+
+// Example_newPortfolio aggregates two account snapshots already in the
+// portfolio's base currency, so no conversion rate is required.
+func Example_newPortfolio() {
+	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(1, 2))
+
+	a := tradertest.MustNewSnapshot(tradertest.SnapshotParams{
+		AccountID: tradertest.MustAccountID(g),
+		Equity:    "10000",
+	})
+	b := tradertest.MustNewSnapshot(tradertest.SnapshotParams{
+		AccountID: tradertest.MustAccountID(g),
+		Broker:    "IBKR",
+		Equity:    "5000",
+	})
+
+	p := tradertest.MustNewPortfolio(tradertest.PortfolioParams{
+		Accounts: []account.Snapshot{a, b},
+	})
+
+	equity, _ := p.Equity()
+	fmt.Println(p.ConversionStatus(), equity)
+	// Output: complete 15000 USD
+}

--- a/tradertest/fill.go
+++ b/tradertest/fill.go
@@ -1,0 +1,72 @@
+package tradertest
+
+import (
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+)
+
+// FillParams builds an order.Fill whose identifying fields (OrderID,
+// BrokerOrderID, AccountID, Listing, Side) match Order, so it passes
+// order.ApplyFill's identity checks. FillID is required — build one
+// with MustFillID. Quantity defaults to Order's remaining quantity
+// (order.Order.RemainingQuantity); Price defaults to Order's
+// AcceptedLimitPrice if set, otherwise "1.10000".
+type FillParams struct {
+	Order        order.Order
+	FillID       id.FillID
+	BrokerFillID string
+	Quantity     string
+	Price        string
+}
+
+// NewFillFor returns a valid order.Fill built from p, filling in
+// defaults for zero-valued fields.
+func NewFillFor(p FillParams) (order.Fill, error) {
+	quantity, err := fillQuantity(p)
+	if err != nil {
+		return order.Fill{}, err
+	}
+	price, err := fillPrice(p)
+	if err != nil {
+		return order.Fill{}, err
+	}
+
+	return order.NewFill(order.Fill{
+		FillID:        p.FillID,
+		OrderID:       p.Order.Request.OrderID,
+		BrokerOrderID: p.Order.BrokerOrderID,
+		BrokerFillID:  p.BrokerFillID,
+		AccountID:     p.Order.Request.AccountID,
+		Listing:       p.Order.Request.Listing,
+		Side:          p.Order.Request.Side,
+		Price:         price,
+		Quantity:      quantity,
+	})
+}
+
+func fillQuantity(p FillParams) (num.Quantity, error) {
+	if p.Quantity != "" {
+		return num.ParseQuantity(p.Quantity)
+	}
+	return p.Order.RemainingQuantity()
+}
+
+func fillPrice(p FillParams) (num.Price, error) {
+	if p.Price != "" {
+		return num.ParsePrice(p.Price)
+	}
+	if p.Order.AcceptedLimitPrice != nil {
+		return *p.Order.AcceptedLimitPrice, nil
+	}
+	return num.ParsePrice("1.10000")
+}
+
+// MustNewFillFor is like NewFillFor but panics on error.
+func MustNewFillFor(p FillParams) order.Fill {
+	f, err := NewFillFor(p)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}

--- a/tradertest/fill_test.go
+++ b/tradertest/fill_test.go
@@ -1,0 +1,90 @@
+package tradertest_test
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/order"
+	"github.com/rustyeddy/trader/tradertest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustWorkingOrder(t *testing.T) order.Order {
+	t.Helper()
+	g := testGenerator()
+	listing := tradertest.MustNewListing(tradertest.ListingParams{})
+	proposal := tradertest.MustNewProposal(tradertest.ProposalParams{
+		Listing:   listing,
+		AccountID: tradertest.MustAccountID(g),
+	})
+	request, err := order.NewRequest(proposal, tradertest.MustOrderID(g))
+	require.NoError(t, err)
+	return tradertest.MustNewOrder(tradertest.OrderParams{Request: request})
+}
+
+func TestNewFillForDefaults(t *testing.T) {
+	g := testGenerator()
+	o := mustWorkingOrder(t)
+
+	f, err := tradertest.NewFillFor(tradertest.FillParams{
+		Order:  o,
+		FillID: tradertest.MustFillID(g),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, o.Request.OrderID, f.OrderID)
+	assert.Equal(t, o.Request.AccountID, f.AccountID)
+	remaining, err := o.RemainingQuantity()
+	require.NoError(t, err)
+	assert.True(t, f.Quantity.Equal(remaining))
+}
+
+func TestNewFillForPartialQuantity(t *testing.T) {
+	g := testGenerator()
+	o := mustWorkingOrder(t)
+
+	f, err := tradertest.NewFillFor(tradertest.FillParams{
+		Order:    o,
+		FillID:   tradertest.MustFillID(g),
+		Quantity: "400",
+	})
+	require.NoError(t, err)
+
+	applied, err := order.ApplyFill(o, f)
+	require.NoError(t, err)
+	assert.Equal(t, order.StatusPartiallyFilled, applied.Status)
+}
+
+func TestNewFillForExplicitPrice(t *testing.T) {
+	g := testGenerator()
+	o := mustWorkingOrder(t)
+
+	f, err := tradertest.NewFillFor(tradertest.FillParams{
+		Order:        o,
+		FillID:       tradertest.MustFillID(g),
+		Price:        "1.23456",
+		BrokerFillID: "broker-fill-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "broker-fill-1", f.BrokerFillID)
+}
+
+func TestNewFillForAppliesCleanly(t *testing.T) {
+	g := testGenerator()
+	o := mustWorkingOrder(t)
+
+	f := tradertest.MustNewFillFor(tradertest.FillParams{
+		Order:  o,
+		FillID: tradertest.MustFillID(g),
+	})
+
+	filled, err := order.ApplyFill(o, f)
+	require.NoError(t, err)
+	assert.Equal(t, order.StatusFilled, filled.Status)
+}
+
+func TestMustNewFillForPanicsOnError(t *testing.T) {
+	assert.Panics(t, func() {
+		tradertest.MustNewFillFor(tradertest.FillParams{})
+	})
+}

--- a/tradertest/helpers_test.go
+++ b/tradertest/helpers_test.go
@@ -1,0 +1,17 @@
+package tradertest_test
+
+import (
+	"time"
+
+	"github.com/rustyeddy/trader/clock"
+	"github.com/rustyeddy/trader/id"
+)
+
+// testGenerator returns a deterministic *id.Generator the way any
+// external consumer would build one: clock.NewSimulated plus
+// id.NewDeterministic, both already public in their own packages. This
+// is deliberately not something tradertest wraps — see the package doc
+// comment.
+func testGenerator() *id.Generator {
+	return id.NewGenerator(clock.NewSimulated(time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)), id.NewDeterministic(1, 2))
+}

--- a/tradertest/ids.go
+++ b/tradertest/ids.go
@@ -2,11 +2,19 @@ package tradertest
 
 import "github.com/rustyeddy/trader/id"
 
+// MustAccountID, MustOrderID, and MustFillID are panic adapters over
+// id.GenerateAccountID/GenerateOrderID/GenerateFillID — nothing more.
+// They do not construct, own, or configure a *id.Generator; g is
+// entirely caller-owned, built the same way any Trader consumer builds
+// one: id.NewGenerator(clock.NewSimulated(start),
+// id.NewDeterministic(seed1, seed2)) for deterministic tests. These
+// exist only because every one of order, account, and portfolio's own
+// M1 tests independently wrote the identical
+// "generate-or-fail-the-test" wrapper around those three calls; they
+// are not a reason to stop calling id.Generate* directly when a caller
+// wants to handle the (rare) error itself instead of panicking.
+
 // MustAccountID generates a new id.AccountID from g, panicking on error.
-// g is a caller-owned *id.Generator (see the package doc comment for
-// why tradertest does not construct one for you) — typically
-// id.NewGenerator(clock.NewSimulated(start), id.NewDeterministic(seed1, seed2))
-// for deterministic tests.
 func MustAccountID(g *id.Generator) id.AccountID {
 	v, err := id.GenerateAccountID(g)
 	if err != nil {

--- a/tradertest/ids.go
+++ b/tradertest/ids.go
@@ -1,0 +1,34 @@
+package tradertest
+
+import "github.com/rustyeddy/trader/id"
+
+// MustAccountID generates a new id.AccountID from g, panicking on error.
+// g is a caller-owned *id.Generator (see the package doc comment for
+// why tradertest does not construct one for you) — typically
+// id.NewGenerator(clock.NewSimulated(start), id.NewDeterministic(seed1, seed2))
+// for deterministic tests.
+func MustAccountID(g *id.Generator) id.AccountID {
+	v, err := id.GenerateAccountID(g)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// MustOrderID generates a new id.OrderID from g, panicking on error.
+func MustOrderID(g *id.Generator) id.OrderID {
+	v, err := id.GenerateOrderID(g)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// MustFillID generates a new id.FillID from g, panicking on error.
+func MustFillID(g *id.Generator) id.FillID {
+	v, err := id.GenerateFillID(g)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/tradertest/ids_test.go
+++ b/tradertest/ids_test.go
@@ -1,0 +1,36 @@
+package tradertest_test
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/tradertest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustAccountIDIsDeterministicAndDistinct(t *testing.T) {
+	g := testGenerator()
+	a := tradertest.MustAccountID(g)
+	b := tradertest.MustAccountID(g)
+
+	assert.False(t, a.IsZero())
+	assert.False(t, b.IsZero())
+	assert.NotEqual(t, a, b)
+}
+
+func TestMustOrderIDIsDeterministicAndDistinct(t *testing.T) {
+	g := testGenerator()
+	a := tradertest.MustOrderID(g)
+	b := tradertest.MustOrderID(g)
+
+	assert.False(t, a.IsZero())
+	assert.NotEqual(t, a, b)
+}
+
+func TestMustFillIDIsDeterministicAndDistinct(t *testing.T) {
+	g := testGenerator()
+	a := tradertest.MustFillID(g)
+	b := tradertest.MustFillID(g)
+
+	assert.False(t, a.IsZero())
+	assert.NotEqual(t, a, b)
+}

--- a/tradertest/listing.go
+++ b/tradertest/listing.go
@@ -1,0 +1,85 @@
+package tradertest
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+)
+
+// ListingParams builds a currency-pair instrument.Listing. Base, Quote,
+// and Provider default to "EUR", "USD", and "OANDA"; Symbol defaults to
+// Base+"_"+Quote. Venue defaults to empty, matching spot FX's lack of a
+// centralized venue (see the instrument.Listing doc comment).
+//
+// Tick size, quantity increment, contract multiplier, and tradability
+// are not parameterized: every existing M1 test fixture used the same
+// values (0.00001 tick, 1 quantity increment, 1 multiplier, tradable),
+// so exposing them here would be speculative rather than
+// evidence-driven. A consumer needing different mechanics should call
+// instrument.NewListing directly.
+type ListingParams struct {
+	Base     string
+	Quote    string
+	Provider string
+	Venue    string
+	Symbol   string
+}
+
+// NewListing returns a valid currency-pair instrument.Listing built
+// from p, filling in defaults for any zero-valued field.
+func NewListing(p ListingParams) (instrument.Listing, error) {
+	if p.Base == "" {
+		p.Base = "EUR"
+	}
+	if p.Quote == "" {
+		p.Quote = "USD"
+	}
+	if p.Provider == "" {
+		p.Provider = "OANDA"
+	}
+	if p.Symbol == "" {
+		p.Symbol = fmt.Sprintf("%s_%s", p.Base, p.Quote)
+	}
+
+	base, err := num.ParseCurrency(p.Base)
+	if err != nil {
+		return instrument.Listing{}, err
+	}
+	quote, err := num.ParseCurrency(p.Quote)
+	if err != nil {
+		return instrument.Listing{}, err
+	}
+	inst, err := instrument.NewCurrencyPair(base, quote)
+	if err != nil {
+		return instrument.Listing{}, err
+	}
+
+	spec, err := instrument.NewSpec(
+		num.MustParsePrice("0.00001"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		quote,
+	)
+	if err != nil {
+		return instrument.Listing{}, err
+	}
+
+	return instrument.NewListing(instrument.ListingParams{
+		Instrument: inst,
+		Provider:   p.Provider,
+		Venue:      p.Venue,
+		Symbol:     p.Symbol,
+		Spec:       spec,
+		Tradable:   true,
+	})
+}
+
+// MustNewListing is like NewListing but panics on error.
+func MustNewListing(p ListingParams) instrument.Listing {
+	l, err := NewListing(p)
+	if err != nil {
+		panic(err)
+	}
+	return l
+}

--- a/tradertest/listing_test.go
+++ b/tradertest/listing_test.go
@@ -1,0 +1,45 @@
+package tradertest_test
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/tradertest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewListingDefaults(t *testing.T) {
+	l, err := tradertest.NewListing(tradertest.ListingParams{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "OANDA", l.Provider())
+	assert.Equal(t, "EUR_USD", l.Symbol())
+	assert.Equal(t, "", l.Venue())
+	assert.True(t, l.Tradable())
+}
+
+func TestNewListingOverrides(t *testing.T) {
+	l, err := tradertest.NewListing(tradertest.ListingParams{
+		Base:     "GBP",
+		Quote:    "JPY",
+		Provider: "IBKR",
+		Venue:    "LSE",
+		Symbol:   "GBPJPY",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "IBKR", l.Provider())
+	assert.Equal(t, "LSE", l.Venue())
+	assert.Equal(t, "GBPJPY", l.Symbol())
+}
+
+func TestNewListingRejectsInvalidCurrency(t *testing.T) {
+	_, err := tradertest.NewListing(tradertest.ListingParams{Base: "not-a-currency"})
+	require.Error(t, err)
+}
+
+func TestMustNewListingPanicsOnError(t *testing.T) {
+	assert.Panics(t, func() {
+		tradertest.MustNewListing(tradertest.ListingParams{Base: "not-a-currency"})
+	})
+}

--- a/tradertest/order.go
+++ b/tradertest/order.go
@@ -1,0 +1,72 @@
+package tradertest
+
+import (
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+)
+
+// OrderParams builds an accepted order.Order from an existing
+// order.Request. Request is required; build one with
+// order.NewRequest(proposal, orderID) — tradertest does not duplicate
+// that constructor, since it already takes exactly the two things a
+// caller has at that point and nothing more.
+//
+// BrokerOrderID and Status default to "broker-order-1" and
+// order.StatusWorking. AcceptedQuantity, AcceptedLimitPrice, and
+// AcceptedStopPrice default to Request's own Quantity, LimitPrice, and
+// StopPrice — the common case of a broker accepting a request exactly
+// as submitted; set AcceptedQuantity (and, if relevant,
+// AcceptedLimitPrice/AcceptedStopPrice) to test broker-side
+// normalization.
+//
+// NewOrder always builds an accepted order, so Status must be one that
+// requires acceptance (order.StatusWorking and beyond). For an
+// unaccepted order (StatusPendingSubmit or StatusRejected), construct
+// order.Order directly — there is no repeated boilerplate here to
+// replace, since that shape appears once in M1's own tests.
+type OrderParams struct {
+	Request       order.Request
+	BrokerOrderID string
+	// AcceptedQuantity is decimal text. Empty means "use
+	// Request.Quantity".
+	AcceptedQuantity string
+	Status           order.Status
+}
+
+// NewOrder returns a valid, accepted order.Order built from p, filling
+// in defaults for zero-valued fields.
+func NewOrder(p OrderParams) (order.Order, error) {
+	if p.BrokerOrderID == "" {
+		p.BrokerOrderID = "broker-order-1"
+	}
+	if p.Status == 0 {
+		p.Status = order.StatusWorking
+	}
+
+	acceptedQuantity := p.Request.Quantity
+	if p.AcceptedQuantity != "" {
+		q, err := num.ParseQuantity(p.AcceptedQuantity)
+		if err != nil {
+			return order.Order{}, err
+		}
+		acceptedQuantity = q
+	}
+
+	return order.NewOrder(order.Order{
+		Request:            p.Request,
+		BrokerOrderID:      p.BrokerOrderID,
+		AcceptedQuantity:   &acceptedQuantity,
+		AcceptedLimitPrice: p.Request.LimitPrice,
+		AcceptedStopPrice:  p.Request.StopPrice,
+		Status:             p.Status,
+	})
+}
+
+// MustNewOrder is like NewOrder but panics on error.
+func MustNewOrder(p OrderParams) order.Order {
+	o, err := NewOrder(p)
+	if err != nil {
+		panic(err)
+	}
+	return o
+}

--- a/tradertest/order.go
+++ b/tradertest/order.go
@@ -30,7 +30,13 @@ type OrderParams struct {
 	// AcceptedQuantity is decimal text. Empty means "use
 	// Request.Quantity".
 	AcceptedQuantity string
-	Status           order.Status
+	// AcceptedLimitPrice and AcceptedStopPrice are decimal text. Empty
+	// means "use Request.LimitPrice"/"use Request.StopPrice". Set
+	// either to test broker-side price normalization specifically;
+	// most tests only need to override AcceptedQuantity.
+	AcceptedLimitPrice string
+	AcceptedStopPrice  string
+	Status             order.Status
 }
 
 // NewOrder returns a valid, accepted order.Order built from p, filling
@@ -52,12 +58,30 @@ func NewOrder(p OrderParams) (order.Order, error) {
 		acceptedQuantity = q
 	}
 
+	acceptedLimitPrice := p.Request.LimitPrice
+	if p.AcceptedLimitPrice != "" {
+		lp, err := num.ParsePrice(p.AcceptedLimitPrice)
+		if err != nil {
+			return order.Order{}, err
+		}
+		acceptedLimitPrice = &lp
+	}
+
+	acceptedStopPrice := p.Request.StopPrice
+	if p.AcceptedStopPrice != "" {
+		sp, err := num.ParsePrice(p.AcceptedStopPrice)
+		if err != nil {
+			return order.Order{}, err
+		}
+		acceptedStopPrice = &sp
+	}
+
 	return order.NewOrder(order.Order{
 		Request:            p.Request,
 		BrokerOrderID:      p.BrokerOrderID,
 		AcceptedQuantity:   &acceptedQuantity,
-		AcceptedLimitPrice: p.Request.LimitPrice,
-		AcceptedStopPrice:  p.Request.StopPrice,
+		AcceptedLimitPrice: acceptedLimitPrice,
+		AcceptedStopPrice:  acceptedStopPrice,
 		Status:             p.Status,
 	})
 }

--- a/tradertest/order_test.go
+++ b/tradertest/order_test.go
@@ -3,6 +3,7 @@ package tradertest_test
 import (
 	"testing"
 
+	"github.com/rustyeddy/trader/num"
 	"github.com/rustyeddy/trader/order"
 	"github.com/rustyeddy/trader/tradertest"
 	"github.com/stretchr/testify/assert"
@@ -48,6 +49,34 @@ func TestNewOrderOverrides(t *testing.T) {
 
 	assert.Equal(t, "custom-broker-id", o.BrokerOrderID)
 	assert.Equal(t, order.StatusPartiallyFilled, o.Status)
+}
+
+func TestNewOrderAcceptedPriceNormalization(t *testing.T) {
+	g := testGenerator()
+	listing := tradertest.MustNewListing(tradertest.ListingParams{})
+	proposal := tradertest.MustNewProposal(tradertest.ProposalParams{
+		Listing:    listing,
+		AccountID:  tradertest.MustAccountID(g),
+		Type:       order.StopLimit,
+		LimitPrice: "1.09000",
+		StopPrice:  "1.08000",
+	})
+	request, err := order.NewRequest(proposal, tradertest.MustOrderID(g))
+	require.NoError(t, err)
+
+	o, err := tradertest.NewOrder(tradertest.OrderParams{
+		Request:            request,
+		AcceptedLimitPrice: "1.09010", // broker normalized the requested price
+		AcceptedStopPrice:  "1.08010",
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, o.AcceptedLimitPrice)
+	require.NotNil(t, o.AcceptedStopPrice)
+	assert.True(t, o.AcceptedLimitPrice.Equal(num.MustParsePrice("1.09010")))
+	assert.True(t, o.AcceptedStopPrice.Equal(num.MustParsePrice("1.08010")))
+	// Requested prices remain untouched, distinct from accepted ones.
+	assert.True(t, request.LimitPrice.Equal(num.MustParsePrice("1.09000")))
 }
 
 func TestMustNewOrderPanicsOnError(t *testing.T) {

--- a/tradertest/order_test.go
+++ b/tradertest/order_test.go
@@ -1,0 +1,57 @@
+package tradertest_test
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/order"
+	"github.com/rustyeddy/trader/tradertest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOrderDefaults(t *testing.T) {
+	g := testGenerator()
+	listing := tradertest.MustNewListing(tradertest.ListingParams{})
+	proposal := tradertest.MustNewProposal(tradertest.ProposalParams{
+		Listing:   listing,
+		AccountID: tradertest.MustAccountID(g),
+	})
+	request, err := order.NewRequest(proposal, tradertest.MustOrderID(g))
+	require.NoError(t, err)
+
+	o, err := tradertest.NewOrder(tradertest.OrderParams{Request: request})
+	require.NoError(t, err)
+
+	assert.Equal(t, "broker-order-1", o.BrokerOrderID)
+	assert.Equal(t, order.StatusWorking, o.Status)
+	require.NotNil(t, o.AcceptedQuantity)
+	assert.True(t, o.AcceptedQuantity.Equal(request.Quantity))
+}
+
+func TestNewOrderOverrides(t *testing.T) {
+	g := testGenerator()
+	listing := tradertest.MustNewListing(tradertest.ListingParams{})
+	proposal := tradertest.MustNewProposal(tradertest.ProposalParams{
+		Listing:   listing,
+		AccountID: tradertest.MustAccountID(g),
+	})
+	request, err := order.NewRequest(proposal, tradertest.MustOrderID(g))
+	require.NoError(t, err)
+
+	o, err := tradertest.NewOrder(tradertest.OrderParams{
+		Request:          request,
+		BrokerOrderID:    "custom-broker-id",
+		AcceptedQuantity: "500",
+		Status:           order.StatusPartiallyFilled,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "custom-broker-id", o.BrokerOrderID)
+	assert.Equal(t, order.StatusPartiallyFilled, o.Status)
+}
+
+func TestMustNewOrderPanicsOnError(t *testing.T) {
+	assert.Panics(t, func() {
+		tradertest.MustNewOrder(tradertest.OrderParams{})
+	})
+}

--- a/tradertest/portfolio.go
+++ b/tradertest/portfolio.go
@@ -1,0 +1,52 @@
+package tradertest
+
+import (
+	"time"
+
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/portfolio"
+)
+
+// PortfolioParams builds a portfolio.Portfolio. Accounts is required
+// and must be non-empty; BaseCurrency and AsOf default to "USD" and
+// DefaultAsOf. Rates is optional, matching portfolio.NewPortfolio's own
+// contract — supply it when Accounts spans more than one currency.
+type PortfolioParams struct {
+	BaseCurrency string
+	AsOf         time.Time
+	Accounts     []account.Snapshot
+	Rates        []portfolio.ConversionRate
+}
+
+// NewPortfolio returns a valid portfolio.Portfolio built from p,
+// filling in defaults for zero-valued fields.
+func NewPortfolio(p PortfolioParams) (portfolio.Portfolio, error) {
+	if p.BaseCurrency == "" {
+		p.BaseCurrency = "USD"
+	}
+	if p.AsOf.IsZero() {
+		p.AsOf = DefaultAsOf
+	}
+
+	base, err := num.ParseCurrency(p.BaseCurrency)
+	if err != nil {
+		return portfolio.Portfolio{}, err
+	}
+
+	return portfolio.NewPortfolio(portfolio.PortfolioParams{
+		BaseCurrency: base,
+		AsOf:         p.AsOf,
+		Accounts:     p.Accounts,
+		Rates:        p.Rates,
+	})
+}
+
+// MustNewPortfolio is like NewPortfolio but panics on error.
+func MustNewPortfolio(p PortfolioParams) portfolio.Portfolio {
+	pf, err := NewPortfolio(p)
+	if err != nil {
+		panic(err)
+	}
+	return pf
+}

--- a/tradertest/portfolio.go
+++ b/tradertest/portfolio.go
@@ -10,8 +10,8 @@ import (
 
 // PortfolioParams builds a portfolio.Portfolio. Accounts is required
 // and must be non-empty; BaseCurrency and AsOf default to "USD" and
-// DefaultAsOf. Rates is optional, matching portfolio.NewPortfolio's own
-// contract — supply it when Accounts spans more than one currency.
+// DefaultAsOf(). Rates is optional, matching portfolio.NewPortfolio's
+// own contract — supply it when Accounts spans more than one currency.
 type PortfolioParams struct {
 	BaseCurrency string
 	AsOf         time.Time
@@ -26,7 +26,7 @@ func NewPortfolio(p PortfolioParams) (portfolio.Portfolio, error) {
 		p.BaseCurrency = "USD"
 	}
 	if p.AsOf.IsZero() {
-		p.AsOf = DefaultAsOf
+		p.AsOf = defaultAsOf
 	}
 
 	base, err := num.ParseCurrency(p.BaseCurrency)

--- a/tradertest/portfolio_test.go
+++ b/tradertest/portfolio_test.go
@@ -1,0 +1,56 @@
+package tradertest_test
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/portfolio"
+	"github.com/rustyeddy/trader/tradertest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPortfolioDefaults(t *testing.T) {
+	g := testGenerator()
+	snapshot := tradertest.MustNewSnapshot(tradertest.SnapshotParams{
+		AccountID: tradertest.MustAccountID(g),
+	})
+
+	p, err := tradertest.NewPortfolio(tradertest.PortfolioParams{
+		Accounts: []account.Snapshot{snapshot},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "USD", p.BaseCurrency().String())
+	assert.True(t, tradertest.DefaultAsOf.Equal(p.AsOf()))
+	assert.Equal(t, portfolio.ConversionComplete, p.ConversionStatus())
+}
+
+func TestNewPortfolioMultiCurrencyNeedsRates(t *testing.T) {
+	g := testGenerator()
+	usdSnapshot := tradertest.MustNewSnapshot(tradertest.SnapshotParams{
+		AccountID: tradertest.MustAccountID(g),
+	})
+	eurSnapshot := tradertest.MustNewSnapshot(tradertest.SnapshotParams{
+		AccountID: tradertest.MustAccountID(g),
+		Currency:  "EUR",
+		Broker:    "OANDA",
+	})
+
+	p, err := tradertest.NewPortfolio(tradertest.PortfolioParams{
+		Accounts: []account.Snapshot{usdSnapshot, eurSnapshot},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, portfolio.ConversionIncomplete, p.ConversionStatus())
+}
+
+func TestNewPortfolioRejectsNoAccounts(t *testing.T) {
+	_, err := tradertest.NewPortfolio(tradertest.PortfolioParams{})
+	require.Error(t, err)
+}
+
+func TestMustNewPortfolioPanicsOnError(t *testing.T) {
+	assert.Panics(t, func() {
+		tradertest.MustNewPortfolio(tradertest.PortfolioParams{})
+	})
+}

--- a/tradertest/portfolio_test.go
+++ b/tradertest/portfolio_test.go
@@ -22,7 +22,7 @@ func TestNewPortfolioDefaults(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "USD", p.BaseCurrency().String())
-	assert.True(t, tradertest.DefaultAsOf.Equal(p.AsOf()))
+	assert.True(t, tradertest.DefaultAsOf().Equal(p.AsOf()))
 	assert.Equal(t, portfolio.ConversionComplete, p.ConversionStatus())
 }
 

--- a/tradertest/position.go
+++ b/tradertest/position.go
@@ -1,0 +1,66 @@
+package tradertest
+
+import (
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+)
+
+// PositionParams builds a non-flat order.Position. Side, Quantity, and
+// AvgPrice default to order.Long, "1000", and "1.10000". AccountID and
+// Listing are required.
+//
+// order.Flat is Side's zero value, so NewPosition cannot distinguish
+// "unset, use the default" from "explicitly Flat" — and a Flat position
+// needs a zero Quantity and nil AvgPrice, which this builder's own
+// defaults don't produce. Build a Flat order.Position directly with
+// order.NewPosition; there is no repeated boilerplate for that case to
+// replace.
+type PositionParams struct {
+	AccountID id.AccountID
+	Listing   instrument.Listing
+	Side      order.PositionSide
+	Quantity  string
+	AvgPrice  string
+}
+
+// NewPosition returns a valid order.Position built from p, filling in
+// defaults for zero-valued fields.
+func NewPosition(p PositionParams) (order.Position, error) {
+	if p.Side == order.Flat {
+		p.Side = order.Long
+	}
+	if p.Quantity == "" {
+		p.Quantity = "1000"
+	}
+	if p.AvgPrice == "" {
+		p.AvgPrice = "1.10000"
+	}
+
+	quantity, err := num.ParseQuantity(p.Quantity)
+	if err != nil {
+		return order.Position{}, err
+	}
+	avgPrice, err := num.ParsePrice(p.AvgPrice)
+	if err != nil {
+		return order.Position{}, err
+	}
+
+	return order.NewPosition(order.Position{
+		AccountID: p.AccountID,
+		Listing:   p.Listing,
+		Side:      p.Side,
+		Quantity:  quantity,
+		AvgPrice:  &avgPrice,
+	})
+}
+
+// MustNewPosition is like NewPosition but panics on error.
+func MustNewPosition(p PositionParams) order.Position {
+	pos, err := NewPosition(p)
+	if err != nil {
+		panic(err)
+	}
+	return pos
+}

--- a/tradertest/position_test.go
+++ b/tradertest/position_test.go
@@ -1,0 +1,49 @@
+package tradertest_test
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/order"
+	"github.com/rustyeddy/trader/tradertest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPositionDefaults(t *testing.T) {
+	g := testGenerator()
+	p, err := tradertest.NewPosition(tradertest.PositionParams{
+		AccountID: tradertest.MustAccountID(g),
+		Listing:   tradertest.MustNewListing(tradertest.ListingParams{}),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, order.Long, p.Side)
+	require.NotNil(t, p.AvgPrice)
+}
+
+func TestNewPositionShortOverride(t *testing.T) {
+	g := testGenerator()
+	p, err := tradertest.NewPosition(tradertest.PositionParams{
+		AccountID: tradertest.MustAccountID(g),
+		Listing:   tradertest.MustNewListing(tradertest.ListingParams{}),
+		Side:      order.Short,
+		Quantity:  "250",
+		AvgPrice:  "1.25000",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, order.Short, p.Side)
+}
+
+func TestNewPositionRejectsZeroAccountID(t *testing.T) {
+	_, err := tradertest.NewPosition(tradertest.PositionParams{
+		Listing: tradertest.MustNewListing(tradertest.ListingParams{}),
+	})
+	require.Error(t, err)
+}
+
+func TestMustNewPositionPanicsOnError(t *testing.T) {
+	assert.Panics(t, func() {
+		tradertest.MustNewPosition(tradertest.PositionParams{})
+	})
+}

--- a/tradertest/proposal.go
+++ b/tradertest/proposal.go
@@ -1,0 +1,88 @@
+package tradertest
+
+import (
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+)
+
+// ProposalParams builds an order.Proposal. Side, Type, TimeInForce, and
+// Quantity default to Buy, Market, GTC, and "1000" — every existing M1
+// test fixture used these unless specifically testing a different
+// order type. Listing and AccountID are required.
+type ProposalParams struct {
+	Listing     instrument.Listing
+	AccountID   id.AccountID
+	Side        order.Side
+	Type        order.Type
+	TimeInForce order.TimeInForce
+	Quantity    string
+	// LimitPrice and StopPrice are decimal text, required exactly when
+	// Type needs them (Limit/StopLimit for LimitPrice, Stop/StopLimit
+	// for StopPrice).
+	LimitPrice string
+	StopPrice  string
+	ReduceOnly bool
+	Metadata   id.Metadata
+}
+
+// NewProposal returns a valid order.Proposal built from p, filling in
+// defaults for zero-valued fields.
+func NewProposal(p ProposalParams) (order.Proposal, error) {
+	if p.Side == 0 {
+		p.Side = order.Buy
+	}
+	if p.Type == 0 {
+		p.Type = order.Market
+	}
+	if p.TimeInForce == 0 {
+		p.TimeInForce = order.GTC
+	}
+	if p.Quantity == "" {
+		p.Quantity = "1000"
+	}
+
+	quantity, err := num.ParseQuantity(p.Quantity)
+	if err != nil {
+		return order.Proposal{}, err
+	}
+
+	var limitPrice, stopPrice *num.Price
+	if p.LimitPrice != "" {
+		lp, err := num.ParsePrice(p.LimitPrice)
+		if err != nil {
+			return order.Proposal{}, err
+		}
+		limitPrice = &lp
+	}
+	if p.StopPrice != "" {
+		sp, err := num.ParsePrice(p.StopPrice)
+		if err != nil {
+			return order.Proposal{}, err
+		}
+		stopPrice = &sp
+	}
+
+	return order.NewProposal(order.Proposal{
+		Listing:     p.Listing,
+		AccountID:   p.AccountID,
+		Side:        p.Side,
+		Type:        p.Type,
+		TimeInForce: p.TimeInForce,
+		Quantity:    quantity,
+		LimitPrice:  limitPrice,
+		StopPrice:   stopPrice,
+		ReduceOnly:  p.ReduceOnly,
+		Metadata:    p.Metadata,
+	})
+}
+
+// MustNewProposal is like NewProposal but panics on error.
+func MustNewProposal(p ProposalParams) order.Proposal {
+	proposal, err := NewProposal(p)
+	if err != nil {
+		panic(err)
+	}
+	return proposal
+}

--- a/tradertest/proposal_test.go
+++ b/tradertest/proposal_test.go
@@ -1,0 +1,83 @@
+package tradertest_test
+
+import (
+	"testing"
+
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+	"github.com/rustyeddy/trader/tradertest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProposalDefaults(t *testing.T) {
+	g := testGenerator()
+	p, err := tradertest.NewProposal(tradertest.ProposalParams{
+		Listing:   tradertest.MustNewListing(tradertest.ListingParams{}),
+		AccountID: tradertest.MustAccountID(g),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, order.Buy, p.Side)
+	assert.Equal(t, order.Market, p.Type)
+	assert.Equal(t, order.GTC, p.TimeInForce)
+	assert.True(t, p.Quantity.Equal(num.MustParseQuantity("1000")))
+	assert.Nil(t, p.LimitPrice)
+	assert.Nil(t, p.StopPrice)
+}
+
+func TestNewProposalLimitOrderRequiresLimitPrice(t *testing.T) {
+	g := testGenerator()
+	_, err := tradertest.NewProposal(tradertest.ProposalParams{
+		Listing:   tradertest.MustNewListing(tradertest.ListingParams{}),
+		AccountID: tradertest.MustAccountID(g),
+		Type:      order.Limit,
+	})
+	require.Error(t, err)
+}
+
+func TestNewProposalLimitOrderWithPrice(t *testing.T) {
+	g := testGenerator()
+	p, err := tradertest.NewProposal(tradertest.ProposalParams{
+		Listing:    tradertest.MustNewListing(tradertest.ListingParams{}),
+		AccountID:  tradertest.MustAccountID(g),
+		Type:       order.Limit,
+		LimitPrice: "1.09000",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, p.LimitPrice)
+	assert.True(t, p.LimitPrice.Equal(num.MustParsePrice("1.09000")))
+}
+
+func TestNewProposalExplicitSideAndTimeInForce(t *testing.T) {
+	g := testGenerator()
+	p, err := tradertest.NewProposal(tradertest.ProposalParams{
+		Listing:     tradertest.MustNewListing(tradertest.ListingParams{}),
+		AccountID:   tradertest.MustAccountID(g),
+		Side:        order.Sell,
+		Type:        order.Stop,
+		TimeInForce: order.GTC,
+		Quantity:    "250",
+		StopPrice:   "1.05000",
+		ReduceOnly:  true,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, order.Sell, p.Side)
+	assert.Equal(t, order.Stop, p.Type)
+	assert.True(t, p.ReduceOnly)
+	require.NotNil(t, p.StopPrice)
+}
+
+func TestNewProposalRejectsZeroAccountID(t *testing.T) {
+	_, err := tradertest.NewProposal(tradertest.ProposalParams{
+		Listing: tradertest.MustNewListing(tradertest.ListingParams{}),
+	})
+	require.Error(t, err)
+}
+
+func TestMustNewProposalPanicsOnError(t *testing.T) {
+	assert.Panics(t, func() {
+		tradertest.MustNewProposal(tradertest.ProposalParams{})
+	})
+}


### PR DESCRIPTION
## Summary

Implements the scope agreed in the #31 discussion, not the issue's
original 8-bullet list:

- **Cut**: marketdata quote/bar fixtures (`marketdata.Quote`/`Bar`
  don't exist until M2 — building fixtures for them now would mean
  pre-designing M2's types from an M1 issue), and any wrapping of
  `clock.NewSimulated`/`id.NewGenerator`/`id.NewDeterministic`/
  `num.MustParse*` (already public, already exactly what M1's own
  tests use directly).
- **Kept, scoped to real repeated boilerplate**: instrument/listing,
  proposal/order/fill/position, and account/portfolio snapshot
  builders, plus a small set of currency-aware and order-state
  assertions.

## What's in `tradertest`

- `NewListing`/`MustNewListing` — currency-pair listing with EUR/USD,
  OANDA defaults.
- `NewProposal`, `NewOrder` (an *accepted* order, defaulting
  `AcceptedQuantity`/`AcceptedLimitPrice`/`AcceptedStopPrice` from its
  `Request`), `NewFillFor` (defaults to remaining quantity and the
  order's accepted limit price), `NewPosition` — each with a `Must*`
  panic variant.
- `NewSnapshot` — `BuyingPower`/`MarginAvailable` default to `Equity`,
  the rest of the `num.Money` fields default to zero, so a test that
  only cares about one invariant doesn't populate all nine fields.
- `NewPortfolio` — thin defaults over `portfolio.PortfolioParams`.
- `MustAccountID`/`MustOrderID`/`MustFillID` — panic wrappers around
  `id.Generate*`, replacing the `mustXxxID(t)` helper that was
  independently duplicated in `order`, `account`, and `portfolio`'s own
  test files.
- `AssertMoneyEqual`/`AssertPriceEqual`/`AssertQuantityEqual`/
  `AssertRateEqual` (using each type's own `.Equal`, not
  reflection-based struct equality) and `AssertStatus`/`AssertTerminal`
  for order state.

Every builder returns the real domain type via the real domain
constructor (`order.NewProposal`, `account.NewSnapshot`, etc.) — never
a parallel object model — and the non-`Must` variant always returns its
error, so invalid fixtures are constructible by just passing bad params
and checking the result.

## Test plan

- [x] Every test file in `tradertest` is `package tradertest_test` —
      an external package importing only public Trader packages,
      satisfying the "external-consumer test" acceptance criterion
      directly.
- [x] `Example_buildOrderLifecycle` exercises the full acceptance
      scenario: instrument → proposal → order → fill → position →
      account snapshot, with little boilerplate.
- [x] `Example_newSnapshot` and `Example_newPortfolio` are additional
      runnable doc examples.
- [x] Unit tests per builder covering defaults, overrides, and error
      paths (invalid currency, zero AccountID, etc.), plus
      `Must*`-panics-on-error tests.
- [x] `go test -race ./tradertest/...` and `make check` — green
- [x] Coverage: 88.7%

## Documentation

- `tradertest/doc.go` states the package's actual purpose (hold
  boilerplate that already existed, repeated, in M1 tests — not a
  second convenience API) and the rule for adding more: only if needed
  by an external-consumer test or replacing existing repeated
  boilerplate.

Issue: #31

https://claude.ai/code/session_01FsfxQH4YBP5DA1LpAafWyt