### PR TITLE
M1-14: M1 completion review

### DIFF
--- a/config/example_test.go
+++ b/config/example_test.go
@@ -1,0 +1,33 @@
+package config_test
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/config"
+)
+
+// Example loads a typed configuration struct from an explicit set of
+// sources — never a real environment or file path in an example — and
+// renders it. A secret-tagged field's real value is loaded correctly
+// but always rendered as config.Redacted, regardless of what it is.
+func Example() {
+	type serverConfig struct {
+		Host   string `default:"0.0.0.0"`
+		Port   int    `default:"8080"`
+		APIKey string `config:"api_key" secret:"true" required:"true"`
+	}
+
+	cfg, err := config.Load[serverConfig](config.Options{
+		Environ:     []string{},
+		FileContent: []byte("api_key: sk_live_deadbeef\n"),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(config.Sprint(cfg))
+	// Output:
+	// api_key = REDACTED
+	// host = 0.0.0.0
+	// port = 8080
+}

--- a/docs/milestones/m1-completion-review.org
+++ b/docs/milestones/m1-completion-review.org
@@ -11,8 +11,9 @@ then record what that exercise found. It is not a feature-building
 issue; code changes here exist only where the exercise below exposed a
 real, concrete deficiency.
 
-M1's public package surface at the time of this review, confirmed via
-=go list ./... | grep -v internal=:
+M1's public package surface at the time of this review — every
+non-internal package under the module root except this review's own
+=examples/m1= addition, confirmed via =go list ./...=:
 
 #+BEGIN_EXAMPLE
 account  clock  config  id  instrument  logging  marketdata
@@ -21,10 +22,10 @@ num  order  portfolio  tradertest
 
 * 1. External-consumer exercise
 
-New package =examples/m1= (=package m1_test=), importing only the nine
-of the above packages the flow actually needs — =marketdata= is
-correctly absent; it has no =Quote=/=Bar= yet (M2), so nothing in an M1
-flow touches it.
+New package =examples/m1= (=package m1_test=), importing ten of the
+eleven packages above — every one of them except =marketdata=, which
+is correctly absent: it has no =Quote=/=Bar= yet (M2), so nothing in an
+M1 flow touches it.
 
 The central lifecycle in =buildM1Scenario= is built almost entirely
 through the real domain constructors, not =tradertest=:

--- a/docs/milestones/m1-completion-review.org
+++ b/docs/milestones/m1-completion-review.org
@@ -1,0 +1,257 @@
+#+TITLE: M1 Completion Review
+#+SUBTITLE: Domain Foundation and Test Kit — verification-first sign-off (issue #32, M1-14)
+#+STARTUP: overview indent
+
+* Purpose
+
+This is the verification-first M1 completion review agreed on issue
+#32: prove M1 is a coherent, externally consumable foundation by
+exercising it the way code outside Trader would actually consume it,
+then record what that exercise found. It is not a feature-building
+issue; code changes here exist only where the exercise below exposed a
+real, concrete deficiency.
+
+M1's public package surface at the time of this review, confirmed via
+=go list ./... | grep -v internal=:
+
+#+BEGIN_EXAMPLE
+account  clock  config  id  instrument  logging  marketdata
+num  order  portfolio  tradertest
+#+END_EXAMPLE
+
+* 1. External-consumer exercise
+
+New package =examples/m1= (=package m1_test=), importing only the nine
+of the above packages the flow actually needs — =marketdata= is
+correctly absent; it has no =Quote=/=Bar= yet (M2), so nothing in an M1
+flow touches it.
+
+The central lifecycle in =buildM1Scenario= is built almost entirely
+through the real domain constructors, not =tradertest=:
+=instrument.NewCurrencyPair=/=NewSpec=/=NewListing= →
+=order.NewProposal= → =order.NewRequest= →
+=order.NewOrder=(=StatusPendingSubmit=) → =order.ApplyAcceptance= →
+=order.NewFill= → =order.ApplyFill= → =order.NewPosition= →
+=account.NewSnapshot= (two accounts, two brokers, two currencies) →
+=portfolio.NewPortfolio= (with an explicit =ConversionRate=, so the
+conversion path is genuinely exercised rather than trivially
+same-currency). =tradertest= is used only incidentally, for assertions
+(=AssertTerminal=, =AssertStatus=, =AssertMoneyEqual=) in the
+accompanying =Test= function — never to build the scenario itself.
+
+=Example_m1Vocabulary= is the runnable example the acceptance criteria
+require; =TestConfigRedactsSecrets= and
+=TestLoggingStructuredFieldsAndInjectedLogger= separately, directly
+cover the configuration-secret-redaction and
+structured-fields/injected-logger criteria rather than leaving them
+incidental to the domain flow.
+
+** Result
+
+*Pass, no API deficiencies.* Every real constructor composed cleanly
+with no awkward workaround, no field that had to be worked around, and
+no place where reaching for a =tradertest= builder felt necessary to
+avoid friction in the real API. The full chain — including the
+=StatusPendingSubmit= → =ApplyAcceptance= → =ApplyFill= lifecycle
+transition path exercised directly, not just the pre-accepted-order
+shortcut — worked exactly as each package's own documentation says it
+should.
+
+* 2. Documentation, naming, and glossary audit
+
+Three checks, run against all 11 packages' non-test source:
+
+1. A =go/doc=-based scan for undocumented top-level exported
+   identifiers (funcs, types, consts, vars). *Zero found.* (An earlier,
+   naive per-struct-field version of this check produced many false
+   positives — =go/doc= collapses a =const (...)= block's individual
+   per-spec comments into one group-level =Doc= string, and Go's own
+   documentation convention does not require every struct field to
+   carry its own comment when the containing type's doc comment already
+   covers it, or the field name is self-evident from its type, e.g.
+   =Side Side=. The check was corrected to test what "documented
+   identifiers" actually means for Go — top-level declarations — not
+   discarded.)
+2. =staticcheck ./account/... ./clock/... ./config/... ./id/...
+   ./instrument/... ./logging/... ./marketdata/... ./num/... ./order/...
+   ./portfolio/... ./tradertest/...=, filtered to non-test files.
+   *Zero findings.*
+3. Every one of the 11 packages has a =// Package <name>= doc comment.
+   *Confirmed.*
+
+** Glossary cross-check (architecture document, Appendix A)
+
+| Glossary term | M1 status |
+|---+---|
+| Instrument, Listing | Implemented as documented (=instrument=) |
+| Proposal, Request, Order, Fill, Position, Trade | Implemented as documented (=order=) |
+| Account | Implemented as =account.Snapshot=, *not* =Account* — a deliberate, ADR-007-recorded decision (broker-scoped action handle vs. observed-state value), not naming drift |
+| Portfolio | Implemented as documented (=portfolio=) |
+| Symbol | Correctly *not* a standalone type — ADR-003: symbol is display/provider-facing, never identity |
+| Quote, Trade event, Bar | Correctly absent — M2 |
+| Indicator, Analysis | Correctly absent — M2/M3 |
+| Strategy, Intent, Risk decision | Correctly absent — M4/M3 |
+| Reconciliation, Journal, Report | Correctly absent — M3/M5+ |
+
+No naming drift found beyond the one already-documented,
+already-decided =Account= → =account.Snapshot= difference.
+
+** Deficiencies found and fixed
+
+The issue's original scope explicitly named "exact values" and
+"configuration" among the packages needing runnable examples. Neither
+=num= nor =config= had a single =Example= function — every other M1
+package did. Fixed:
+
+- =num/example_test.go=: =Example= (Price/Quantity arithmetic, exact —
+  no floating-point drift) and =Example_money= (Money's mandatory
+  currency and =Convert=, the one sanctioned conversion primitive).
+- =config/example_test.go=: =Example= (=Load= plus =Sprint=, showing a
+  =secret:"true"= field rendering as =REDACTED=).
+
+No other documentation, naming, or glossary deficiency was found.
+
+* 3. Dependency-boundary review
+
+Manual review of each package's project-local imports
+(=go list -f '{{join .Imports "\n"}}' ./<pkg>=), against
+=docs/arch/package-boundaries.org='s preliminary map and dependency
+rules. No new enforcement tooling added, per the #32 discussion —
+automated dependency-direction enforcement, if wanted, is a deliberate
+follow-on decision, not part of this sign-off.
+
+#+BEGIN_EXAMPLE
+account     -> id, instrument, num, order
+clock       -> (none)
+config      -> (none)
+id          -> clock
+instrument  -> num
+logging     -> (none)
+marketdata  -> (none)
+num         -> (none)
+order       -> id, instrument, num
+portfolio   -> account, id, instrument, num, order
+tradertest  -> account, id, instrument, num, order, portfolio
+#+END_EXAMPLE
+
+** Findings
+
+- Matches the preliminary map's direction throughout: nothing points
+  "backward" (e.g. =instrument= depends on nothing but =num=; =order=
+  and =account= depend on =instrument= but never the reverse;
+  =portfolio= depends on =account= but nothing depends on
+  =portfolio= except =tradertest=).
+- No cycles.
+- No domain package (=account=, =clock=, =id=, =instrument=,
+  =marketdata=, =num=, =order=, =portfolio=) imports =config=,
+  =logging=, or =tradertest= — confirmed by grep, not just the import
+  list above. Domain code reading configuration, logging, or depending
+  on test-support code would each be a distinct rule violation; none
+  exist.
+- =tradertest= is imported only by its own tests and by
+  =examples/m1= — confirmed by
+  =grep -rl "rustyeddy/trader/tradertest"=. Nothing in the domain
+  surface depends on it.
+- =examples/m1= itself imports no =internal/= path (confirmed by its
+  import list: =account=, =clock=, =config=, =id=, =instrument=,
+  =logging=, =num=, =order=, =portfolio=, =tradertest= — all public).
+- =num/internal/fixed= and =id/internal/ulid= are each imported only by
+  their own parent package. No cross-package =internal/= leakage.
+
+No violations found; no code changes required by this section.
+
+* 4. M1 public API baseline
+
+Recorded here directly (per the #32 discussion, this is intentionally
+not a generated/CI-enforced artifact — formal =apidiff=-style tooling
+and a semver policy are ADR-011's job, and ADR-011 is still Proposed).
+Future changes to any of the signatures below are a compatibility
+question worth a deliberate look, not a mechanically blocked one yet.
+
+- *account*: =Snapshot=, =SnapshotParams=, =NewSnapshot=,
+  =ErrInvalidSnapshot=.
+- *clock*: =Clock=, =Timer=, =Real=, =Simulated=, =NewSimulated=,
+  =ErrNegativeAdvance=.
+- *config*: =Load[T]=, =Render=, =Sprint=, =Options=, =Error=,
+  =FieldError=, =Redacted=, plus the =ErrInvalidTarget=/
+  =ErrUnsupportedType=/=ErrParse=/=ErrEnum=/=ErrRequired=/
+  =ErrInvalidTag=/=ErrValidation= sentinels.
+- *id*: =ID[K]=, =Kind=, =RunID=/=OrderID=/=FillID=/=EventID=/
+  =CorrelationID=/=AccountID= (aliases of =ID[K]=), =Metadata=,
+  =Source=, =Generator=, =NewGenerator=, =EntropySource=, =Random=,
+  =Deterministic=, =NewDeterministic=, the =Generate*ID= family, the
+  =Parse*ID=/=MustParse*ID= family, =ErrInvalidID=, =ErrZeroValue=,
+  =ErrClockMovedBackward=, =ErrEntropyExhausted=.
+- *instrument*: =ID=, =Kind=, =Instrument= + per-kind constructors,
+  =Listing=, =ListingParams=, =NewListing=, =Spec=, =NewSpec=,
+  =Resolver=, =MemoryResolver=, =NewMemoryResolver=, the
+  =ErrInvalid*=/=ErrUnknownSymbol=/=ErrAmbiguousSymbol=/
+  =ErrDuplicateListing=/=ErrInvalidResolution= sentinels.
+- *logging*: =New=, =Config=, =Discard=, =Secret=, =NewContextHandler=,
+  =WithComponent=, =WithCorrelationID=, =WithCausationID=, the
+  =RunID=/=SessionID=/=AccountID=/... attribute-key constants, plus the
+  testkit surface (=Capture=, =Record=, =Recorder=).
+- *marketdata*: =Interval= + =M1=/=H1=/=H4=/=D1=/=W1=, =Unit=,
+  =TimeRange=, =Calendar=, =FXCalendar=, =FXCalendarParams=, =Status=.
+- *num*: =Price=, =Quantity=, =Money=, =Rate=, =Currency=, each with
+  =Parse*=/=MustParse*= plus their exact arithmetic methods (including
+  =Money.Convert=), and the =Err*= sentinel family.
+- *order*: =Proposal=, =Request=, =Order=, =Fill=, =Position=, =Trade=,
+  =CancelRequest=/=CancelResult=, =ReplaceRequest=/=ReplaceResult=,
+  =Side=, =Type=, =TimeInForce=, =Status=, =PositionSide=,
+  =RejectReason=, =Rejection=, the =New*=/=Apply*= constructor and
+  lifecycle-transition families, and the =Err*= sentinel family.
+- *portfolio*: =Portfolio=, =PortfolioParams=, =NewPortfolio=,
+  =ConversionRate=, =ConversionStatus=, =Exposure=,
+  =AccountPosition=, =ErrInvalidPortfolio=.
+- *tradertest*: the =New*=/=Must*New*= builder family for =Listing=,
+  =Proposal=, =Order=, =Fill=, =Position=, =Snapshot=, =Portfolio=; the
+  =Must*ID= panic adapters; =DefaultAsOf=; the =Assert*= family.
+
+* 5. No later-milestone behavior leaked into M1
+
+- *account*: snapshot/aggregate value types only; no broker queries, no
+  reconciliation (ADR-019).
+- *clock*: time abstraction only.
+- *config*: composition-root configuration loading only; no network or
+  broker calls.
+- *id*: identifier generation/parsing only.
+- *instrument*: identity/listing/spec value types and a resolver only;
+  no market data, no pricing.
+- *logging*: structured logging framework only.
+- *marketdata*: interval/calendar/time-range vocabulary only —
+  =Quote=/=Bar=/live feeds/historical sources are M2 and are absent.
+- *num*: exact value types only.
+- *order*: broker-neutral order/execution vocabulary and lifecycle
+  rules only; no broker I/O, no execution manager (ADR-006, ADR-008).
+- *portfolio*: aggregation/exposure grouping only; no valuation, no
+  reconciliation.
+- *tradertest*: builders/assertions over the above only; no simulated
+  broker, no strategy harness, no journal/report helpers.
+
+Confirmed: nothing in M3 (broker execution), M4 (strategy), or M2
+(market-data pipelines beyond interval/calendar vocabulary) is present.
+
+* 6. make check
+
+=make check= (=gofmt -l=, =go vet ./...=, =go test -race ./...=)
+passes across the whole repository, including the new
+=examples/m1=, =num=, and =config= additions from this review.
+
+* Recommendation
+
+*M1 is ready to close.*
+
+Every acceptance criterion in issue #32 is satisfied: documentation
+audit clean (two real gaps found and fixed), a runnable integrated
+example exists and passes, the external-consumer package imports only
+public code, the dependency graph has no violations, no later-milestone
+behavior is present, secrets are redacted in configuration output,
+logging examples use structured fields through an injected logger, and
+=make check=/=go test -race ./...= are green.
+
+No outstanding blockers are known. The one deliberately deferred item —
+automated, CI-enforced dependency-direction and API-compatibility
+tooling — is a known, named gap (=package-boundaries.org= already says
+so), not a defect in M1's current surface, and is left for a future,
+separate decision rather than folded into this sign-off.

--- a/examples/m1/integration_test.go
+++ b/examples/m1/integration_test.go
@@ -16,7 +16,11 @@
 package m1_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -222,11 +226,19 @@ func buildM1Scenario(g *id.Generator) (m1Scenario, error) {
 	}, nil
 }
 
+// scenarioClockStart is the fixed reference time buildM1Scenario's
+// clock uses. A literal, not time.Now(): this scenario specifically
+// demonstrates Trader's deterministic clock/ID vocabulary, so it must
+// be deterministic by construction — not just incidentally so because
+// nothing today happens to print a generated ID or a clock-derived
+// value.
+var scenarioClockStart = time.Date(2026, time.January, 2, 9, 0, 0, 0, time.UTC)
+
 // Example_m1Vocabulary is the runnable example issue #32 requires: it
 // exercises the integrated M1 vocabulary end to end, using only public
 // packages.
 func Example_m1Vocabulary() {
-	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(1, 2))
+	g := id.NewGenerator(clock.NewSimulated(scenarioClockStart), id.NewDeterministic(1, 2))
 
 	scenario, err := buildM1Scenario(g)
 	if err != nil {
@@ -248,7 +260,7 @@ func Example_m1Vocabulary() {
 // incidental, verification-only use of tradertest the #32 plan calls
 // for, as opposed to using it to build the scenario itself.
 func TestM1VocabularyReachesExpectedState(t *testing.T) {
-	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(3, 4))
+	g := id.NewGenerator(clock.NewSimulated(scenarioClockStart), id.NewDeterministic(3, 4))
 
 	scenario, err := buildM1Scenario(g)
 	require.NoError(t, err)
@@ -299,30 +311,36 @@ func TestConfigRedactsSecrets(t *testing.T) {
 	assert.Contains(t, out, "OANDA", "non-secret fields still render normally")
 }
 
-// TestLoggingStructuredFieldsAndInjectedLogger exercises an injected
-// (not global) *slog.Logger built by logging.New, and confirms
-// structured fields — including one wrapped by logging.Secret — are
-// captured correctly rather than interpolated into a formatted string.
+// TestLoggingStructuredFieldsAndInjectedLogger exercises the actual
+// *slog.Logger a caller injects into its own components — the one
+// logging.New itself returns, not logging package's separate Capture
+// testkit helper — and confirms structured fields it logs, including
+// one wrapped by logging.Secret, reach the real output correctly
+// redacted rather than interpolated into a formatted string. Output is
+// a temp file (New's "any other value is a file path" case) so the
+// real JSON New produces can be read back and asserted on directly.
 func TestLoggingStructuredFieldsAndInjectedLogger(t *testing.T) {
-	logger, closer, err := logging.New(logging.Config{Format: "json", Output: "stderr"})
+	logPath := filepath.Join(t.TempDir(), "trader.log")
+
+	logger, closer, err := logging.New(logging.Config{Format: "json", Output: logPath})
 	require.NoError(t, err)
-	defer closer.Close()
 	require.NotNil(t, logger, "New returns a logger a caller injects into its own components, not a package-level global")
 
-	// logging.Capture is the public testkit counterpart to New: same
-	// structured-record shape, but assertable instead of writing to an
-	// io.Writer.
-	captured, rec := logging.Capture()
-	captured.Info("order filled",
+	logger.Info("order filled",
 		"order_status", "filled",
 		"broker", "OANDA",
 		"api_key", logging.Secret("sk_live_deadbeefdeadbeef"),
 	)
+	require.NoError(t, closer.Close())
 
-	records := rec.Records()
-	require.Len(t, records, 1)
-	assert.Equal(t, "order filled", records[0].Message)
-	assert.Equal(t, "filled", records[0].Attrs["order_status"])
-	assert.Equal(t, "OANDA", records[0].Attrs["broker"])
-	assert.Equal(t, "REDACTED", records[0].Attrs["api_key"])
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+
+	var record map[string]any
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(data), &record))
+
+	assert.Equal(t, "order filled", record["msg"])
+	assert.Equal(t, "filled", record["order_status"])
+	assert.Equal(t, "OANDA", record["broker"])
+	assert.Equal(t, "REDACTED", record["api_key"])
 }

--- a/examples/m1/integration_test.go
+++ b/examples/m1/integration_test.go
@@ -1,0 +1,328 @@
+// Package m1_test is an external consumer of Trader's M1 public API: it
+// imports only public packages (account, clock, config, id, instrument,
+// logging, num, order, portfolio, and tradertest for incidental
+// assertion/fixture support only), the way real code outside this
+// module would. It exists for issue #32 (M1-14): proving M1 is a
+// coherent, externally consumable foundation, not a collection of
+// individually compiling packages.
+//
+// The central lifecycle (§1 of the #32 plan) is built almost entirely
+// through the real domain constructors — instrument.New*,
+// order.NewProposal/NewRequest/NewOrder/ApplyAcceptance/NewFill/
+// ApplyFill, account.NewSnapshot, portfolio.NewPortfolio — rather than
+// tradertest's builders, since the point of this package is to audit
+// that API directly rather than exercise a convenience layer sitting
+// in front of it.
+package m1_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rustyeddy/trader/account"
+	"github.com/rustyeddy/trader/clock"
+	"github.com/rustyeddy/trader/config"
+	"github.com/rustyeddy/trader/id"
+	"github.com/rustyeddy/trader/instrument"
+	"github.com/rustyeddy/trader/logging"
+	"github.com/rustyeddy/trader/num"
+	"github.com/rustyeddy/trader/order"
+	"github.com/rustyeddy/trader/portfolio"
+	"github.com/rustyeddy/trader/tradertest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// m1Scenario is the result of building one complete, realistic M1
+// vocabulary flow: an instrument and its listing, a filled order and
+// the position it produced, two account snapshots at two different
+// brokers in two different currencies, and the portfolio aggregating
+// them.
+type m1Scenario struct {
+	listing     instrument.Listing
+	filledOrder order.Order
+	position    order.Position
+	usdSnapshot account.Snapshot
+	gbpSnapshot account.Snapshot
+	portfolio   portfolio.Portfolio
+}
+
+// buildM1Scenario builds one EUR/USD order through to a fill and a
+// resulting position, then aggregates it alongside a second, unrelated
+// GBP account into one USD-denominated portfolio. Every domain value is
+// built through its own package's real constructor; g supplies
+// deterministic identity only.
+func buildM1Scenario(g *id.Generator) (m1Scenario, error) {
+	// instrument / listing.
+	inst, err := instrument.NewCurrencyPair(num.MustParseCurrency("EUR"), num.MustParseCurrency("USD"))
+	if err != nil {
+		return m1Scenario{}, err
+	}
+	spec, err := instrument.NewSpec(
+		num.MustParsePrice("0.00001"),
+		num.MustParseQuantity("1"),
+		num.MustParseRate("1"),
+		num.MustParseCurrency("USD"),
+	)
+	if err != nil {
+		return m1Scenario{}, err
+	}
+	listing, err := instrument.NewListing(instrument.ListingParams{
+		Instrument: inst,
+		Provider:   "OANDA",
+		Symbol:     "EUR_USD",
+		Spec:       spec,
+		Tradable:   true,
+	})
+	if err != nil {
+		return m1Scenario{}, err
+	}
+
+	// proposal -> request -> order lifecycle: PendingSubmit -> Working -> Filled.
+	accountID, err := id.GenerateAccountID(g)
+	if err != nil {
+		return m1Scenario{}, err
+	}
+	proposal, err := order.NewProposal(order.Proposal{
+		Listing:     listing,
+		AccountID:   accountID,
+		Side:        order.Buy,
+		Type:        order.Market,
+		TimeInForce: order.GTC,
+		Quantity:    num.MustParseQuantity("1000"),
+	})
+	if err != nil {
+		return m1Scenario{}, err
+	}
+	orderID, err := id.GenerateOrderID(g)
+	if err != nil {
+		return m1Scenario{}, err
+	}
+	request, err := order.NewRequest(proposal, orderID)
+	if err != nil {
+		return m1Scenario{}, err
+	}
+	pendingOrder, err := order.NewOrder(order.Order{
+		Request: request,
+		Status:  order.StatusPendingSubmit,
+	})
+	if err != nil {
+		return m1Scenario{}, err
+	}
+	workingOrder, err := order.ApplyAcceptance(pendingOrder, "broker-order-1", request.Quantity, nil, nil)
+	if err != nil {
+		return m1Scenario{}, err
+	}
+
+	fillID, err := id.GenerateFillID(g)
+	if err != nil {
+		return m1Scenario{}, err
+	}
+	fillPrice := num.MustParsePrice("1.10000")
+	fill, err := order.NewFill(order.Fill{
+		FillID:        fillID,
+		OrderID:       workingOrder.Request.OrderID,
+		BrokerOrderID: workingOrder.BrokerOrderID,
+		AccountID:     workingOrder.Request.AccountID,
+		Listing:       workingOrder.Request.Listing,
+		Side:          workingOrder.Request.Side,
+		Price:         fillPrice,
+		Quantity:      request.Quantity,
+	})
+	if err != nil {
+		return m1Scenario{}, err
+	}
+	filledOrder, err := order.ApplyFill(workingOrder, fill)
+	if err != nil {
+		return m1Scenario{}, err
+	}
+
+	// position resulting from the fill.
+	position, err := order.NewPosition(order.Position{
+		AccountID: accountID,
+		Listing:   listing,
+		Side:      order.Long,
+		Quantity:  request.Quantity,
+		AvgPrice:  &fillPrice,
+	})
+	if err != nil {
+		return m1Scenario{}, err
+	}
+
+	// account snapshot holding that position.
+	asOf := time.Date(2026, time.January, 2, 12, 0, 0, 0, time.UTC)
+	usd := num.MustParseCurrency("USD")
+	usdSnapshot, err := account.NewSnapshot(account.SnapshotParams{
+		AccountID:       accountID,
+		Broker:          "OANDA",
+		Currency:        usd,
+		AsOf:            asOf,
+		CashBalances:    []num.Money{num.MustParseMoney("10000", usd)},
+		Equity:          num.MustParseMoney("10000", usd),
+		BuyingPower:     num.MustParseMoney("9000", usd),
+		MarginUsed:      num.MustParseMoney("1000", usd),
+		MarginAvailable: num.MustParseMoney("9000", usd),
+		RealizedPnL:     num.MustParseMoney("0", usd),
+		UnrealizedPnL:   num.MustParseMoney("0", usd),
+		Fees:            num.MustParseMoney("0", usd),
+		Financing:       num.MustParseMoney("0", usd),
+		Positions:       []order.Position{position},
+	})
+	if err != nil {
+		return m1Scenario{}, err
+	}
+
+	// a second, unrelated account at a different broker in a different
+	// currency, so the portfolio actually exercises cross-currency
+	// aggregation rather than a trivial same-currency sum.
+	gbpAccountID, err := id.GenerateAccountID(g)
+	if err != nil {
+		return m1Scenario{}, err
+	}
+	gbp := num.MustParseCurrency("GBP")
+	gbpSnapshot, err := account.NewSnapshot(account.SnapshotParams{
+		AccountID:       gbpAccountID,
+		Broker:          "IBKR",
+		Currency:        gbp,
+		AsOf:            asOf,
+		CashBalances:    []num.Money{num.MustParseMoney("5000", gbp)},
+		Equity:          num.MustParseMoney("5000", gbp),
+		BuyingPower:     num.MustParseMoney("5000", gbp),
+		MarginUsed:      num.MustParseMoney("0", gbp),
+		MarginAvailable: num.MustParseMoney("5000", gbp),
+		RealizedPnL:     num.MustParseMoney("0", gbp),
+		UnrealizedPnL:   num.MustParseMoney("0", gbp),
+		Fees:            num.MustParseMoney("0", gbp),
+		Financing:       num.MustParseMoney("0", gbp),
+	})
+	if err != nil {
+		return m1Scenario{}, err
+	}
+
+	p, err := portfolio.NewPortfolio(portfolio.PortfolioParams{
+		BaseCurrency: usd,
+		AsOf:         asOf,
+		Accounts:     []account.Snapshot{usdSnapshot, gbpSnapshot},
+		Rates: []portfolio.ConversionRate{
+			{From: gbp, To: usd, Rate: num.MustParseRate("1.25"), AsOf: asOf, Source: "example"},
+		},
+	})
+	if err != nil {
+		return m1Scenario{}, err
+	}
+
+	return m1Scenario{
+		listing:     listing,
+		filledOrder: filledOrder,
+		position:    position,
+		usdSnapshot: usdSnapshot,
+		gbpSnapshot: gbpSnapshot,
+		portfolio:   p,
+	}, nil
+}
+
+// Example_m1Vocabulary is the runnable example issue #32 requires: it
+// exercises the integrated M1 vocabulary end to end, using only public
+// packages.
+func Example_m1Vocabulary() {
+	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(1, 2))
+
+	scenario, err := buildM1Scenario(g)
+	if err != nil {
+		panic(err)
+	}
+
+	equity, ok := scenario.portfolio.Equity()
+	if !ok {
+		panic("expected complete portfolio conversion")
+	}
+
+	fmt.Println(scenario.filledOrder.Status, scenario.portfolio.ConversionStatus(), equity)
+	// Output: filled complete 16250 USD
+}
+
+// TestM1VocabularyReachesExpectedState re-runs the same scenario and
+// asserts on it with testify plus a couple of tradertest's assertions
+// (AssertTerminal, AssertStatus, AssertMoneyEqual) — the kind of
+// incidental, verification-only use of tradertest the #32 plan calls
+// for, as opposed to using it to build the scenario itself.
+func TestM1VocabularyReachesExpectedState(t *testing.T) {
+	g := id.NewGenerator(clock.NewSimulated(time.Now()), id.NewDeterministic(3, 4))
+
+	scenario, err := buildM1Scenario(g)
+	require.NoError(t, err)
+
+	tradertest.AssertTerminal(t, scenario.filledOrder)
+	tradertest.AssertStatus(t, order.StatusFilled, scenario.filledOrder)
+
+	require.NotNil(t, scenario.filledOrder.AcceptedQuantity)
+	assert.True(t, scenario.filledOrder.FilledQuantity.Equal(*scenario.filledOrder.AcceptedQuantity))
+
+	assert.Equal(t, order.Long, scenario.position.Side)
+
+	require.Len(t, scenario.usdSnapshot.Positions(), 1)
+	require.Empty(t, scenario.usdSnapshot.OpenOrders(), "the order is Filled/terminal, so it must not appear as an open order")
+
+	require.Equal(t, portfolio.ConversionComplete, scenario.portfolio.ConversionStatus())
+	equity, ok := scenario.portfolio.Equity()
+	require.True(t, ok)
+	tradertest.AssertMoneyEqual(t, num.MustParseMoney("16250", num.MustParseCurrency("USD")), equity)
+
+	assert.Len(t, scenario.portfolio.Accounts(), 2)
+}
+
+// appConfig is a small, realistic composition-root configuration type:
+// one plain field, one field with a default, and one secret.
+type appConfig struct {
+	Broker   string `config:"broker" default:"OANDA"`
+	APIKey   string `config:"api_key" secret:"true" required:"true"`
+	LogLevel string `config:"log_level" default:"info" enum:"debug,info,warn,error"`
+}
+
+// TestConfigRedactsSecrets exercises config.Load and config.Sprint: a
+// secret-tagged field's real value must never appear in rendered
+// configuration output.
+func TestConfigRedactsSecrets(t *testing.T) {
+	const secretValue = "sk_live_deadbeefdeadbeef"
+
+	cfg, err := config.Load[appConfig](config.Options{
+		Environ:     []string{},
+		FileContent: []byte("broker: OANDA\napi_key: " + secretValue + "\nlog_level: debug\n"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, secretValue, cfg.APIKey, "Load itself must still resolve the real value")
+
+	out := config.Sprint(cfg)
+	assert.Contains(t, out, config.Redacted)
+	assert.NotContains(t, out, secretValue, "the secret's real value must never reach rendered output")
+	assert.Contains(t, out, "OANDA", "non-secret fields still render normally")
+}
+
+// TestLoggingStructuredFieldsAndInjectedLogger exercises an injected
+// (not global) *slog.Logger built by logging.New, and confirms
+// structured fields — including one wrapped by logging.Secret — are
+// captured correctly rather than interpolated into a formatted string.
+func TestLoggingStructuredFieldsAndInjectedLogger(t *testing.T) {
+	logger, closer, err := logging.New(logging.Config{Format: "json", Output: "stderr"})
+	require.NoError(t, err)
+	defer closer.Close()
+	require.NotNil(t, logger, "New returns a logger a caller injects into its own components, not a package-level global")
+
+	// logging.Capture is the public testkit counterpart to New: same
+	// structured-record shape, but assertable instead of writing to an
+	// io.Writer.
+	captured, rec := logging.Capture()
+	captured.Info("order filled",
+		"order_status", "filled",
+		"broker", "OANDA",
+		"api_key", logging.Secret("sk_live_deadbeefdeadbeef"),
+	)
+
+	records := rec.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, "order filled", records[0].Message)
+	assert.Equal(t, "filled", records[0].Attrs["order_status"])
+	assert.Equal(t, "OANDA", records[0].Attrs["broker"])
+	assert.Equal(t, "REDACTED", records[0].Attrs["api_key"])
+}

--- a/num/example_test.go
+++ b/num/example_test.go
@@ -1,0 +1,41 @@
+package num_test
+
+import (
+	"fmt"
+
+	"github.com/rustyeddy/trader/num"
+)
+
+// Example demonstrates num's exact value types: Price and Quantity are
+// backed by a scaled integer (ADR-004), never a raw float64, so
+// arithmetic on them never introduces floating-point error the way
+// 1.1+0.0001 would in binary floating point.
+func Example() {
+	price := num.MustParsePrice("1.10000")
+	quantity := num.MustParseQuantity("1000")
+
+	marked, err := price.Add(num.MustParsePrice("0.00010"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(price, quantity, marked)
+	// Output: 1.1 1000 1.1001
+}
+
+// Example_money shows Money's mandatory currency and its one sanctioned
+// currency-conversion primitive, Convert. Money.MulRate deliberately
+// preserves currency and is not conversion — see the Money doc comment.
+func Example_money() {
+	usd := num.MustParseCurrency("USD")
+	eur := num.MustParseCurrency("EUR")
+
+	balance := num.MustParseMoney("1000", usd)
+	converted, err := balance.Convert(eur, num.MustParseRate("0.92"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(balance, converted)
+	// Output: 1000 USD 920 EUR
+}


### PR DESCRIPTION
## Summary

Implements the verification-first plan agreed on #32: exercise M1 as a
coherent, externally consumable foundation, fix only what the exercise
exposes, and record a completion review — not a broad cleanup pass.

### §1 — External-consumer exercise (`examples/m1/integration_test.go`)

An external package (`package m1_test`, only public imports) building
the whole M1 vocabulary almost entirely through the *real* domain
constructors, per your note that #32 is supposed to audit the actual
public API rather than `tradertest`'s convenience layer:
`instrument.NewCurrencyPair/NewSpec/NewListing` → `order.NewProposal` →
`order.NewRequest` → `order.NewOrder` (`StatusPendingSubmit`) →
`order.ApplyAcceptance` → `order.NewFill`/`ApplyFill` →
`order.NewPosition` → `account.NewSnapshot` (two brokers, two
currencies) → `portfolio.NewPortfolio` (with a real `ConversionRate`,
so conversion is genuinely exercised). `tradertest` appears only
incidentally, in the assertions (`AssertTerminal`, `AssertStatus`,
`AssertMoneyEqual`), never to build the scenario. Separate dedicated
tests cover config secret redaction and structured logging through an
injected (non-global) logger specifically.

**Result: pass, no API deficiencies** — every constructor composed
cleanly, no workarounds needed.

### §2 — Documentation/naming/glossary audit

`go/doc`-based scan for undocumented top-level exported identifiers
(zero found — after correcting a false-positive struct-field-level
version of the check, see the review doc), `staticcheck` across all 11
packages (zero findings), every package has a doc comment (confirmed),
and a glossary cross-check against the architecture document's Appendix
A (no drift beyond the already-ADR-007-documented `Account` →
`account.Snapshot` naming).

**One real, concrete gap found and fixed**: the issue's scope names
"exact values" (`num`) and "configuration" (`config`) among the
packages needing runnable examples — neither had a single `Example`
function, unlike every other M1 package. Added
`num/example_test.go` and `config/example_test.go`.

### §3 — Dependency-boundary review (manual, no new tooling)

Per your note, no new `dependency_test.go`/enforcement infrastructure.
Manual review of each package's import graph against
`package-boundaries.org`'s map: no forbidden edges, no cycles, no
domain package imports `config`/`logging`/`tradertest`, `tradertest` is
consumed only by its own tests and `examples/m1`, no cross-package
`internal/` leakage. Findings recorded in the review doc.

### §4 — Lightweight API baseline

Recorded directly in `docs/milestones/m1-completion-review.org` §4 —
no generated snapshot file, no `make` target, per your note that this
should wait for ADR-011 (still Proposed) to define the durable
mechanism.

### §5 — `docs/milestones/m1-completion-review.org`

The completion review artifact you approved keeping as a checked-in
file: scenario result, audit findings, dependency review findings, API
baseline, an explicit no-later-milestone-behavior statement per
package, and the closing recommendation.

**Recommendation: M1 is ready to close.**

## Test plan

- [x] `Example_m1Vocabulary`, `TestM1VocabularyReachesExpectedState`,
      `TestConfigRedactsSecrets`,
      `TestLoggingStructuredFieldsAndInjectedLogger` — all pass
- [x] `num`/`config` new examples pass
- [x] `staticcheck` clean across all 11 M1 packages (non-test code)
- [x] Manual dependency/glossary/doc audits — findings in the review
      doc
- [x] `make check` (fmt, vet, `go test -race ./...`) — green across the
      whole repository, including the new `examples/m1` package

Issue: #32

https://claude.ai/code/session_01FsfxQH4YBP5DA1LpAafWyt